### PR TITLE
Replace pthreads with C11 threading support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,18 @@ jobs:
       - name: test
         run: |
           make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_UBSAN=y test
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: |
+          make CONFIG_WIN32=y CONFIG_WERROR=y
+      - name: stats
+        run: |
+          make CONFIG_WIN32=y CONFIG_WERROR=y qjs
+          ./qjs.exe -qd
+      - name: test
+        run: |
+          make CONFIG_WIN32=y CONFIG_WERROR=y test

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ DEFINES+=-D__USE_MINGW_ANSI_STDIO # for standard snprintf behavior
 endif
 
 CFLAGS+=$(DEFINES)
+CFLAGS+=-std=c11
 CFLAGS_DEBUG=$(CFLAGS) -O0
 CFLAGS_SMALL=$(CFLAGS) -Os
 CFLAGS_OPT=$(CFLAGS) -O2

--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,10 @@ QJS_LIB_OBJS+=$(OBJDIR)/libbf.o
 QJS_OBJS+=$(OBJDIR)/qjscalc.o
 endif
 
-HOST_LIBS=-lm -ldl -lpthread
+HOST_LIBS=-lm -ldl
 LIBS=-lm
 ifndef CONFIG_WIN32
-LIBS+=-ldl -lpthread
+LIBS+=-ldl
 endif
 LIBS+=$(EXTRA_LIBS)
 

--- a/qjsc.c
+++ b/qjsc.c
@@ -451,7 +451,6 @@ static int output_executable(const char *out_filename, const char *cfilename,
     *arg++ = libjsname;
     *arg++ = "-lm";
     *arg++ = "-ldl";
-    *arg++ = "-lpthread";
     *arg = NULL;
     
     if (verbose) {

--- a/release.sh
+++ b/release.sh
@@ -45,7 +45,6 @@ if echo $release_list | grep -w -q win_binary ; then
 
 # win64
 
-dlldir=/usr/x86_64-w64-mingw32/sys-root/mingw/bin
 cross_prefix="x86_64-w64-mingw32-"
 d="quickjs-win-x86_64-${version}"
 outdir="/tmp/${d}"
@@ -56,7 +55,6 @@ mkdir -p $outdir
 make CONFIG_WIN32=y qjs.exe
 cp qjs.exe $outdir
 ${cross_prefix}strip $outdir/qjs.exe
-cp $dlldir/libwinpthread-1.dll $outdir
 
 ( cd /tmp/$d && rm -f ../${d}.zip && zip -r ../${d}.zip . )
 
@@ -64,7 +62,6 @@ make CONFIG_WIN32=y clean
 
 # win32
 
-dlldir=/usr/i686-w64-mingw32/sys-root/mingw/bin
 cross_prefix="i686-w64-mingw32-"
 d="quickjs-win-i686-${version}"
 outdir="/tmp/${d}"
@@ -78,7 +75,6 @@ make CONFIG_WIN32=y clean
 make CONFIG_WIN32=y CONFIG_M32=y qjs.exe
 cp qjs.exe $outdir
 ${cross_prefix}strip $outdir/qjs.exe
-cp $dlldir/libwinpthread-1.dll $outdir
 
 ( cd /tmp/$d && rm -f ../${d}.zip && zip -r ../${d}.zip . )
 


### PR DESCRIPTION
This should make it feasible to build quickjs on Windows with VS 2022.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1