### PR TITLE
Implement RegExp serialization

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -230,6 +230,14 @@ static inline uint64_t bswap64(uint64_t v)
         ((v & ((uint64_t)0xff << (0 * 8))) << (7 * 8));
 }
 
+static inline void inplace_bswap16(uint8_t *tab) {
+    put_u16(tab, bswap16(get_u16(tab)));
+}
+
+static inline void inplace_bswap32(uint8_t *tab) {
+    put_u32(tab, bswap32(get_u32(tab)));
+}
+
 /* XXX: should take an extra argument to pass slack information to the caller */
 typedef void *DynBufReallocFunc(void *opaque, void *ptr, size_t size);
 

--- a/libregexp.h
+++ b/libregexp.h
@@ -53,6 +53,8 @@ int lre_exec(uint8_t **capture,
 int lre_parse_escape(const uint8_t **pp, int allow_utf16);
 LRE_BOOL lre_is_space(int c);
 
+void lre_byte_swap(uint8_t *buf, size_t len, BOOL is_byte_swapped);
+
 /* must be provided by the user */
 LRE_BOOL lre_check_stack_overflow(void *opaque, size_t alloca_size);
 void *lre_realloc(void *opaque, void *ptr, size_t size);

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -143,6 +143,18 @@ function bjson_test_reference()
     }
 }
 
+function bjson_test_regexp()
+{
+    var buf, r;
+
+    bjson_test(/xyzzy/);
+    bjson_test(/xyzzy/digu);
+
+    buf = bjson.write(/(?<𝓓𝓸𝓰>dog)/);
+    r = bjson.read(buf, 0, buf.byteLength);
+    assert("sup dog".match(r).groups["𝓓𝓸𝓰"], "dog");
+}
+
 function bjson_test_all()
 {
     var obj;
@@ -171,6 +183,7 @@ function bjson_test_all()
     }
 
     bjson_test_reference();
+    bjson_test_regexp();
 }
 
 bjson_test_all();


### PR DESCRIPTION
JS_WriteObject() and JS_ReadObject() now support RegExp objects.