### PR TITLE
Add ASAN/MSAN/UBSAN support to CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,41 +194,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sys:
-          - mingw64
-          - ucrt64
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{matrix.sys}}
-        install: >-
-          git
-          make
-        pacboy: >-
-          toolchain:p
-    - name: build
-      run: |
-        make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_MINGW=y
-    - name: stats
-      run: |
-        make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_MINGW=y qjs
-        ./qjs -qd
-    - name: test
-      run: |
-        make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_MINGW=y test
-
-  windows-mingw-cmake:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
         buildType: [Debug, Release]
         sys:
           - mingw64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,39 +17,6 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: build
-        run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y all run-test262
-      - name: test
-        run: |
-          make test test2
-  linux-asan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: test
-        run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_ASAN=y ASAN_OPTIONS="halt_on_error=1" test
-  linux-msan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: test
-        run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_MSAN=y CONFIG_CLANG=y MSAN_OPTIONS="halt_on_error=1" test
-  linux-ubsan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: test
-        run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_UBSAN=y UBSAN_OPTIONS="halt_on_error=1" test
-  linux-cmake:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -81,36 +48,76 @@ jobs:
         if: ${{ matrix.buildType == 'Release' }}
         run: |
           time ./build/run-test262 -m -c test262.conf -a
-
-  macos:
-    runs-on: macos-latest
+  linux-asan:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: build
         run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y
-      - name: stats
-        run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y qjs
-          ./qjs -qd
+          mkdir build
+          cd build
+          cmake -DCONFIG_ASAN=ON ..
+          cd ..
+          cmake --build build -j$(getconf _NPROCESSORS_ONLN)
       - name: test
+        env:
+          ASAN_OPTIONS: halt_on_error=1
         run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y test
-  macos-asan:
-    runs-on: macos-latest
+          ./build/qjs tests/test_bigint.js
+          ./build/qjs tests/test_closure.js
+          ./build/qjs tests/test_language.js
+          ./build/qjs tests/test_builtin.js
+          ./build/qjs tests/test_loop.js
+          ./build/qjs tests/test_std.js
+          ./build/qjs tests/test_worker.js
+  linux-msan:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: test
+      - name: build
+        env:
+          CC: clang
         run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_ASAN=y ASAN_OPTIONS="halt_on_error=1" test
-  macos-ubsan:
-    runs-on: macos-latest
+          mkdir build
+          cd build
+          cmake -DCONFIG_MSAN=ON ..
+          cd ..
+          cmake --build build -j$(getconf _NPROCESSORS_ONLN)
+      - name: test
+        env:
+          MSAN_OPTIONS: halt_on_error=1
+        run: |
+          ./build/qjs tests/test_bigint.js
+          ./build/qjs tests/test_closure.js
+          ./build/qjs tests/test_language.js
+          ./build/qjs tests/test_builtin.js
+          ./build/qjs tests/test_loop.js
+          ./build/qjs tests/test_std.js
+          ./build/qjs tests/test_worker.js
+  linux-ubsan:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: test
+      - name: build
         run: |
-          make -j$(getconf _NPROCESSORS_ONLN) CONFIG_WERROR=y CONFIG_UBSAN=y UBSAN_OPTIONS="halt_on_error=1" test
-  macos-cmake:
+          mkdir build
+          cd build
+          cmake -DCONFIG_UBSAN=ON ..
+          cd ..
+          cmake --build build -j$(getconf _NPROCESSORS_ONLN)
+      - name: test
+        env:
+          UBSAN_OPTIONS: halt_on_error=1
+        run: |
+          ./build/qjs tests/test_bigint.js
+          ./build/qjs tests/test_closure.js
+          ./build/qjs tests/test_language.js
+          ./build/qjs tests/test_builtin.js
+          ./build/qjs tests/test_loop.js
+          ./build/qjs tests/test_std.js
+          ./build/qjs tests/test_worker.js
+
+  macos:
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -129,6 +136,50 @@ jobs:
         run: |
           ./build/qjs -qd
       - name: test
+        run: |
+          ./build/qjs tests/test_bigint.js
+          ./build/qjs tests/test_closure.js
+          ./build/qjs tests/test_language.js
+          ./build/qjs tests/test_builtin.js
+          ./build/qjs tests/test_loop.js
+          ./build/qjs tests/test_std.js
+          ./build/qjs tests/test_worker.js
+  macos-asan:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          cmake -DCONFIG_ASAN=ON ..
+          cd ..
+          cmake --build build -j$(getconf _NPROCESSORS_ONLN)
+      - name: test
+        env:
+          ASAN_OPTIONS: halt_on_error=1
+        run: |
+          ./build/qjs tests/test_bigint.js
+          ./build/qjs tests/test_closure.js
+          ./build/qjs tests/test_language.js
+          ./build/qjs tests/test_builtin.js
+          ./build/qjs tests/test_loop.js
+          ./build/qjs tests/test_std.js
+          ./build/qjs tests/test_worker.js
+  macos-ubsan:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          cmake -DCONFIG_UBSAN=ON ..
+          cd ..
+          cmake --build build -j$(getconf _NPROCESSORS_ONLN)
+      - name: test
+        env:
+          UBSAN_OPTIONS: halt_on_error=1
         run: |
           ./build/qjs tests/test_bigint.js
           ./build/qjs tests/test_closure.js

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ project(quickjs LANGUAGES C)
 # TODO:
 #  - LTO
 #  - Support cross-compilation
-#  - ASAN / MSAN / UBSAN
 #  - Install targets
 #  - Shared library target
 
@@ -51,7 +50,49 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
     )
 endif()
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
+option(CONFIG_ASAN "Enable AddressSanitizer (ASan)" OFF)
+option(CONFIG_MSAN "Enable MemorySanitizer (MSan)" OFF)
+option(CONFIG_UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" OFF)
+
+if(CONFIG_ASAN)
+message(STATUS "Building with ASan")
+add_compile_options(
+    -fsanitize=address
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+add_link_options(
+    -fsanitize=address
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+elseif(CONFIG_MSAN)
+message(STATUS "Building with MSan")
+add_compile_options(
+    -fsanitize=memory
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+add_link_options(
+    -fsanitize=memory
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+elseif(CONFIG_UBSAN)
+message(STATUS "Building with UBSan")
+add_compile_options(
+    -fsanitize=undefined
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+add_link_options(
+    -fsanitize=undefined
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+endif()
+
+set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
 
 
 # QuickJS library


### PR DESCRIPTION
First commit is https://github.com/quickjs-ng/quickjs/pull/52

Note I started replacing the use of the Makefile with CMake on the CI. My end goal is to eventually replace all functionality and provide a Makefile that basically calls out to CMake. Let me know what you think!