### PR TITLE
Expose class name to static initializers

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -20972,6 +20972,14 @@ static __exception int js_parse_class(JSParseState *s, BOOL is_class_expr,
             emit_atom(s, JS_ATOM_this);
             emit_u16(s, 0);
 
+            // expose class name to static initializers
+            if (is_static && class_name != JS_ATOM_NULL) {
+                emit_op(s, OP_dup);
+                emit_op(s, OP_scope_put_var_init);
+                emit_atom(s, class_name);
+                emit_u16(s, s->cur_func->scope_level);
+            }
+
             if (name == JS_ATOM_NULL) {
                 emit_op(s, OP_scope_get_var);
                 emit_atom(s, field_var_name);

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -325,6 +325,15 @@ function test_class()
     /* test class name scope */
     var E1 = class E { static F() { return E; } };
     assert(E1 === E1.F());
+
+    class S {
+        static x = 42;
+        static y = S.x;
+        static z = this.x;
+    }
+    assert(S.x === 42);
+    assert(S.y === 42);
+    assert(S.z === 42);
 };
 
 function test_template()


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/138