### PR TITLE
Fix building with tcc

### DIFF
--- a/libbf.h
+++ b/libbf.h
@@ -27,7 +27,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if INTPTR_MAX >= INT64_MAX && !defined(_WIN32)
+#if INTPTR_MAX >= INT64_MAX && !defined(_WIN32) && !defined(__TINYC__)
 #define LIMB_LOG2_BITS 6
 #else
 #define LIMB_LOG2_BITS 5

--- a/qjsc.c
+++ b/qjsc.c
@@ -178,6 +178,7 @@ static int js_module_dummy_init(JSContext *ctx, JSModuleDef *m)
 {
     /* should never be called when compiling JS code */
     abort();
+    return -1; // pacify compiler
 }
 
 static void find_unique_cname(char *cname, size_t cname_size)

--- a/quickjs.c
+++ b/quickjs.c
@@ -2615,6 +2615,7 @@ static JSAtomKindEnum JS_AtomGetKind(JSContext *ctx, JSAtom v)
     default:
         abort();
     }
+    return (JSAtomKindEnum){-1}; // pacify compiler
 }
 
 static BOOL JS_AtomIsString(JSContext *ctx, JSAtom v)
@@ -44106,6 +44107,7 @@ static JSWeakRefRecord **get_first_weak_ref(JSValueConst key)
         default:
             abort();
         }
+        return NULL; // pacify compiler
 }
 
 static JSMapRecord *map_add_record(JSContext *ctx, JSMapState *s,
@@ -50142,6 +50144,7 @@ static JSValue js_dataview_getValue(JSContext *ctx,
     default:
         abort();
     }
+    return JS_EXCEPTION; // pacify compiler
 }
 
 static JSValue js_dataview_setValue(JSContext *ctx,


### PR DESCRIPTION
- tcc doesn't support 128 bits integral types, use 64 bits math instead

- suppress some unreachable code warnings