### PR TITLE
Fix CI to make actual release builds on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,18 +377,18 @@ jobs:
           cmake --build build --config ${{matrix.buildType}} --target function_source
       - name: stats
         run: |
-          cmd /r build\${{matrix.buildType}}\qjs.exe -qd
+          build\${{matrix.buildType}}\qjs.exe -qd
       - name: test
         run: |
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_bigint.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_closure.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_language.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_builtin.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_loop.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_std.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_worker.js
-          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_queue_microtask.js
-          cmd /r build\${{matrix.buildType}}\function_source.exe
+          build\${{matrix.buildType}}\qjs.exe tests\test_bigint.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_closure.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_language.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_builtin.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_loop.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_std.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_worker.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_queue_microtask.js
+          build\${{matrix.buildType}}\function_source.exe
 
   windows-mingw:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,38 @@ jobs:
           build\${{matrix.buildType}}\qjs.exe tests\test_queue_microtask.js
           build\${{matrix.buildType}}\function_source.exe
 
+  windows-ninja:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        buildType: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: install ninja
+        run: |
+          choco install ninja
+          ninja.exe --version
+      - name: build
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -G "Ninja"
+          cmake --build build --target qjs_exe
+          cmake --build build --target function_source
+      - name: stats
+        run: |
+          build\qjs.exe -qd
+      - name: test
+        run: |
+          build\qjs.exe tests\test_bigint.js
+          build\qjs.exe tests\test_closure.js
+          build\qjs.exe tests\test_language.js
+          build\qjs.exe tests\test_builtin.js
+          build\qjs.exe tests\test_loop.js
+          build\qjs.exe tests\test_std.js
+          build\qjs.exe tests\test_worker.js
+          build\qjs.exe tests\test_queue_microtask.js
+          build\function_source.exe
+
   windows-mingw:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,23 +344,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: build
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -G "Visual Studio 17 2022"
-          cmake --build build --target qjs_exe
-          cmake --build build --target function_source
+          cmake -B build -G "Visual Studio 17 2022"
+          cmake --build build --config ${{matrix.buildType}} --target qjs_exe
+          cmake --build build --config ${{matrix.buildType}} --target function_source
       - name: stats
         run: |
-          build\Debug\qjs.exe -qd
+          build\${{matrix.buildType}}\qjs.exe -qd
       - name: test
         run: |
-          build\Debug\qjs.exe tests\test_bigint.js
-          build\Debug\qjs.exe tests\test_closure.js
-          build\Debug\qjs.exe tests\test_language.js
-          build\Debug\qjs.exe tests\test_builtin.js
-          build\Debug\qjs.exe tests\test_loop.js
-          build\Debug\qjs.exe tests\test_std.js
-          build\Debug\qjs.exe tests\test_worker.js
-          build\Debug\qjs.exe tests\test_queue_microtask.js
-          build\Debug\function_source.exe
+          build\${{matrix.buildType}}\qjs.exe tests\test_bigint.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_closure.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_language.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_builtin.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_loop.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_std.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_worker.js
+          build\${{matrix.buildType}}\qjs.exe tests\test_queue_microtask.js
+          build\${{matrix.buildType}}\function_source.exe
 
   windows-clang:
     runs-on: windows-latest
@@ -372,23 +372,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: build
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -G "Visual Studio 17 2022" -T ClangCL
-          cmake --build build --target qjs_exe
-          cmake --build build --target function_source
+          cmake -B build -G "Visual Studio 17 2022" -T ClangCL
+          cmake --build build --config ${{matrix.buildType}} --target qjs_exe
+          cmake --build build --config ${{matrix.buildType}} --target function_source
       - name: stats
         run: |
-          cmd /r build\Debug\qjs.exe -qd
+          cmd /r build\${{matrix.buildType}}\qjs.exe -qd
       - name: test
         run: |
-          cmd /r build\Debug\qjs.exe tests\test_bigint.js
-          cmd /r build\Debug\qjs.exe tests\test_closure.js
-          cmd /r build\Debug\qjs.exe tests\test_language.js
-          cmd /r build\Debug\qjs.exe tests\test_builtin.js
-          cmd /r build\Debug\qjs.exe tests\test_loop.js
-          cmd /r build\Debug\qjs.exe tests\test_std.js
-          cmd /r build\Debug\qjs.exe tests\test_worker.js
-          cmd /r build\Debug\qjs.exe tests\test_queue_microtask.js
-          cmd /r build\Debug\function_source.exe
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_bigint.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_closure.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_language.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_builtin.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_loop.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_std.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_worker.js
+          cmd /r build\${{matrix.buildType}}\qjs.exe tests\test_queue_microtask.js
+          cmd /r build\${{matrix.buildType}}\function_source.exe
 
   windows-mingw:
     runs-on: windows-latest


### PR DESCRIPTION
CMAKE_BUILD_TYPE only applies on single-configuration generators: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

For multi-configuration generators like Visual Studio (or Xcode) --config needs to be used in order to build that specific configuration.