### PR TITLE
Implement setInterval()

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -2104,7 +2104,6 @@ static JSValue js_os_clearTimeout(JSContext *ctx, JSValue this_val,
     unlink_timer(JS_GetRuntime(ctx), th);
     JS_FreeValue(ctx, th->func);
     th->func = JS_UNDEFINED;
-    th->repeats = FALSE;
     return JS_UNDEFINED;
 }
 
@@ -2133,7 +2132,6 @@ static int js_os_run_timers(JSRuntime *rt, JSContext *ctx, JSThreadState *ts)
     JSOSTimer *th;
     int min_delay;
     int64_t cur_time, delay;
-    JSOSRWHandler *rh;
     struct list_head *el;
 
     if (list_empty(&ts->os_timers))

--- a/tests/test_std.js
+++ b/tests/test_std.js
@@ -254,7 +254,16 @@ function test_os_exec()
     }
 }
 
-function test_timer()
+function test_interval()
+{
+    var t = os.setInterval(f, 1);
+    function f() {
+        if (++f.count === 3) os.clearInterval(t);
+    }
+    f.count = 0;
+}
+
+function test_timeout()
 {
     var th, i;
 
@@ -266,6 +275,18 @@ function test_timer()
         os.clearTimeout(th[i]);
 }
 
+function test_timeout_order()
+{
+    var s = "";
+    os.setTimeout(a, 1);
+    os.setTimeout(b, 2);
+    os.setTimeout(d, 5);
+    function a() { s += "a"; os.setTimeout(c, 0); }
+    function b() { s += "b"; }
+    function c() { s += "c"; }
+    function d() { assert(s === "abc"); } // not "acb"
+}
+
 test_printf();
 test_file1();
 test_file2();
@@ -273,4 +294,6 @@ test_getline();
 test_popen();
 test_os();
 !isWin && test_os_exec();
-test_timer();
+test_interval();
+test_timeout();
+test_timeout_order();


### PR DESCRIPTION
Coincidentally fixes a timer ordering bug for which a regression test has been added.

Fixes: https://github.com/quickjs-ng/quickjs/issues/279