### PR TITLE
Add method to GetClassID

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -3348,7 +3348,7 @@ JSClassID JS_GetClassID(JSValue v)
 {
   JSObject *p;
   if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
-    return 0;
+    return JS_INVALID_CLASS_ID;
   p = JS_VALUE_GET_OBJ(v);
   return p->class_id;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -3344,6 +3344,15 @@ JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id)
     return class_id;
 }
 
+JSClassID JS_GetClassID(JSValue v)
+{
+  JSObject *p;
+  if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
+    return 0;
+  p = JS_VALUE_GET_OBJ(v);
+  return p->class_id;
+}
+
 BOOL JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id)
 {
     return (class_id < rt->class_count &&

--- a/quickjs.h
+++ b/quickjs.h
@@ -456,6 +456,8 @@ typedef struct JSClassDef {
 } JSClassDef;
 
 JS_EXTERN JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id);
+/* Returns the class ID if `v` is an object, otherwise returns 0. */
+JS_EXTERN JSClassID JS_GetClassID(JSValue v);
 JS_EXTERN int JS_NewClass(JSRuntime *rt, JSClassID class_id, const JSClassDef *class_def);
 JS_EXTERN int JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id);
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -455,8 +455,9 @@ typedef struct JSClassDef {
     JSClassExoticMethods *exotic;
 } JSClassDef;
 
+#define JS_INVALID_CLASS_ID 0
 JS_EXTERN JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id);
-/* Returns the class ID if `v` is an object, otherwise returns 0. */
+/* Returns the class ID if `v` is an object, otherwise returns JS_INVALID_CLASS_ID. */
 JS_EXTERN JSClassID JS_GetClassID(JSValue v);
 JS_EXTERN int JS_NewClass(JSRuntime *rt, JSClassID class_id, const JSClassDef *class_def);
 JS_EXTERN int JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id);


### PR DESCRIPTION
If you want to extend a built-in class you need it's class ID and there
is no robust way to get that without this accessor.

