### PR TITLE
Remove unnecessary ssize_t posix-ism

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -6117,7 +6117,7 @@ void JS_ComputeMemoryUsage(JSRuntime *rt, JSMemoryUsage *s)
 void JS_DumpMemoryUsage(FILE *fp, const JSMemoryUsage *s, JSRuntime *rt)
 {
     fprintf(fp, "QuickJS-ng memory usage -- %s version, %d-bit, malloc limit: %"PRId64"\n\n",
-        JS_GetVersion(), (int)sizeof(void *) * 8, (int64_t)(ssize_t)s->malloc_limit);
+        JS_GetVersion(), (int)sizeof(void *) * 8, s->malloc_limit);
     if (rt) {
         static const struct {
             const char *name;


### PR DESCRIPTION
ssize_t is not always available and the cast it was used in wasn't necessary in the first place, the value already has the right type.