### PR TITLE
Fix Map hash bug

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -44379,7 +44379,7 @@ static uint32_t map_hash_key(JSContext *ctx, JSValue key)
         h = (uintptr_t)JS_VALUE_GET_PTR(key) * 3163;
         break;
     case JS_TAG_INT:
-        d = JS_VALUE_GET_INT(key) * 3163;
+        d = JS_VALUE_GET_INT(key);
         goto hash_float64;
     case JS_TAG_BIG_INT:
         a = JS_GetBigInt(key);
@@ -44393,7 +44393,7 @@ static uint32_t map_hash_key(JSContext *ctx, JSValue key)
     hash_float64:
         u.d = d;
         h = (u.u32[0] ^ u.u32[1]) * 3163;
-        break;
+        return h ^= JS_TAG_FLOAT64;
     default:
         h = 0;
         break;

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -695,6 +695,16 @@ function test_map()
 {
     var a, i, n, tab, o, v;
     n = 1000;
+
+    a = new Map();
+    for (var i = 0; i < n; i++) {
+        a.set(i, i);
+    }
+    a.set(-2147483648, 1);
+    assert(a.get(-2147483648), 1);
+    assert(a.get(-2147483647 - 1), 1);
+    assert(a.get(-2147483647.5 - 0.5), 1);
+
     a = new Map();
     tab = [];
     for(i = 0; i < n; i++) {


### PR DESCRIPTION
- `map_hash_key` must generate the same key for JS_TAG_INT and JS_TAG_FLOAT64 values with the same numerical value
- add test cases in tests/test_builtin.js