### PR TITLE
Enable support for GCC compler v < 4.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,36 @@ jobs:
       - name: test
         run: |
           make test
+  linux-gcc48:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:14.04
+    steps:
+      - name: install dependencies
+        run: |
+          apt update && apt -y install make gcc-4.8 wget time software-properties-common
+          # git in default ppa repository is too old to run submodule checkout
+          add-apt-repository -y ppa:git-core/ppa
+          apt update
+          apt install -y git
+          wget https://github.com/Kitware/CMake/releases/download/v3.28.0-rc5/cmake-3.28.0-rc5-linux-x86_64.sh
+          sh cmake-3.28.0-rc5-linux-x86_64.sh --skip-license --prefix=/usr
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: build
+        run: |
+          CC=gcc-4.8 make
+      - name: stats
+        run: |
+          make stats
+      - name: test
+        run: |
+          make test
+      - name: test 262
+        run: |
+          time make test262
   linux-examples:
     runs-on: ubuntu-latest
     steps:

--- a/quickjs-c-atomics.h
+++ b/quickjs-c-atomics.h
@@ -1,0 +1,54 @@
+/*
+ * QuickJS C atomics definitions
+ *
+ * Copyright (c) 2023 Marcin Kolny
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__clang__)
+   // Use GCC builtins for version < 4.9
+#  if((__GNUC__ << 16) + __GNUC_MINOR__ < ((4) << 16) + 9)
+#    define GCC_BUILTIN_ATOMICS
+#  endif
+#endif
+
+#ifdef GCC_BUILTIN_ATOMICS
+#define atomic_fetch_add(obj, arg) \
+    __atomic_fetch_add(obj, arg, __ATOMIC_SEQ_CST)
+#define atomic_compare_exchange_strong(obj, expected, desired) \
+    __atomic_compare_exchange_n(obj, expected, desired, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
+#define atomic_exchange(obj, desired) \
+    __atomic_exchange_n (obj, desired, __ATOMIC_SEQ_CST)
+#define atomic_load(obj) \
+    __atomic_load_n(obj, __ATOMIC_SEQ_CST)
+#define atomic_store(obj, desired) \
+    __atomic_store_n(obj, desired, __ATOMIC_SEQ_CST)
+#define atomic_fetch_or(obj, arg) \
+    __atomic_fetch_or(obj, arg, __ATOMIC_SEQ_CST)
+#define atomic_fetch_xor(obj, arg) \
+    __atomic_fetch_xor(obj, arg, __ATOMIC_SEQ_CST)
+#define atomic_fetch_and(obj, arg) \
+    __atomic_fetch_and(obj, arg, __ATOMIC_SEQ_CST)
+#define atomic_fetch_sub(obj, arg) \
+    __atomic_fetch_sub(obj, arg, __ATOMIC_SEQ_CST)
+#define _Atomic
+#else
+#include <stdatomic.h>
+#endif

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -64,7 +64,7 @@ typedef sig_t sighandler_t;
 
 #ifdef USE_WORKER
 #include <pthread.h>
-#include <stdatomic.h>
+#include "quickjs-c-atomics.h"
 #endif
 
 #include "cutils.h"
@@ -3142,7 +3142,7 @@ static JSContext *(*js_worker_new_context_func)(JSRuntime *rt);
 
 static int atomic_add_int(int *ptr, int v)
 {
-    return atomic_fetch_add((_Atomic(uint32_t) *)ptr, v) + v;
+    return atomic_fetch_add((_Atomic uint32_t*)ptr, v) + v;
 }
 
 /* shared array buffer allocator */

--- a/quickjs.c
+++ b/quickjs.c
@@ -103,7 +103,7 @@
 
 #ifdef CONFIG_ATOMICS
 #include <pthread.h>
-#include <stdatomic.h>
+#include "quickjs-c-atomics.h"
 #include <errno.h>
 #endif
 
