### PR TITLE
Align module export API with upstream

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -792,6 +792,7 @@ JS_EXTERN void JS_SetModuleLoaderFunc(JSRuntime *rt,
 /* return the import.meta object of a module */
 JS_EXTERN JSValue JS_GetImportMeta(JSContext *ctx, JSModuleDef *m);
 JS_EXTERN JSAtom JS_GetModuleName(JSContext *ctx, JSModuleDef *m);
+JSValue JS_GetModuleNamespace(JSContext *ctx, JSModuleDef *m);
 
 /* JS Job support */
 
@@ -966,11 +967,6 @@ JS_EXTERN int JS_SetModuleExport(JSContext *ctx, JSModuleDef *m, const char *exp
                                  JSValue val);
 JS_EXTERN int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
                                      const JSCFunctionListEntry *tab, int len);
-/* can only be called after the module is initialized */
-JS_EXTERN JSValue JS_GetModuleExport(JSContext *ctx, const JSModuleDef *m, const char *export_name);
-JS_EXTERN int JS_CountModuleExport(JSContext *ctx, const JSModuleDef *m);
-JS_EXTERN JSAtom JS_GetModuleExportName(JSContext *ctx, const JSModuleDef *m, int idx);
-JS_EXTERN JSValue JS_GetModuleExportValue(JSContext *ctx, const JSModuleDef *m, int idx);
 
 /* Promise */
 


### PR DESCRIPTION
Partially reverts
https://github.com/quickjs-ng/quickjs/commit/6868fb9e2516fde4a7a3fcef113a6bb1e5ecc957 but the same behavior can be implemented in userland by getting the module ns and querying its properties.

Ref: https://github.com/bellard/quickjs/commit/c6cc6a9a5e420fa2707e828da23d131d2bf170f7
Fixes: https://github.com/quickjs-ng/quickjs/issues/259