### PR TITLE
Enable direct dispatch for WASI

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -46,7 +46,7 @@
 #include "libregexp.h"
 #include "libbf.h"
 
-#if defined(EMSCRIPTEN) || defined(_MSC_VER) || defined(__wasi__)
+#if defined(EMSCRIPTEN) || defined(_MSC_VER)
 #define DIRECT_DISPATCH  0
 #else
 #define DIRECT_DISPATCH  1


### PR DESCRIPTION
Direct dispatch is faster than a "normal" switch clause and it's disabled for WASI, although it works fine in wasmtime, so I'm not sure why it was disabled.


Background reading on computed gotos for interpreter loops: https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables