### PR TITLE
Pin Ubuntu CI images to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,7 @@ jobs:
         run: make test
 
   openbsd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: build + test
@@ -497,7 +497,7 @@ jobs:
             gmake stats
 
   freebsd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: build + test
@@ -511,7 +511,7 @@ jobs:
             gmake stats
 
   netbsd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: build + test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   codegen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: build
@@ -25,7 +25,7 @@ jobs:
       - name: Check if the git repository is clean
         run: $(exit $(git status --porcelain --untracked-files=no | head -255 | wc -l)) || (echo "Dirty git tree"; git diff; exit 1)
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         run: |
           ./v8.sh
   linux-32bits:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: alpine.sh {0}
@@ -72,7 +72,7 @@ jobs:
         run: |
           make test
   linux-s390x:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: alpine.sh {0}
@@ -92,7 +92,7 @@ jobs:
         run: |
           make test
   linux-gcc48:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ubuntu:14.04
     steps:
@@ -122,7 +122,7 @@ jobs:
         run: |
           time make test262
   linux-examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: build
@@ -144,7 +144,7 @@ jobs:
           ./build/qjs tests/test_bjson.js
           ./build/function_source
   linux-shared:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: build
@@ -155,7 +155,7 @@ jobs:
         run: |
           make stats
   linux-asan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -174,7 +174,7 @@ jobs:
         run: |
           time make test262
   linux-msan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -190,7 +190,7 @@ jobs:
         run: |
           make test
   linux-ubsan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -209,7 +209,7 @@ jobs:
         run: |
           time make test262
   linux-tcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -428,7 +428,7 @@ jobs:
           make stats
 
   emscripten:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: mymindstorm/setup-emsdk@v13
@@ -441,7 +441,7 @@ jobs:
       - name: result
         run: ls -lh build
   wasi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: jcbhmr/setup-wasmtime@v2
@@ -483,7 +483,7 @@ jobs:
         run: make test
 
   openbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: build + test
@@ -497,7 +497,7 @@ jobs:
             gmake stats
 
   freebsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: build + test
@@ -511,7 +511,7 @@ jobs:
             gmake stats
 
   netbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: build + test
@@ -526,7 +526,7 @@ jobs:
             gmake test
 
   android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: reactnativecommunity/react-native-android:v13.0
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linux-x86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: jirutka/setup-alpine@v1
@@ -36,7 +36,7 @@ jobs:
           path: build/*-linux-x86
 
   linux-x86_64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: jirutka/setup-alpine@v1
@@ -150,7 +150,7 @@ jobs:
           path: build/*-windows-x86_64.exe
 
   wasi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: setup wasi-sdk
@@ -170,7 +170,7 @@ jobs:
 
   upload-to-release:
     needs: [linux-x86, linux-x86_64, macos, windows-x86, windows-x86_64, wasi]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: get assets
         uses: actions/download-artifact@v3

--- a/v8.js
+++ b/v8.js
@@ -9,6 +9,7 @@ const exclude = [
     "arguments-indirect.js",        // implementation-defined
     "array-concat.js",              // slow
     "array-isarray.js",             // unstable output due to stack overflow
+    "array-join.js",                // unstable output due to stack overflow
     "ascii-regexp-subject.js",      // slow
     "asm-directive.js",             // v8 specific
     "disallow-codegen-from-strings.js", // --disallow-code-generation-from-strings

--- a/v8.txt
+++ b/v8.txt
@@ -23,19 +23,6 @@
 === array-join-element-tostring-prototype-side-effects.js
 === array-join-nesting.js
 === array-join-nonarray-length-getter-side-effects.js
-=== array-join.js
-RangeError: Maximum call stack size exceeded
-    at join (native)
-    at toString (native)
-    at join (native)
-    at toString (native)
-    at join (native)
-    at toString (native)
-    at join (native)
-    at toString (native)
-    at join (native)
-    at toString (native)
-
 === array-lastindexof.js
 === array-length-number-conversion.js
 === array-length.js


### PR DESCRIPTION
GitHub recently upgraded the ubuntu-latest images and I suspect that is the cause of the linux-asan and linux-msan failures. Pin to the old LTS for now.

Fixes: https://github.com/quickjs-ng/quickjs/issues/314