### PR TITLE
Add support for `cmake -DDUMP_LEAKS=1`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 
 add_library(qjs ${qjs_sources})
 target_compile_definitions(qjs PRIVATE ${qjs_defines})
-if (CMAKE_BUILD_TYPE MATCHES Debug)
+if (CMAKE_BUILD_TYPE MATCHES Debug OR DUMP_LEAKS)
     target_compile_definitions(qjs PRIVATE
         DUMP_LEAKS
     )


### PR DESCRIPTION
I want to do a Release build (so that assert is disabled), but still log leaks. This adds the option to enable that through CMake.