### PR TITLE
Add user-definable hook to prevent objects from being GC'ed

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -434,6 +434,7 @@ typedef void JSClassGCMark(JSRuntime *rt, JSValue val,
 typedef JSValue JSClassCall(JSContext *ctx, JSValue func_obj,
                             JSValue this_val, int argc, JSValue *argv,
                             int flags);
+typedef JS_BOOL JSClassCanDestroy(JSRuntime *rt, JSValue val);
 
 typedef struct JSClassDef {
     const char *class_name;
@@ -448,6 +449,7 @@ typedef struct JSClassDef {
     /* XXX: suppress this indirection ? It is here only to save memory
        because only a few classes need these methods */
     JSClassExoticMethods *exotic;
+    JSClassCanDestroy *can_destroy;
 } JSClassDef;
 
 JS_EXTERN JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id);


### PR DESCRIPTION
Hi,

I'm considering switching my project's[^1] vendored QJS fork to QJS-ng. For this, I would need the following patch for adding a callback that allows cooperation with the QJS garbage collector.

Background: my project is written in Nim, and has a facility to automatically convert Nim objects (managed by the Nim garbage collector) to JS objects as follows:

* If a JS object is already associated with the Nim object, return that object.
* Otherwise, create a new JS object, and associate the JS object with the Nim object.

The problem lies in resource deallocation. The naive idea of using finalizers does not work because of cycles:

* We can try incrementing the JS refcount only. Does not work for obvious reasons (Nim object gets deallocated while JS object is still alive; we get UAF or null deref.)
* We can try incrementing both refcounts. Now the objects will never be collected; we have to implement a cycle collector that somehow communicates with the Nim and QJS cycle collectors too. (Unrealistic)
* We can try incrementing the Nim refcount only. Now the following breaks:

```js
let po = new PlatformObject(); // backed by a Nim object
po.doSomethingInNim(); // doSomethingInNim is a JSCFunction calling the corresponding Nim function.
po.jsField = "abcd"; // not known to Nim; this is set on the JS object
window.platformObjectStore = po; // only stores Nim object!
po = null; // assume GC is now triggered, the JS object is destroyed
console.log(window.platformObjectStore.jsField); // undefined :(
```

Instead, my solution uses a hook in the QJS GC:

* Again, we only increment the refcount of the Nim object.
* If JS_FreeValue reaches a refcount of 0, call a callback that decreases the backing Nim object's refcount. If this does not free the Nim object, increase the QJS object's refcount and free it when the Nim object is destroyed.

(So basically, ownership after creating a platform object from JS is JS -> Nim. Ownership after JS would have been freed is Nim -> JS.)

The idea remains the same for cycle collection: for all objects that would be deleted, restore them if the callback returns true. Changes to the current cycle collector are:

* We add a second temporary object list, `tmp_hook_obj_list`.
* In `gc_decref`, put every object with a callback hook into `tmp_hook_obj_list` instead of `tmp_obj_list`.
* In `gc_scan`, go through every obj of `tmp_hook_obj_list`:
	- call the hook
	- if hook returns OK, move obj to `tmp_obj_list`; destruction of this object proceeds as normal
	- if hook returns cancel, move obj and all its descendants back to `gc_obj_list` (and re-add the refcount to them)

Performance considerations: the cycle collector modification is O(N) complexity where N is the number of objects with a hook. If the hook is not used, the only change is an additional NULL check every time an object is freed, and a NULL check for each object before being placed in `tmp_obj_list`.

Note: I guess this feature should be mentioned in the manual, I'll add it if this proposal gets accepted at all :)

[^1]: https://sr.ht/~bptato/chawan/
