### PR TITLE
Fix `JS_ReadString` for wide strings on big endian targets

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -33650,7 +33650,13 @@ static JSString *JS_ReadString(BCReaderState *s)
     }
     memcpy(p->u.str8, s->ptr, size);
     s->ptr += size;
-    if (!is_wide_char) {
+    if (is_wide_char) {
+        if (is_be()) {
+            uint32_t i;
+            for (i = 0; i < len; i++)
+                p->u.str16[i] = bswap16(p->u.str16[i]);
+        }
+    } else {
         p->u.str8[size] = '\0'; /* add the trailing zero for 8 bit strings */
     }
 #ifdef DUMP_READ_OBJECT


### PR DESCRIPTION
wide characters are stored in little endian order, so they must be swapped when read in a big endian target
