### PR TITLE
Disable `CONFIG_STACK_CHECK`

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -65,7 +65,9 @@
 #define CONFIG_PRINTF_RNDN
 #endif
 
-#if !defined(EMSCRIPTEN) && !defined(__ASAN__)
+// #if !defined(EMSCRIPTEN) && !defined(__ASAN__)
+// https://github.com/quickjs-ng/quickjs/issues/79
+#if false
 /* enable stack limitation */
 #define CONFIG_STACK_CHECK
 #endif


### PR DESCRIPTION
Fixes https://github.com/quickjs-ng/quickjs/issues/79

`__builtin_frame_address(0)` returns a much greater address sometimes - triggering the stack overflow check.