### PR TITLE
android: Additional malloc_usable_size() fixes

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -40,6 +40,8 @@
 #endif
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
+#elif defined(__ANDROID__)
+#include <dlmalloc.h>
 #elif defined(__linux__) || defined(__CYGWIN__)
 #include <malloc.h>
 #elif defined(__FreeBSD__)

--- a/quickjs.c
+++ b/quickjs.c
@@ -1726,6 +1726,8 @@ static const JSMallocFunctions def_malloc_funcs = {
     malloc_size,
 #elif defined(_WIN32)
     (size_t (*)(const void *))_msize,
+#elif defined(__ANDROID__)
+    (size_t (*)(const void *))dlmalloc_usable_size,
 #elif defined(__linux__) || defined (__CYGWIN__)
     (size_t (*)(const void *))malloc_usable_size,
 #else


### PR DESCRIPTION
This includes a few more fixes for using `malloc_usable_size()` in Android.
