### PR TITLE
Revert "Fix sloppy mode arguments uninitialized value use"

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -13185,8 +13185,6 @@ static JSValue js_build_mapped_arguments(JSContext *ctx, int argc,
     if (JS_IsException(val))
         return val;
     p = JS_VALUE_GET_OBJ(val);
-    p->u.array.u.values = NULL;
-    p->u.array.count = 0;
 
     /* add the length field (cannot fail) */
     pr = add_property(ctx, p, JS_ATOM_length,


### PR DESCRIPTION
This reverts commit f8b3a2e93cb998e181457f3fecd30066454bbc66.

No longer necessary after commit 90d8c6bae0b1345e94e4f4ea210b063f4d805047.

<hr>

Same as bellard/quickjs@95e0aa052667b367673f2993622ec42207587b09