### PR TITLE
Change to SIGTERM in child process test

### DIFF
--- a/tests/test_std.js
+++ b/tests/test_std.js
@@ -243,10 +243,10 @@ function test_os_exec()
 
     pid = os.exec(["cat"], { block: false } );
     assert(pid >= 0);
-    os.kill(pid, os.SIGQUIT);
+    os.kill(pid, os.SIGTERM);
     [ret, status] = os.waitpid(pid, 0);
     assert(ret, pid);
-    assert(status & 0x7f, os.SIGQUIT);
+    assert(status & 0x7f, os.SIGTERM);
 }
 
 function test_timer()


### PR DESCRIPTION
The hope is that switching from SIGQUIT to SIGTERM will resolve the test's flakiness on Cygwin.

Refs: https://github.com/quickjs-ng/quickjs/issues/184