### PR TITLE
android: malloc_usable_size() was renamed to dlmalloc_usable_size()

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -429,6 +429,8 @@ static inline size_t js__malloc_usable_size(const void *ptr)
     return malloc_size(ptr);
 #elif defined(_WIN32)
     return _msize((void *)ptr);
+#elif defined(__ANDROID__)
+    return dlmalloc_usable_size((void *)ptr);
 #elif defined(__linux__) || defined(__FreeBSD__)
     return malloc_usable_size((void *)ptr);
 #else


### PR DESCRIPTION
On Android builds, use `dlmalloc_usable_size()` instead of `malloc_usable_size()`.