### PR TITLE
Remove no-op OP_swap+OP_swap bytecode sequence

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -29675,6 +29675,15 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
             }
             goto no_change;
 
+        case OP_swap:
+            // transformation: swap swap -> nothing!
+            if (code_match(&cc, pos_next, OP_swap, -1, -1)) {
+                if (cc.line_num >= 0) line_num = cc.line_num;
+                pos_next = cc.pos;
+                break;
+            }
+            goto no_change;
+
         case OP_get_loc:
             {
                 /* transformation:


### PR DESCRIPTION
Observed in generated code for static initializers. We could in theory track and correct it in js_parse_class() but doing it as a peephole optimization is both easier and more general.