### PR TITLE
Make `performance` configurable

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -51144,7 +51144,7 @@ void JS_AddPerformance(JSContext *ctx)
                            JS_PROP_ENUMERABLE);
     JS_DefinePropertyValueStr(ctx, ctx->global_obj, "performance",
                            js_dup(performance),
-                           JS_PROP_ENUMERABLE);
+                           JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE);
     JS_FreeValue(ctx, performance);
 }
 


### PR DESCRIPTION
I was already including a `performance` property, but switching to quickjs-ng throws an error when trying to re-define that prop. Make it configurable to match browser behavior:

```js
Object.getOwnPropertyDescriptor(globalThis, 'performance').configurable
// true
```