### PR TITLE
Small fixes in Date.parse

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -47763,7 +47763,9 @@ static BOOL js_date_parse_otherstring(const uint8_t *sp,
                     if (!string_get_digits(sp, &p, &fields[5], 1, 2))
                         return FALSE;
                     string_get_milliseconds(sp, &p, &fields[6]);
-                }
+                } else
+                if (sp[p] != '\0' && sp[p] != ' ')
+                    return FALSE;
                 has_time = TRUE;
             } else {
                 if (p - p_start > 2) {
@@ -47785,11 +47787,13 @@ static BOOL js_date_parse_otherstring(const uint8_t *sp,
             string_skip_until(sp, &p, "0123456789 -/(");
         } else
         if (has_time && string_match(sp, &p, "PM")) {
-            if (fields[3] < 12)
+            if (fields[3] != 12)
                 fields[3] += 12;
             continue;
         } else
         if (has_time && string_match(sp, &p, "AM")) {
+            if (fields[3] > 12)
+                return FALSE;
             if (fields[3] == 12)
                 fields[3] -= 12;
             continue;

--- a/quickjs.c
+++ b/quickjs.c
@@ -47787,11 +47787,15 @@ static BOOL js_date_parse_otherstring(const uint8_t *sp,
             string_skip_until(sp, &p, "0123456789 -/(");
         } else
         if (has_time && string_match(sp, &p, "PM")) {
+            /* hours greater than 12 will be incremented and
+               rejected by the range check in js_Date_parse */
+            /* 00:00 PM will be silently converted as 12:00 */
             if (fields[3] != 12)
                 fields[3] += 12;
             continue;
         } else
         if (has_time && string_match(sp, &p, "AM")) {
+            /* 00:00 AM will be silently accepted */
             if (fields[3] > 12)
                 return FALSE;
             if (fields[3] == 12)

--- a/v8.txt
+++ b/v8.txt
@@ -137,7 +137,6 @@ Failure (54[]): expected <true> found <false>
 Failure (55[]): expected <true> found <false>
 Failure (56[]): expected <true> found <false>
 === date-parse.js
-Failure (May 25 2008 1:30( )AM (PM) is not NaN.): expected <true> found <false>
 === declare-locally.js
 === deep-recursion.js
 === define-property-gc.js


### PR DESCRIPTION
- reject AM/PM suffix for hours > 12
- stricter time parser (fixes last v8 test)