### PR TITLE
Remove non-standard Date.__date_clock method

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -39764,17 +39764,6 @@ static const JSCFunctionListEntry js_math_obj[] = {
 
 /* Date */
 
-/* OS dependent: return the UTC time in microseconds since 1970. */
-static JSValue js___date_clock(JSContext *ctx, JSValueConst this_val,
-                               int argc, JSValueConst *argv)
-{
-    int64_t d;
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    d = (int64_t)tv.tv_sec * 1000000 + tv.tv_usec;
-    return JS_NewInt64(ctx, d);
-}
-
 /* OS dependent. d = argv[0] is in ms from 1970. Return the difference
    between UTC time and local time 'd' in minutes */
 static int getTimezoneOffset(int64_t time) {
@@ -45555,9 +45544,6 @@ static const JSCFunctionListEntry js_global_funcs[] = {
     JS_PROP_DOUBLE_DEF("Infinity", 1.0 / 0.0, 0 ),
     JS_PROP_DOUBLE_DEF("NaN", NAN, 0 ),
     JS_PROP_UNDEFINED_DEF("undefined", 0 ),
-
-    /* for the 'Date' implementation */
-    JS_CFUNC_DEF("__date_clock", 0, js___date_clock ),
 };
 
 /* Date */

--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -97,17 +97,7 @@ var clocks_per_sec = 1000000;
 var max_iterations = 100;
 var clock_threshold = 2000;  /* favoring short measuring spans */
 var min_n_argument = 1;
-var get_clock;
-
-if (typeof globalThis.__date_clock != "function") {
-    console.log("using fallback millisecond clock");
-    clocks_per_sec = 1000;
-    max_iterations = 10;
-    clock_threshold = 100;
-    get_clock = Date.now;
-} else {
-    get_clock = globalThis.__date_clock;
-}
+var get_clock = Date.now;
 
 function log_one(text, n, ti) {
     var ref;


### PR DESCRIPTION
First commit is #87.

(I probably should have done those in reverse order. Voortschrijdend inzicht.)