### PR TITLE
Add fused get_loc0_loc1 opcode

### DIFF
--- a/quickjs-opcode.h
+++ b/quickjs-opcode.h
@@ -302,6 +302,7 @@ DEF(       get_loc8, 2, 0, 1, loc8)
 DEF(       put_loc8, 2, 1, 0, loc8)
 DEF(       set_loc8, 2, 1, 1, loc8)
 
+DEF(  get_loc0_loc1, 1, 0, 2, none_loc)
 DEF(       get_loc0, 1, 0, 1, none_loc)
 DEF(       get_loc1, 1, 0, 1, none_loc)
 DEF(       get_loc2, 1, 0, 1, none_loc)


### PR DESCRIPTION
get_loc0 and get_loc1 are individually very frequent opcodes _and_ they are very often paired together, making them ideal candidates for opcode fusion.

Reduces microbench.js running time by about 4%.