### PR TITLE
Remove broken JS_READ_OBJ_ROM_DATA flag

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -812,7 +812,7 @@ JS_EXTERN uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
                                    int flags, uint8_t ***psab_tab, size_t *psab_tab_len);
 
 #define JS_READ_OBJ_BYTECODE  (1 << 0) /* allow function/module */
-#define JS_READ_OBJ_ROM_DATA  (1 << 1) /* avoid duplicating 'buf' data */
+#define JS_READ_OBJ_ROM_DATA  (0)      /* avoid duplicating 'buf' data (obsolete, broken by ICs) */
 #define JS_READ_OBJ_SAB       (1 << 2) /* allow SharedArrayBuffer */
 #define JS_READ_OBJ_REFERENCE (1 << 3) /* allow object references */
 JS_EXTERN JSValue JS_ReadObject(JSContext *ctx, const uint8_t *buf, size_t buf_len, int flags);


### PR DESCRIPTION
This JS_ReadObject() flag no longer works for bytecode. The IC opcodes are patched during execution.

Fixes: https://github.com/quickjs-ng/quickjs/issues/206
Refs: https://github.com/quickjs-ng/quickjs/pull/120