### PR TITLE
Fix stack overflow in CVE-2023-31922

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -43631,6 +43631,12 @@ static int js_proxy_isArray(JSContext *ctx, JSValueConst obj)
     JSProxyData *s = JS_GetOpaque(obj, JS_CLASS_PROXY);
     if (!s)
         return FALSE;
+
+    if (js_check_stack_overflow(ctx->rt, 0)) {
+        JS_ThrowStackOverflow(ctx);
+        return -1;
+    }
+
     if (s->is_revoked) {
         JS_ThrowTypeErrorRevokedProxy(ctx);
         return -1;

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -710,8 +710,8 @@ function test_generator()
 /* CVE-2023-31922 */
 function test_proxy_is_array()
 {
-  for (var r = new Proxy ([],{}) , y = 0 ; y < 331072 ; y ++ )
-      r = new Proxy (r, {});
+  for (var r = new Proxy([], {}), y = 0; y < 331072; y++)
+      r = new Proxy(r, {});
 
   try {
     /* Without ASAN */
@@ -721,7 +721,7 @@ function test_proxy_is_array()
     if (e instanceof InternalError) {
       assert(e.message, "stack overflow", "Stack overflow error was not raised")
     } else {
-      throw(e);
+      throw e;
     }
   }
 }

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -707,6 +707,25 @@ function test_generator()
     assert(v.value === undefined && v.done === true);
 }
 
+/* CVE-2023-31922 */
+function test_proxy_is_array()
+{
+  for (var r = new Proxy ([],{}) , y = 0 ; y < 331072 ; y ++ )
+      r = new Proxy (r, {});
+
+  try {
+    /* Without ASAN */
+    assert(Array.isArray(r));
+  } catch(e) {
+    /* With ASAN expect InternalError "stack overflow" to be raised */
+    if (e instanceof InternalError) {
+      assert(e.message, "stack overflow", "Stack overflow error was not raised")
+    } else {
+      throw(e);
+    }
+  }
+}
+
 test();
 test_function();
 test_enum();
@@ -724,3 +743,4 @@ test_map();
 test_weak_map();
 test_weak_set();
 test_generator();
+test_proxy_is_array();


### PR DESCRIPTION
`isArray` and proxy `isArray` can call each other indefinitely in a mutually recursive loop.

Add a stack overflow check in the`js_proxy_isArray` function before calling `JS_isArray(ctx, s->target)`.

Original issue: https://github.com/bellard/quickjs/issues/178
CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-31922
