### PR TITLE
Optimize RegExp ASCII literal matching

### DIFF
--- a/libregexp-opcode.h
+++ b/libregexp-opcode.h
@@ -25,7 +25,8 @@
 #ifdef DEF
 
 DEF(invalid, 1) /* never used */
-DEF(char, 3)
+DEF(char8, 2) /* 7 bits in fact */
+DEF(char16, 3)
 DEF(char32, 5)
 DEF(dot, 1)
 DEF(any, 1) /* same as dot but match any character including line terminator */

--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -653,6 +653,30 @@ function math_min(n)
     return n * 1000;
 }
 
+function regexp_ascii(n)
+{
+    var i, j, r, s;
+    s = "the quick brown fox jumped over the lazy dog"
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 10000; i++)
+            r = /the quick brown fox/.exec(s)
+        global_res = r;
+    }
+    return n * 10000;
+}
+
+function regexp_utf16(n)
+{
+    var i, j, r, s;
+    s = "the quick brown ᶠᵒˣ jumped over the lazy ᵈᵒᵍ"
+    for(j = 0; j < n; j++) {
+        for(i = 0; i < 10000; i++)
+            r = /the quick brown ᶠᵒˣ/.exec(s)
+        global_res = r;
+    }
+    return n * 10000;
+}
+
 /* incremental string contruction as local var */
 function string_build1(n)
 {
@@ -950,6 +974,8 @@ function main(argc, argv, g)
         array_for_in,
         array_for_of,
         math_min,
+        regexp_ascii,
+        regexp_utf16,
         string_build1,
         string_build2,
         //string_build3,


### PR DESCRIPTION
Add REOP_char8 that matches single bytes. Compresses bytecode for the ASCII common case by 33% and reduces regexp_ascii benchmark running time by 4%. The regexp_utf16 benchmark is unaffected.

<hr>

A future optimization is to coalesce `char8 'a'; char8 'b'; char8 'c'` to something like `str8 3 "abc"`