### PR TITLE
Implement getTimezoneOffset for Win32

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -40827,8 +40827,9 @@ static const JSCFunctionListEntry js_math_obj[] = {
    between UTC time and local time 'd' in minutes */
 static int getTimezoneOffset(int64_t time) {
 #if defined(_WIN32)
-    /* XXX: TODO */
-    return 0;
+    TIME_ZONE_INFORMATION time_zone_info;
+    GetTimeZoneInformation(&time_zone_info);
+    return (int)time_zone_info.Bias / 60;
 #else
     time_t ti;
     struct tm tm;

--- a/quickjs.c
+++ b/quickjs.c
@@ -33,6 +33,9 @@
 #if !defined(_MSC_VER)
 #include <sys/time.h>
 #endif
+#if defined(_WIN32)
+#include <timezoneapi.h>
+#endif
 #include <time.h>
 #include <fenv.h>
 #include <math.h>

--- a/quickjs.c
+++ b/quickjs.c
@@ -32,9 +32,9 @@
 #include <assert.h>
 #if !defined(_MSC_VER)
 #include <sys/time.h>
-#endif
 #if defined(_WIN32)
 #include <timezoneapi.h>
+#endif
 #endif
 #include <time.h>
 #include <fenv.h>


### PR DESCRIPTION
Useful links
- [GetTimeZoneInformation](https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-gettimezoneinformation)
- [GetTimeZoneInformation#Remarks](https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-gettimezoneinformation#remarks)

Notes

> The bias is the difference, in minutes, between UTC time and local time.