### PR TITLE
Add os.cputime()

### DIFF
--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -98,7 +98,7 @@ var clocks_per_sec = 1000000;
 var max_iterations = 100;
 var clock_threshold = 2000;  /* favoring short measuring spans */
 var min_n_argument = 1;
-var get_clock = os.now;
+var get_clock = os.cputime ?? os.now;
 
 function log_one(text, n, ti) {
     var ref;


### PR DESCRIPTION
And use it in microbench to get slightly more accurate results.