### PR TITLE
Remove JS_VALUE_GET_STRING from the public API

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -208,6 +208,8 @@ typedef struct JSShape JSShape;
 typedef struct JSString JSString;
 typedef struct JSString JSAtomStruct;
 
+#define JS_VALUE_GET_STRING(v) ((JSString *)JS_VALUE_GET_PTR(v))
+
 typedef enum {
     JS_GC_PHASE_NONE,
     JS_GC_PHASE_DECREF,

--- a/quickjs.h
+++ b/quickjs.h
@@ -205,7 +205,6 @@ static inline JS_BOOL JS_VALUE_IS_NAN(JSValue v)
 #define JS_VALUE_IS_BOTH_FLOAT(v1, v2) (JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(v1)) && JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(v2)))
 
 #define JS_VALUE_GET_OBJ(v) ((JSObject *)JS_VALUE_GET_PTR(v))
-#define JS_VALUE_GET_STRING(v) ((JSString *)JS_VALUE_GET_PTR(v))
 #define JS_VALUE_HAS_REF_COUNT(v) ((unsigned)JS_VALUE_GET_TAG(v) >= (unsigned)JS_TAG_FIRST)
 
 /* special values */


### PR DESCRIPTION
JSString is not part of the API.
