### PR TITLE
Add methods to detect arrays

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -48195,6 +48195,10 @@ JSValue JS_NewArrayBuffer(JSContext *ctx, uint8_t *buf, size_t len,
                                         buf, free_func, opaque, FALSE);
 }
 
+JS_BOOL JS_IsArrayBuffer(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_ARRAY_BUFFER;
+}
+
 /* create a new ArrayBuffer of length 'len' and copy 'buf' to it */
 JSValue JS_NewArrayBufferCopy(JSContext *ctx, const uint8_t *buf, size_t len)
 {
@@ -50691,6 +50695,9 @@ JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len)
     return js_new_uint8array(ctx, buffer);
 }
 
+JS_BOOL JS_IsUint8Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_UINT8_ARRAY;
+}
 
 /* Atomics */
 #ifdef CONFIG_ATOMICS

--- a/quickjs.h
+++ b/quickjs.h
@@ -748,6 +748,7 @@ JS_EXTERN JSValue JS_NewArrayBuffer(JSContext *ctx, uint8_t *buf, size_t len,
 JS_EXTERN JSValue JS_NewArrayBufferCopy(JSContext *ctx, const uint8_t *buf, size_t len);
 JS_EXTERN void JS_DetachArrayBuffer(JSContext *ctx, JSValue obj);
 JS_EXTERN uint8_t *JS_GetArrayBuffer(JSContext *ctx, size_t *psize, JSValue obj);
+JS_EXTERN JS_BOOL JS_IsArrayBuffer(JSValue obj);
 JS_EXTERN uint8_t *JS_GetUint8Array(JSContext *ctx, size_t *psize, JSValue obj);
 JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
                                          size_t *pbyte_offset,
@@ -756,6 +757,7 @@ JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
 JS_EXTERN JSValue JS_NewUint8Array(JSContext *ctx, uint8_t *buf, size_t len,
                                    JSFreeArrayBufferDataFunc *free_func, void *opaque,
                                    JS_BOOL is_shared);
+JS_EXTERN JS_BOOL JS_IsUint8Array(JSValue obj);
 JS_EXTERN JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len);
 typedef struct {
     void *(*sab_alloc)(void *opaque, size_t size);


### PR DESCRIPTION
I have a use case where a user can hand me many different kinds of
types, array buffer, uint8array, or a string, and I need to be able to
distingush between them.

