### PR TITLE
Accept /[\-]/u as a valid regular expression

### DIFF
--- a/libregexp.c
+++ b/libregexp.c
@@ -783,6 +783,9 @@ static int get_class_atom(REParseState *s, CharRange *cr,
                     /* always valid to escape these characters */
                     goto normal_char;
                 } else if (s->is_unicode) {
+                    // special case: allowed inside [] but not outside
+                    if (ret == -2 && *p == '-' && inclass)
+                        goto normal_char;
                 invalid_escape:
                     return re_parse_error(s, "invalid escape sequence in regular expression");
                 } else {

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -699,6 +699,9 @@ function test_regexp()
         ex = _ex;
     }
     assert(ex?.message, "invalid class range");
+
+    eval("/[\\-]/");
+    eval("/[\\-]/u");
 }
 
 function test_symbol()


### PR DESCRIPTION
The non-Unicode version of the pattern was already accepted.

~~test262 does not seem to test this particular pattern and I'm not 100% sure if it's actually per spec but both V8 and Spidermonkey accept it.~~ - edit: see commit log

Fixes: https://github.com/quickjs-ng/quickjs/issues/286