### PR TITLE
Don't build with Atomics support by default

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -67,12 +67,6 @@
 #define CONFIG_PRINTF_RNDN
 #endif
 
-/* define to include Atomics.* operations which depend on the OS
-   threads */
-#if !defined(EMSCRIPTEN)
-#define CONFIG_ATOMICS
-#endif
-
 #if !defined(EMSCRIPTEN)
 /* enable stack limitation */
 #define CONFIG_STACK_CHECK


### PR DESCRIPTION
It's not currently implemented for Windows which makes the bytecode generated by qjsc not portable.