### PR TITLE
Improve source location supports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 unicode/
 test262_*.txt
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ endif()
 
 xoption(BUILD_QJS_LIBC "Build standard library modules as part of the library" OFF)
 xoption(DUMP_QJS_TOKEN "Dump token while parsing, used for inspecting the lexer" OFF)
+xoption(DUMP_QJS_BYTECODE "Dump bytecodes while parsing, used for inspecting the parser" OFF)
 
 set(qjs_sources
     cutils.c
@@ -165,6 +166,10 @@ target_include_directories(qjs PUBLIC
 
 if(DUMP_QJS_TOKEN)
   target_compile_definitions(qjs PRIVATE DUMP_TOKEN)
+endif()
+
+if(DUMP_QJS_BYTECODE)
+  target_compile_definitions(qjs PRIVATE DUMP_BYTECODE=${DUMP_QJS_BYTECODE})
 endif()
 
 if(EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ endif()
 #
 
 xoption(BUILD_QJS_LIBC "Build standard library modules as part of the library" OFF)
+xoption(DUMP_QJS_TOKEN "Dump token while parsing, used for inspecting the lexer" OFF)
 
 set(qjs_sources
     cutils.c
@@ -161,6 +162,10 @@ target_include_directories(qjs PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>  
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+if(DUMP_QJS_TOKEN)
+  target_compile_definitions(qjs PRIVATE DUMP_TOKEN)
+endif()
 
 if(EMSCRIPTEN)
     add_executable(qjs_wasm ${qjs_sources})

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@
 BUILD_DIR=build
 BUILD_TYPE?=Release
 DUMP_TOKEN?=OFF
+DUMP_BYTECODE?=
 
 QJS=$(BUILD_DIR)/qjs
 RUN262=$(BUILD_DIR)/run-test262
@@ -45,7 +46,7 @@ endif
 all: $(QJS)
 
 $(BUILD_DIR):
-	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DDUMP_QJS_TOKEN=$(DUMP_TOKEN)
+	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DDUMP_QJS_TOKEN=$(DUMP_TOKEN) -DDUMP_QJS_BYTECODE=$(DUMP_BYTECODE)
 
 $(QJS): $(BUILD_DIR)
 	cmake --build $(BUILD_DIR) -j $(JOBS)
@@ -79,6 +80,10 @@ test: $(QJS)
 test-col: 
 	BUILD_TYPE=Debug DUMP_TOKEN=ON $(MAKE) -B
 	$(QJS) tests/test-col/run-tests.js
+
+test-op_loc: 
+	BUILD_TYPE=Debug DUMP_BYTECODE=2 $(MAKE) -B
+	$(QJS) tests/test-op_loc/run-tests.js
 
 test262: $(QJS)
 	$(RUN262) -m -c test262.conf -a

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@
 
 BUILD_DIR=build
 BUILD_TYPE?=Release
+DUMP_TOKEN?=OFF
 
 QJS=$(BUILD_DIR)/qjs
 RUN262=$(BUILD_DIR)/run-test262
@@ -44,7 +45,7 @@ endif
 all: $(QJS)
 
 $(BUILD_DIR):
-	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
+	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DDUMP_QJS_TOKEN=$(DUMP_TOKEN)
 
 $(QJS): $(BUILD_DIR)
 	cmake --build $(BUILD_DIR) -j $(JOBS)
@@ -73,6 +74,11 @@ test: $(QJS)
 	$(QJS) tests/test_std.js
 	$(QJS) tests/test_worker.js
 	$(QJS) tests/test_queue_microtask.js
+	$(MAKE) test-col
+
+test-col: 
+	BUILD_TYPE=Debug DUMP_TOKEN=ON $(MAKE) -B
+	$(QJS) tests/test-col/run-tests.js
 
 test262: $(QJS)
 	$(RUN262) -m -c test262.conf -a

--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,14 @@ test: $(QJS)
 	$(QJS) tests/test_worker.js
 	$(QJS) tests/test_queue_microtask.js
 	$(MAKE) test-col
+	$(MAKE) test-op_loc
 
 test-col: 
 	BUILD_TYPE=Debug DUMP_TOKEN=ON $(MAKE) -B
 	$(QJS) tests/test-col/run-tests.js
 
 test-op_loc: 
-	BUILD_TYPE=Debug DUMP_BYTECODE=2 $(MAKE) -B
+	BUILD_TYPE=Debug DUMP_TOKEN=OFF DUMP_BYTECODE=2 $(MAKE) -B
 	$(QJS) tests/test-op_loc/run-tests.js
 
 test262: $(QJS)

--- a/quickjs.c
+++ b/quickjs.c
@@ -30,7 +30,6 @@
 #include <inttypes.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/_types/_intptr_t.h>
 #if !defined(_MSC_VER)
 #include <sys/time.h>
 #endif
@@ -19410,6 +19409,7 @@ static __exception int json_next_token(JSParseState *s)
         }
         /* fall thru */
     case '\n':
+        p++;
         s->line_num++;
         s->col_num = 1;
         s->over_cols = 0;

--- a/quickjs.c
+++ b/quickjs.c
@@ -25173,6 +25173,7 @@ static __exception int js_parse_statement_or_decl(JSParseState *s,
 
     default:
     hasexpr:
+        s->loc = LOC(s->token.line_num, s->token.col_num);
         if (js_parse_expr(s))
             goto fail;
         if (s->cur_func->eval_ret_idx >= 0) {

--- a/quickjs.c
+++ b/quickjs.c
@@ -24,7 +24,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <_types/_uint8_t.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/tests/test-col/cases/break.js
+++ b/tests/test-col/cases/break.js
@@ -1,0 +1,15 @@
+var a = 1;
+
+outer: while (a > 1) {
+  while (a < 1) {
+    break outer;
+  }
+}
+
+/* EXPECT(while):
+3:8 ident: 'while'
+*/
+
+/* EXPECT(outer):
+5:11 ident: 'outer'
+*/

--- a/tests/test-col/cases/continue.js
+++ b/tests/test-col/cases/continue.js
@@ -1,0 +1,11 @@
+var a = 1;
+
+outer: while (a > 1) {
+  while (a < 1) {
+    continue outer;
+  }
+}
+
+/* EXPECT(outer):
+5:14 ident: 'outer'
+*/

--- a/tests/test-col/cases/dowhile.js
+++ b/tests/test-col/cases/dowhile.js
@@ -1,0 +1,22 @@
+var a = 1;
+
+do {
+  print(a);
+} while (a < 0);
+
+/* EXPECT({):
+3:4 token: '{'
+*/
+
+/* EXPECT(a):
+4:9 ident: 'a'
+*/
+
+/* EXPECT(a <):
+5:10 ident: 'a'
+5:12 token: '<'
+*/
+
+/* EXPECT(0):
+5:14 number: 0
+*/

--- a/tests/test-col/cases/expr_basic.js
+++ b/tests/test-col/cases/expr_basic.js
@@ -1,0 +1,28 @@
+var a;
+
+function b() {}
+
+var c = { ["👌"]: () => {} };
+
+a = new b();
+a = a + b() + c["👌"]();
+
+/* EXPECT(b after new):
+7:9 ident: 'b'
+*/
+
+/* EXPECT(( after new b):
+7:10 token: '('
+*/
+
+/* EXPECT(( after b):
+8:10 token: '('
+*/
+
+/* EXPECT([ after c):
+8:15 ident: 'c'
+*/
+
+/* EXPECT() after ]):
+8:22 token: ')'
+*/

--- a/tests/test-col/cases/for_basic.js
+++ b/tests/test-col/cases/for_basic.js
@@ -1,0 +1,23 @@
+ for (let a = 1, 
+  b, c; a < 10; a++, b++) {
+  c += 1;
+}
+
+/* EXPECT(let a = 1):
+1:7 ident: 'let'
+1:11 ident: 'a'
+1:13 token: '='
+1:15 number: 1
+*/
+
+/* EXPECT(b):
+2:3 ident: 'b'
+*/
+
+/* EXPECT(c in c += 1):
+3:3 ident: 'c'
+*/
+
+/* EXPECT(1 in c += 1):
+3:8 number: 1
+*/

--- a/tests/test-col/cases/forin_basic.js
+++ b/tests/test-col/cases/forin_basic.js
@@ -1,0 +1,12 @@
+var b;
+for 
+    (const a in b) {
+}
+
+/* EXPECT(a):
+3:12 ident: 'a'
+*/
+
+/* EXPECT(b):
+3:17 ident: 'b'
+*/

--- a/tests/test-col/cases/forin_destruct.js
+++ b/tests/test-col/cases/forin_destruct.js
@@ -1,0 +1,16 @@
+var b;
+for (const {
+    a, b: c } in b) {
+}
+
+/* EXPECT(a):
+3:5 ident: 'a'
+*/
+
+/* EXPECT(b):
+3:8 ident: 'b'
+*/
+
+/* EXPECT(c):
+3:11 ident: 'c'
+*/

--- a/tests/test-col/cases/forof_basic.js
+++ b/tests/test-col/cases/forof_basic.js
@@ -1,0 +1,17 @@
+var b = [];
+for (
+const a 
+of b) {
+}
+
+/* EXPECT(]):
+1:10 token: ']'
+*/
+
+/* EXPECT(a):
+3:7 ident: 'a'
+*/
+
+/* EXPECT(b):
+4:4 ident: 'b'
+*/

--- a/tests/test-col/cases/forof_destruct.js
+++ b/tests/test-col/cases/forof_destruct.js
@@ -1,0 +1,31 @@
+var b = 
+[];
+for (const [
+    a,
+{ b: c = 1 }] of 
+b) {
+}
+
+/* EXPECT(]):
+2:2 token: ']'
+*/
+
+/* EXPECT(a):
+4:5 ident: 'a'
+*/
+
+/* EXPECT(b):
+5:3 ident: 'b'
+*/
+
+/* EXPECT(b):
+6:1 ident: 'b'
+*/
+
+/* EXPECT(c):
+5:6 ident: 'c' 
+*/
+
+/* EXPECT(1):
+5:10 number: 1
+*/

--- a/tests/test-col/cases/if_basic.js
+++ b/tests/test-col/cases/if_basic.js
@@ -1,0 +1,13 @@
+var a = 1;
+
+if ( print(a)) {
+ } else if ("😀" === a) {
+}
+
+/* EXPECT(a after emoji):
+4:21 ident: 'a'
+*/
+
+/* EXPECT(a):
+3:12 ident: 'a'
+*/

--- a/tests/test-col/cases/return.js
+++ b/tests/test-col/cases/return.js
@@ -1,0 +1,7 @@
+function f() {
+  return /* xxx */1;
+}
+
+/* EXPECT(1):
+2:19 number: 1
+*/

--- a/tests/test-col/cases/switch.js
+++ b/tests/test-col/cases/switch.js
@@ -1,0 +1,24 @@
+var a = 1;
+
+switch (a) {
+  case "a":
+    break;
+  default   :
+    print(a);
+}
+
+/* EXPECT(a):
+3:9 ident: 'a'
+*/
+
+/* EXPECT('a'):
+4:8 string: 'a
+*/
+
+/* EXPECT(:):
+6:13 token: ':'
+*/
+
+/* EXPECT(a in print):
+7:11 ident: 'a'
+*/

--- a/tests/test-col/cases/throw.js
+++ b/tests/test-col/cases/throw.js
@@ -1,0 +1,15 @@
+try {
+  throw "test😀";
+} catch (error) {}
+
+/* EXPECT({ after try):
+1:5 token: '{'
+*/
+
+/* EXPECT(; term throw):
+2:16 token: ';'
+*/
+
+/* EXPECT(error):
+3:10 ident: 'error'
+*/

--- a/tests/test-col/cases/unicode.js
+++ b/tests/test-col/cases/unicode.js
@@ -1,0 +1,23 @@
+ let a = "😀" + 1;
+
+ let b = "🙂🙂" + 2;
+
+/* EXPECT(let):
+1:2 ident: 'let'
+*/
+
+/* EXPECT(a):
+1:6 ident: 'a'
+*/
+
+/* EXPECT(=):
+1:8 token: '='
+*/
+
+/* EXPECT(1):
+1:16 number: 1
+*/
+
+/* EXPECT(2):
+3:17 number: 2
+*/

--- a/tests/test-col/cases/vardec_basic.js
+++ b/tests/test-col/cases/vardec_basic.js
@@ -1,0 +1,38 @@
+var a = 1;
+let b = 1,
+  c;
+ const /* 🙂abc */ d = 1;
+
+const fn = () => {}; /*
+😀
+*/ const obj = { d: fn() };
+
+/* EXPECT(a):
+1:5 ident: 'a'
+1:7 token: '='
+1:9 number: 1
+*/
+
+/* EXPECT(b):
+2:5 ident: 'b'
+2:7 token: '='
+2:9 number: 1
+*/
+
+/* EXPECT(c):
+3:3 ident: 'c'
+*/
+
+/* EXPECT(d):
+4:19 ident: 'd'
+4:21 token: '='
+4:23 number: 1
+*/
+
+/* EXPECT(const after cmt):
+8:4 ident: 'const'
+*/
+
+/* EXPECT(fn):
+8:21 ident: 'fn'
+*/

--- a/tests/test-col/cases/vardec_destruct.js
+++ b/tests/test-col/cases/vardec_destruct.js
@@ -1,0 +1,35 @@
+const [d, { e: f } = { e: 1 }] = [];
+const { h: { 
+    i = 1 } = {} } = {};
+
+/* EXPECT(d):
+1:8 ident: 'd'
+*/
+
+/* EXPECT(e-alias):
+1:13 ident: 'e'
+*/
+
+/* EXPECT(e-default):
+1:24 ident: 'e'
+*/
+
+/* EXPECT(f):
+1:16 ident: 'f'
+*/
+
+/* EXPECT(h):
+2:9 ident: 'h'
+*/
+
+/* EXPECT(i):
+3:5 ident: 'i'
+*/
+
+/* EXPECT([):
+1:34 token: '['
+*/
+
+/* EXPECT({):
+3:22 token: '{'
+*/

--- a/tests/test-col/cases/while_basic.js
+++ b/tests/test-col/cases/while_basic.js
@@ -1,0 +1,24 @@
+var a = 0,
+  b = 10;
+
+while(
+  a > 
+      b) { 1 
+    + '👌😋' + 2
+}
+
+/* EXPECT(a):
+5:3 ident: 'a'
+*/
+
+/* EXPECT(b):
+6:7 ident: 'b'
+*/
+
+/* EXPECT(1):
+6:12 number: 1
+*/
+
+/* EXPECT(2):
+7:14 number: 2
+*/

--- a/tests/test-col/run-tests.js
+++ b/tests/test-col/run-tests.js
@@ -1,6 +1,8 @@
 import * as std from "std";
 import * as os from "os";
 
+const isWin = os.platform === "win32";
+
 function extractExpect(code) {
   const matches = code.matchAll(/\/\* EXPECT\((.*?)\):\n([\s\S]*?)\*\//gm);
   return [...matches].map((m) => ({
@@ -57,20 +59,23 @@ function test(name) {
   }
 }
 
-test("unicode");
-test("expr_basic");
-test("vardec_basic");
-test("vardec_destruct");
-test("if_basic");
-test("for_basic");
-test("forin_basic");
-test("forin_destruct");
-test("forof_basic");
-test("forof_destruct");
-test("while_basic");
-test("dowhile");
-test("break");
-test("continue");
-test("return");
-test("throw");
-test("switch");
+// the tests depends on `os.pipe` which does not exists on win
+if (!isWin) {
+  test("unicode");
+  test("expr_basic");
+  test("vardec_basic");
+  test("vardec_destruct");
+  test("if_basic");
+  test("for_basic");
+  test("forin_basic");
+  test("forin_destruct");
+  test("forof_basic");
+  test("forof_destruct");
+  test("while_basic");
+  test("dowhile");
+  test("break");
+  test("continue");
+  test("return");
+  test("throw");
+  test("switch");
+}

--- a/tests/test-col/run-tests.js
+++ b/tests/test-col/run-tests.js
@@ -1,0 +1,79 @@
+import * as std from "std";
+import * as os from "os";
+
+function extractExpect(code) {
+  const matches = code.matchAll(/\/\* EXPECT\((.*?)\):\n([\s\S]*?)\*\//gm);
+  return [...matches].map((m) => ({
+    name: m[1],
+    excepted: m[2].trim(),
+  }));
+}
+
+const cwd = import.meta.url
+  .slice("file://".length)
+  .slice(0, -"run-tests.js".length - 1);
+const proj = `${cwd}/../..`;
+
+// 1. build qjs by turn on the flag `QJS_DUMP_TOKEN` which will print
+//    token info in stdout
+// 2. add/modify the tests under the subdirectories
+// 3. include test by using `test(TEST_CASE)` form where the `TEST_CASE`
+//    comes from the relative path of the test file
+// 4. the test file is self-included, that means it consists of the test stuff
+//    and their excepted output:
+//
+//    ```
+//    /* EXCEPT(NAME_OF_THIS_CAST):
+//    THE_EXCEPTED_OUTPUT_TO_COMPARE_WITH_THE_TEST
+//    */
+//    ```
+function test(name) {
+  const fds = os.pipe();
+  const qjs = `${proj}/build/qjs`;
+  const target = `${cwd}/cases/${name}.js`;
+
+  os.exec([qjs, target], {
+    stdout: fds[1],
+    block: true,
+  });
+  os.close(fds[1]);
+
+  const f = std.fdopen(fds[0], "r");
+  const bc = f.readAsString();
+  f.close();
+
+  const tf = std.fdopen(os.open(target, os.O_RDONLY), "r");
+  const code = tf.readAsString();
+  tf.close();
+  const cases = extractExpect(code);
+
+  for (const { name: subname, excepted } of cases) {
+    if (!bc.includes(excepted)) {
+      throw new Error(
+        `failed to test [${name}] at [${subname}],
+--got--:
+|${bc}|
+--excepted--:
+|${excepted}|`
+      );
+    }
+  }
+}
+
+test("unicode");
+test("expr_basic");
+test("vardec_basic");
+test("vardec_destruct");
+test("if_basic");
+test("for_basic");
+test("forin_basic");
+test("forin_destruct");
+test("forof_basic");
+test("forof_destruct");
+test("while_basic");
+test("dowhile");
+test("break");
+test("continue");
+test("return");
+test("throw");
+test("switch");

--- a/tests/test-col/run-tests.js
+++ b/tests/test-col/run-tests.js
@@ -14,13 +14,10 @@ const cwd = import.meta.url
   .slice(0, -"run-tests.js".length - 1);
 const proj = `${cwd}/../..`;
 
-// 1. build qjs by turn on the flag `QJS_DUMP_TOKEN` which will print
+// 1. build qjs by turn on the flag `DUMP_QJS_TOKEN` which will print
 //    token info in stdout
 // 2. add/modify the tests under the subdirectories
-// 3. include test by using `test(TEST_CASE)` form where the `TEST_CASE`
-//    comes from the relative path of the test file
-// 4. the test file is self-included, that means it consists of the test stuff
-//    and their excepted output:
+// 3. the test file is self-included, that means it consists of the test rules:
 //
 //    ```
 //    /* EXCEPT(NAME_OF_THIS_CAST):

--- a/tests/test-op_loc/cases/break.js
+++ b/tests/test-op_loc/cases/break.js
@@ -1,0 +1,12 @@
+var a = 1;
+
+outer: while (a > 1) {
+  while (a < 1) {
+    break outer;
+  }
+}
+
+/* EXPECT(outer):
+        source_loc 5:5
+        goto 2:128
+*/

--- a/tests/test-op_loc/cases/break.js
+++ b/tests/test-op_loc/cases/break.js
@@ -8,5 +8,5 @@ outer: while (a > 1) {
 
 /* EXPECT(outer):
         source_loc 5:5
-        goto 2:128
+        goto 2:146
 */

--- a/tests/test-op_loc/cases/class_call_private.js
+++ b/tests/test-op_loc/cases/class_call_private.js
@@ -1,0 +1,18 @@
+class c {
+  #b = () => {};
+
+  f() {
+    this.#b();
+  }
+}
+
+/* EXPECT(this.#b()):
+        source_loc 5:10
+        dup
+        get_var_ref 0: "#b"
+        get_private_field
+
+
+        source_loc 5:12
+        call_method 0
+*/

--- a/tests/test-op_loc/cases/class_ctor.js
+++ b/tests/test-op_loc/cases/class_ctor.js
@@ -1,0 +1,41 @@
+class c {
+  constructor(a) {
+    this.a = a;
+  }
+
+  f2() {}
+}
+
+function f1() {}
+const a = {
+  f1,
+};
+
+1 + new a.f1(1);
+2 + new c().f2();
+
+/* EXPECT(= a):
+        source_loc 3:14
+        insert2
+        put_field a
+*/
+
+/* EXPECT(new a.f1(1)):
+        source_loc 14:11
+        get_field f1
+        dup
+        push_i32 1
+        source_loc 14:9
+        call_constructor 1
+*/
+
+/* EXPECT(new c().f2()):
+        get_var c
+        dup
+        source_loc 15:9
+        call_constructor 0
+        source_loc 15:13
+        get_field2 f2
+        source_loc 15:15
+        call_method 0
+*/

--- a/tests/test-op_loc/cases/class_method.js
+++ b/tests/test-op_loc/cases/class_method.js
@@ -1,0 +1,12 @@
+class c {
+  f() {}
+}
+
+new c().f();
+
+/* EXPECT(c.f()):
+        source_loc 5:9
+        get_field2 f
+        source_loc 5:10
+        call_method 0
+*/

--- a/tests/test-op_loc/cases/class_prop_init.js
+++ b/tests/test-op_loc/cases/class_prop_init.js
@@ -1,0 +1,10 @@
+const f = () => {};
+class c {
+  a = f();
+}
+
+/* EXPECT(a = f())):
+        get_var f
+        source_loc 3:8
+        call 0
+*/

--- a/tests/test-op_loc/cases/continue.js
+++ b/tests/test-op_loc/cases/continue.js
@@ -1,0 +1,12 @@
+var a = 1;
+
+outer: while (a > 1) {
+  while (a < 1) {
+    continue outer;
+  }
+}
+
+/* EXPECT(outer):
+        source_loc 5:5
+        goto 1:40
+*/

--- a/tests/test-op_loc/cases/dowhile.js
+++ b/tests/test-op_loc/cases/dowhile.js
@@ -1,0 +1,13 @@
+var a = 1;
+
+do {
+  print(a);
+} while (a < 0);
+
+/* EXPECT(a < 0):
+        get_var a
+        push_i32 0
+        lt
+        source_loc 5:10
+        if_true 3:36
+*/

--- a/tests/test-op_loc/cases/expr_call.js
+++ b/tests/test-op_loc/cases/expr_call.js
@@ -1,0 +1,56 @@
+const fn = () => {};
+const obj = { f1: fn, b: { f2: fn } };
+// ·f, = ·{}, ·fn()
+const { d, e: f = { e: 2 } } = { d: fn() };
+obj.f1();
+obj.b.f2();
+obj["f1"]();
+obj["b"]["f2"]();
+
+/* EXPECT(()=>{}):
+        source_loc 1:12
+        put_var_init fn
+*/
+
+/* EXPECT(e: f):
+        source_loc 4:15
+        put_var_init f
+*/
+
+/* EXPECT(d: fn):
+        get_var fn
+        source_loc 4:39
+        call 0
+*/
+
+/* EXPECT(obj.f1()):
+        source_loc 5:5
+        get_field2 f1
+        source_loc 5:7
+        call_method 0
+*/
+
+/* EXPECT(obj.b.f2()):
+        source_loc 6:5
+        get_field b
+        source_loc 6:7
+        get_field2 f2
+        source_loc 6:9
+        call_method 0
+*/
+
+/* EXPECT(obj["f1"]()):
+        get_var obj
+        push_atom_value f1
+        get_array_el2
+        source_loc 7:10
+        call_method 0
+*/
+
+/* EXPECT(obj["b"]["f2"]()):
+        get_array_el
+        push_atom_value f2
+        get_array_el2
+        source_loc 8:15
+        call_method 0
+*/

--- a/tests/test-op_loc/cases/for_basic.js
+++ b/tests/test-op_loc/cases/for_basic.js
@@ -11,11 +11,12 @@ for (let a = 1, b, c;
 */
 
 /* EXPECT(a < 10):
+        source_loc 3:3
         get_loc_check 1: a
         push_i32 10
         lt
         source_loc 3:3
-        if_false 3:168
+        if_false 3:186
 */
 
 /* EXPECT(a++):

--- a/tests/test-op_loc/cases/for_basic.js
+++ b/tests/test-op_loc/cases/for_basic.js
@@ -1,0 +1,35 @@
+// prettier-ignore
+for (let a = 1, b, c; 
+  a < 10; a++, b++) {
+  c += 1;
+}
+
+/* EXPECT(let a = 1):
+        push_i32 1
+        source_loc 2:14
+        put_loc 1: a
+*/
+
+/* EXPECT(a < 10):
+        get_loc_check 1: a
+        push_i32 10
+        lt
+        source_loc 3:3
+        if_false 3:168
+*/
+
+/* EXPECT(a++):
+        source_loc 3:11
+        get_loc_check 1: a
+        post_inc
+*/
+
+/* EXPECT(c += 1):
+        source_loc 4:3
+        get_loc_check 3: c
+        push_i32 1
+        add
+        source_loc 4:8
+        dup
+        put_loc_check 3: c
+*/

--- a/tests/test-op_loc/cases/forin_basic.js
+++ b/tests/test-op_loc/cases/forin_basic.js
@@ -18,7 +18,7 @@ for (const a in b) {
         push_i32 2
         add
         source_loc 3:8
-        label 5:103
-  103:  insert3
+        label 5:112
+  112:  insert3
         put_ref_value
 */

--- a/tests/test-op_loc/cases/forin_basic.js
+++ b/tests/test-op_loc/cases/forin_basic.js
@@ -1,0 +1,24 @@
+var b;
+for (const a in b) {
+  a += 2;
+}
+
+/* EXPECT(const a):
+        source_loc 2:12
+        put_loc 1: a
+*/
+
+/* EXPECT(in b):
+        source_loc 2:17
+        for_in_next
+*/
+
+/* EXPECT(a += 2):
+        get_ref_value
+        push_i32 2
+        add
+        source_loc 3:8
+        label 5:103
+  103:  insert3
+        put_ref_value
+*/

--- a/tests/test-op_loc/cases/forin_destruct.js
+++ b/tests/test-op_loc/cases/forin_destruct.js
@@ -1,0 +1,18 @@
+var b;
+for (const { a, b: c } in b) {
+}
+
+/* EXPECT(a):
+        source_loc 2:14
+        put_loc 1: a
+*/
+
+/* EXPECT(b):
+        source_loc 2:20
+        put_loc 2: c
+*/
+
+/* EXPECT(in b):
+        source_loc 2:27
+        for_in_next
+*/

--- a/tests/test-op_loc/cases/forof_await.js
+++ b/tests/test-op_loc/cases/forof_await.js
@@ -1,0 +1,15 @@
+var b = [];
+async function f() {
+  for await (const a of b) {
+  }
+}
+
+/* EXPECT(a):
+        source_loc 3:20
+        put_loc 0: a
+*/
+
+/* EXPECT(of b):
+        source_loc 3:25
+        iterator_get_value_done
+*/

--- a/tests/test-op_loc/cases/forof_basic.js
+++ b/tests/test-op_loc/cases/forof_basic.js
@@ -1,0 +1,13 @@
+var b = [];
+for (const a of b) {
+}
+
+/* EXPECT(a):
+        loc 2:12
+        put_loc 1: a
+*/
+
+/* EXPECT(b):
+        loc 2:17
+        for_of_next 0
+*/

--- a/tests/test-op_loc/cases/forof_destruct.js
+++ b/tests/test-op_loc/cases/forof_destruct.js
@@ -1,0 +1,18 @@
+var b = [];
+for (const [a, { b: c = 1 }] of b) {
+}
+
+/* EXPECT(a):
+        source_loc 2:13
+        put_loc 1: a
+*/
+
+/* EXPECT(c):
+        source_loc 2:21
+        put_loc 2: c
+*/
+
+/* EXPECT(of b):
+        source_loc 2:33
+        for_of_next 0
+*/

--- a/tests/test-op_loc/cases/if_basic.js
+++ b/tests/test-op_loc/cases/if_basic.js
@@ -6,7 +6,9 @@ if (print(a)) {
 }
 
 /* EXPECT(print(a)):
+        source_loc 3:5
         get_var print
+        source_loc 3:11
         get_var a
         source_loc 3:10
         call 1

--- a/tests/test-op_loc/cases/if_basic.js
+++ b/tests/test-op_loc/cases/if_basic.js
@@ -1,0 +1,21 @@
+var a = 1;
+
+if (print(a)) {
+} else if ("😀" === a) {
+  print(2);
+}
+
+/* EXPECT(print(a)):
+        get_var print
+        get_var a
+        source_loc 3:10
+        call 1
+*/
+
+/* EXPECT(print(2)):
+        source_loc 5:3
+        get_var print
+        push_i32 2
+        source_loc 5:8
+        call 1
+*/

--- a/tests/test-op_loc/cases/literal_arr.js
+++ b/tests/test-op_loc/cases/literal_arr.js
@@ -1,0 +1,7 @@
+// = ·[]
+const [d, { e: f } = { e: 2 }] = [];
+
+/* EXPECT(= []):
+        source_loc 2:34
+        array_from 0
+*/

--- a/tests/test-op_loc/cases/literal_obj.js
+++ b/tests/test-op_loc/cases/literal_obj.js
@@ -1,0 +1,13 @@
+const fn = () => {};
+// ·f, = ·{}, ·fn()
+const { d, e: f = { e: 2 } } = { d: fn() };
+
+/* EXPECT(()=>{}):
+        loc 1:12
+        put_var_init fn
+*/
+
+/* EXPECT(f):
+        loc 3:15
+        put_var_init f
+*/

--- a/tests/test-op_loc/cases/return.js
+++ b/tests/test-op_loc/cases/return.js
@@ -1,0 +1,29 @@
+function f() {
+  return print(1);
+}
+
+function f1() {
+  return;
+}
+
+function f2(a) {
+  return a;
+}
+
+/* EXPECT(return print(1)):
+        source_loc 2:15
+        call 1
+        source_loc 2:3
+        return
+*/
+
+/* EXPECT(return):
+        source_loc 6:3
+        return_undef
+*/
+
+/* EXPECT(return a):
+        get_arg 0: a
+        source_loc 10:3
+        return
+*/

--- a/tests/test-op_loc/cases/switch.js
+++ b/tests/test-op_loc/cases/switch.js
@@ -20,12 +20,13 @@ switch (a) {
 
 /* EXPECT(break b):
         source_loc 8:5
-        goto 1:175
+        goto 1:193
 */
 
 /* EXPECT(default):
         source_loc 10:5
         get_var print
+        source_loc 10:11
         get_var a
         source_loc 10:10
         call 1

--- a/tests/test-op_loc/cases/switch.js
+++ b/tests/test-op_loc/cases/switch.js
@@ -1,0 +1,32 @@
+var a = 1;
+
+switch (a) {
+  case "a":
+    print("a");
+    break;
+  case "b":
+    break;
+  default:
+    print(a);
+}
+
+/* EXPECT(case "a"):
+        source_loc 5:5
+        get_var print
+        push_atom_value a
+        source_loc 5:10
+        call 1
+*/
+
+/* EXPECT(break b):
+        source_loc 8:5
+        goto 1:175
+*/
+
+/* EXPECT(default):
+        source_loc 10:5
+        get_var print
+        get_var a
+        source_loc 10:10
+        call 1
+*/

--- a/tests/test-op_loc/cases/vardec_basic.js
+++ b/tests/test-op_loc/cases/vardec_basic.js
@@ -1,0 +1,31 @@
+var a = 1;
+let b = 2;
+const c = 3,
+  d = 4;
+let e;
+var f;  
+
+/* EXPECT(a):
+        source_loc 1:9
+        put_var a
+*/
+
+/* EXPECT(b):
+        source_loc 2:9
+        put_var_init b
+*/
+
+/* EXPECT(c):
+        source_loc 3:11
+        put_var_init c
+*/
+
+/* EXPECT(d):
+        source_loc 4:7
+        put_var_init d
+*/
+
+/* EXPECT(e):
+        source_loc 5:5
+        put_var_init e
+*/

--- a/tests/test-op_loc/cases/vardec_destruct.js
+++ b/tests/test-op_loc/cases/vardec_destruct.js
@@ -1,0 +1,20 @@
+// ·d, ·f
+const [d, { e: f } = { e: 2 }] = [];
+
+// ·i, = ·{}
+const { h: { i = 1 } = {} } = {};
+
+/* EXPECT(d):
+        source_loc 2:8
+        put_var_init d
+*/
+
+/* EXPECT(f):
+        source_loc 2:16
+        put_var_init f
+*/
+
+/* EXPECT(i):
+        source_loc 5:14
+        put_var_init i
+*/

--- a/tests/test-op_loc/cases/while_basic.js
+++ b/tests/test-op_loc/cases/while_basic.js
@@ -12,8 +12,9 @@ while (a > b) {
 */
 
 /* EXPECT(a > b):
+        source_loc 4:12
         get_var b
         gt
         source_loc 4:8
-        if_false 3:129
+        if_false 3:147
 */

--- a/tests/test-op_loc/cases/while_basic.js
+++ b/tests/test-op_loc/cases/while_basic.js
@@ -1,0 +1,19 @@
+var a = 0,
+  b = 10;
+
+while (a > b) {
+  a++;
+}
+
+/* EXPECT(a++):
+        source_loc 5:3
+        get_var a
+        post_inc
+*/
+
+/* EXPECT(a > b):
+        get_var b
+        gt
+        source_loc 4:8
+        if_false 3:129
+*/

--- a/tests/test-op_loc/run-tests.js
+++ b/tests/test-op_loc/run-tests.js
@@ -1,6 +1,8 @@
 import * as std from "std";
 import * as os from "os";
 
+const isWin = os.platform === "win32";
+
 function extractExpect(code) {
   const matches = code.matchAll(/\/\* EXPECT\((.*?)\):\n([\s\S]*?)\*\//gm);
   return [...matches].map((m) => ({
@@ -57,25 +59,28 @@ function test(name) {
   }
 }
 
-test("literal_arr");
-test("literal_obj");
-test("expr_call");
-test("vardec_basic");
-test("vardec_destruct");
-test("class_ctor");
-test("class_method");
-test("class_prop_init");
-test("class_call_private");
-test("if_basic");
-test("for_basic");
-test("forin_basic");
-test("forin_destruct");
-test("forof_basic");
-test("forof_destruct");
-test("forof_await");
-test("while_basic");
-test("dowhile");
-test("break");
-test("continue");
-test("return");
-test("switch");
+// the tests depends on `os.pipe` which does not exists on win
+if (!isWin) {
+  test("literal_arr");
+  test("literal_obj");
+  test("expr_call");
+  test("vardec_basic");
+  test("vardec_destruct");
+  test("class_ctor");
+  test("class_method");
+  test("class_prop_init");
+  test("class_call_private");
+  test("if_basic");
+  test("for_basic");
+  test("forin_basic");
+  test("forin_destruct");
+  test("forof_basic");
+  test("forof_destruct");
+  test("forof_await");
+  test("while_basic");
+  test("dowhile");
+  test("break");
+  test("continue");
+  test("return");
+  test("switch");
+}

--- a/tests/test-op_loc/run-tests.js
+++ b/tests/test-op_loc/run-tests.js
@@ -14,13 +14,10 @@ const cwd = import.meta.url
   .slice(0, -"run-tests.js".length - 1);
 const proj = `${cwd}/../..`;
 
-// 1. build qjs by turn on the flag `QJS_DUMP_TOKEN` which will print
-//    token info in stdout
+// 1. build qjs by turn on the flag `DUMP_QJS_BYTECODE` which will print
+//    the bytecode stream in stdout
 // 2. add/modify the tests under the subdirectories
-// 3. include test by using `test(TEST_CASE)` form where the `TEST_CASE`
-//    comes from the relative path of the test file
-// 4. the test file is self-included, that means it consists of the test stuff
-//    and their excepted output:
+// 3. the test file is self-included, that means it consists of the test rules:
 //
 //    ```
 //    /* EXCEPT(NAME_OF_THIS_CAST):

--- a/tests/test-op_loc/run-tests.js
+++ b/tests/test-op_loc/run-tests.js
@@ -1,0 +1,84 @@
+import * as std from "std";
+import * as os from "os";
+
+function extractExpect(code) {
+  const matches = code.matchAll(/\/\* EXPECT\((.*?)\):\n([\s\S]*?)\*\//gm);
+  return [...matches].map((m) => ({
+    name: m[1],
+    excepted: m[2].trim(),
+  }));
+}
+
+const cwd = import.meta.url
+  .slice("file://".length)
+  .slice(0, -"run-tests.js".length - 1);
+const proj = `${cwd}/../..`;
+
+// 1. build qjs by turn on the flag `QJS_DUMP_TOKEN` which will print
+//    token info in stdout
+// 2. add/modify the tests under the subdirectories
+// 3. include test by using `test(TEST_CASE)` form where the `TEST_CASE`
+//    comes from the relative path of the test file
+// 4. the test file is self-included, that means it consists of the test stuff
+//    and their excepted output:
+//
+//    ```
+//    /* EXCEPT(NAME_OF_THIS_CAST):
+//    THE_EXCEPTED_OUTPUT_TO_COMPARE_WITH_THE_TEST
+//    */
+//    ```
+function test(name) {
+  const fds = os.pipe();
+  const qjs = `${proj}/build/qjs`;
+  const target = `${cwd}/cases/${name}.js`;
+
+  os.exec([qjs, target], {
+    stdout: fds[1],
+    block: true,
+  });
+  os.close(fds[1]);
+
+  const f = std.fdopen(fds[0], "r");
+  const bc = f.readAsString();
+  f.close();
+
+  const tf = std.fdopen(os.open(target, os.O_RDONLY), "r");
+  const code = tf.readAsString();
+  tf.close();
+  const cases = extractExpect(code);
+
+  for (const { name: subname, excepted } of cases) {
+    if (!bc.includes(excepted)) {
+      throw new Error(
+        `failed to test [${name}] at [${subname}],
+--got--:
+|${bc}|
+--excepted--:
+|${excepted}|`
+      );
+    }
+  }
+}
+
+test("literal_arr");
+test("literal_obj");
+test("expr_call");
+test("vardec_basic");
+test("vardec_destruct");
+test("class_ctor");
+test("class_method");
+test("class_prop_init");
+test("class_call_private");
+test("if_basic");
+test("for_basic");
+test("forin_basic");
+test("forin_destruct");
+test("forof_basic");
+test("forof_destruct");
+test("forof_await");
+test("while_basic");
+test("dowhile");
+test("break");
+test("continue");
+test("return");
+test("switch");


### PR DESCRIPTION
Hi, this PR tries to improve the source location supports.

The source location correctness is useful I think, not for better error reports but also for later debugger to support breakpoints, so I make below changes, request for review.

### Unicode

handle unicodes included in strings, identifiers, comments and regexp literals.

```js
let a = "😀" + 1;
```

current token stream is:

```
1:1 ident: 'let'
1:4 ident: 'a'
1:1 ident: 'let'
1:4 ident: 'a'
1:6 token: '='
1:8 string: '😀'
1:15 token: '+'
1:17 number: 1
1:17 token: ';'
2:1 eof
```

loc of `+` is miscalculated, the correct one is `1:13`

### Leading spaces

source location is miscalculated if the line starts with spaces.

```js
  let a = "😀" + 1;
```

current token stream is:

```
1:2 ident: 'let'
1:6 ident: 'a'
1:2 ident: 'let'
1:6 ident: 'a'
1:8 token: '='
1:10 string: '😀'
1:17 token: '+'
1:19 number: 1
1:19 token: ';'
2:1 eof
```

the loc of `let` should be `1:3` to comply with editor's behaviors.

### Regression tests

some tests under the `tests` directory to cover changes in this PR.

the tests base on:

1. two new options `DUMP_QJS_TOKEN` and `DUMP_QJS_BYTECODE` to tell qjs
to print the token streams and bytecode streams to stdout

2. then the test runner `run-test.js` will assert the expected snapshots present in stdout.

