### PR TITLE
Unbreak microbench, add os.now()

### DIFF
--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 import * as std from "std";
+import * as os from "os";
 
 function pad(str, n) {
     str += "";
@@ -97,7 +98,7 @@ var clocks_per_sec = 1000000;
 var max_iterations = 100;
 var clock_threshold = 2000;  /* favoring short measuring spans */
 var min_n_argument = 1;
-var get_clock = Date.now;
+var get_clock = os.now;
 
 function log_one(text, n, ti) {
     var ref;


### PR DESCRIPTION
The removal of the high-precision but non-standard clock source in commit 5af98ca broke microbench because Date.now() is not granular enough for the benchmark runner to make forward progress.

This commit adds a new method to the os module that returns time with microsecond precision.