@@ -50106,16 +50106,16 @@ static JSValue js_atomics_op(JSContext *ctx,
 
 #define OP(op_name, func_name)                          \
     case ATOMICS_OP_ ## op_name | (0 << 3):             \
-       a = func_name((_Atomic(uint8_t) *)ptr, v);       \
+       a = func_name((_Atomic uint8_t *)ptr, v);        \
        break;                                           \
     case ATOMICS_OP_ ## op_name | (1 << 3):             \
-        a = func_name((_Atomic(uint16_t) *)ptr, v);     \
+        a = func_name((_Atomic uint16_t *)ptr, v);      \
         break;                                          \
     case ATOMICS_OP_ ## op_name | (2 << 3):             \
-        a = func_name((_Atomic(uint32_t) *)ptr, v);     \
+        a = func_name((_Atomic uint32_t *)ptr, v);      \
         break;                                          \
     case ATOMICS_OP_ ## op_name | (3 << 3):             \
-        a = func_name((_Atomic(uint64_t) *)ptr, v);     \
+        a = func_name((_Atomic uint64_t *)ptr, v);      \
         break;
         OP(ADD, atomic_fetch_add)
         OP(AND, atomic_fetch_and)
@@ -50126,42 +50126,42 @@ static JSValue js_atomics_op(JSContext *ctx,
 #undef OP
 
     case ATOMICS_OP_LOAD | (0 << 3):
-        a = atomic_load((_Atomic(uint8_t) *)ptr);
+        a = atomic_load((_Atomic uint8_t *)ptr);
         break;
     case ATOMICS_OP_LOAD | (1 << 3):
-        a = atomic_load((_Atomic(uint16_t) *)ptr);
+        a = atomic_load((_Atomic uint16_t *)ptr);
         break;
     case ATOMICS_OP_LOAD | (2 << 3):
-        a = atomic_load((_Atomic(uint32_t) *)ptr);
+        a = atomic_load((_Atomic uint32_t *)ptr);
         break;
     case ATOMICS_OP_LOAD | (3 << 3):
-        a = atomic_load((_Atomic(uint64_t) *)ptr);
+        a = atomic_load((_Atomic uint64_t *)ptr);
         break;
     case ATOMICS_OP_COMPARE_EXCHANGE | (0 << 3):
         {
             uint8_t v1 = v;
-            atomic_compare_exchange_strong((_Atomic(uint8_t) *)ptr, &v1, rep_val);
+            atomic_compare_exchange_strong((_Atomic uint8_t *)ptr, &v1, rep_val);
             a = v1;
         }
         break;
     case ATOMICS_OP_COMPARE_EXCHANGE | (1 << 3):
         {
             uint16_t v1 = v;
-            atomic_compare_exchange_strong((_Atomic(uint16_t) *)ptr, &v1, rep_val);
+            atomic_compare_exchange_strong((_Atomic uint16_t *)ptr, &v1, rep_val);
             a = v1;
         }
         break;
     case ATOMICS_OP_COMPARE_EXCHANGE | (2 << 3):
         {
             uint32_t v1 = v;
-            atomic_compare_exchange_strong((_Atomic(uint32_t) *)ptr, &v1, rep_val);
+            atomic_compare_exchange_strong((_Atomic uint32_t *)ptr, &v1, rep_val);
             a = v1;
         }
         break;
     case ATOMICS_OP_COMPARE_EXCHANGE | (3 << 3):
         {
             uint64_t v1 = v;
-            atomic_compare_exchange_strong((_Atomic(uint64_t) *)ptr, &v1, rep_val);
+            atomic_compare_exchange_strong((_Atomic uint64_t *)ptr, &v1, rep_val);
             a = v1;
         }
         break;
@@ -50225,7 +50225,7 @@ static JSValue js_atomics_store(JSContext *ctx,
         }
         if (abuf->detached)
             return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
-        atomic_store((_Atomic(uint64_t) *)ptr, v64);
+        atomic_store((_Atomic uint64_t *)ptr, v64);
     } else {
         uint32_t v;
         /* XXX: spec, would be simpler to return the written value */
@@ -50240,13 +50240,13 @@ static JSValue js_atomics_store(JSContext *ctx,
             return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
         switch(size_log2) {
         case 0:
-            atomic_store((_Atomic(uint8_t) *)ptr, v);
+            atomic_store((_Atomic uint8_t *)ptr, v);
             break;
         case 1:
-            atomic_store((_Atomic(uint16_t) *)ptr, v);
+            atomic_store((_Atomic uint16_t *)ptr, v);
             break;
         case 2:
-            atomic_store((_Atomic(uint32_t) *)ptr, v);
+            atomic_store((_Atomic uint32_t *)ptr, v);
             break;
         default:
             abort();


### PR DESCRIPTION
GCCv4.8 and lower doesn't ship with stdatomic implementation (even though they don't define __STD_NO_ATOMICS__ for c11). If the code is compiled with GCCv4.8 and older, we use builtin GCC atomic operations instead.

The patch was initially proposed in quickjs's mailing group: https://www.freelists.org/post/quickjs-devel/PATCH-support-for-older-gcc-versions-whitespace-changes-excluded