### PR TITLE
Fix JS_INVALID_PROMISE_STATE macro

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -977,7 +977,7 @@ JS_EXTERN int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
 
 /* Promise */
 
-#define JS_INVALID_PROMISE_STATE -1
+#define JS_INVALID_PROMISE_STATE (-1)
 
 typedef enum JSPromiseStateEnum {
     JS_PROMISE_PENDING,


### PR DESCRIPTION
Followup to https://github.com/quickjs-ng/quickjs/pull/280#issuecomment-1962742333