### PR TITLE
Handle TypedArray detach during iteration

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -49584,7 +49584,12 @@ static int js_TA_cmp_generic(const void *a, const void *b, void *opaque) {
     uint32_t a_idx, b_idx;
     JSValue argv[2];
     JSValue res;
+    JSObject *p;
     int cmp;
+
+    p = JS_VALUE_GET_OBJ(psc->arr);
+    if (typed_array_is_detached(ctx, p))
+        return 0;
 
     cmp = 0;
     if (!psc->exception) {
@@ -49614,9 +49619,6 @@ static int js_TA_cmp_generic(const void *a, const void *b, void *opaque) {
         if (cmp == 0) {
             /* make sort stable: compare array offsets */
             cmp = (a_idx > b_idx) - (a_idx < b_idx);
-        }
-        if (validate_typed_array(ctx, psc->arr) < 0) {
-            psc->exception = 1;
         }
     done:
         JS_FreeValue(ctx, (JSValue)argv[0]);
@@ -49712,6 +49714,9 @@ static JSValue js_typed_array_sort(JSContext *ctx, JSValue this_val,
                    js_TA_cmp_generic, &tsc);
             if (tsc.exception)
                 goto fail;
+            // per spec: typed array can be detached mid-iteration
+            if (typed_array_is_detached(ctx, p))
+                goto done;
             array_tmp = js_malloc(ctx, len * elt_size);
             if (!array_tmp) {
             fail:
@@ -49748,6 +49753,7 @@ static JSValue js_typed_array_sort(JSContext *ctx, JSValue this_val,
                 abort();
             }
             js_free(ctx, array_tmp);
+        done:
             js_free(ctx, array_idx);
         } else {
             rqsort(array_ptr, len, elt_size, cmpfun, &tsc);

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -3,8 +3,6 @@ test262/test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-brok
 test262/test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-broken-promise-try-catch.js:39: strict mode: TypeError: $DONE() not called
 test262/test/built-ins/RegExp/lookahead-quantifier-match-groups.js:27: Test262Error: Expected [a, abc] and [a, undefined] to have the same contents. ? quantifier
 test262/test/built-ins/RegExp/lookahead-quantifier-match-groups.js:27: strict mode: Test262Error: Expected [a, abc] and [a, undefined] to have the same contents. ? quantifier
-test262/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js:30: TypeError: ArrayBuffer is detached (Testing with Float64Array.)
-test262/test/built-ins/TypedArray/prototype/sort/sort-tonumber.js:30: strict mode: TypeError: ArrayBuffer is detached (Testing with Float64Array.)
 test262/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer.js:46: Test262Error:  (Testing with BigInt64Array.)
 test262/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer.js:46: strict mode: Test262Error:  (Testing with BigInt64Array.)
 test262/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer.js:40: Test262Error: Reflect.defineProperty(ta, 0, {value: {valueOf() {$DETACHBUFFER(ta.buffer); return 42n;}}}) must return true Expected SameValue(«false», «true») to be true (Testing with BigInt64Array.)


### PR DESCRIPTION
Per spec: detaching the TA mid-iteration is allowed.

TypedArray.prototype.sort should not throw an exception when that happens and now no longer does.