### PR TITLE
Add faster test262 test target

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,4 +20,4 @@ jobs:
           make BUILD_TYPE=RelWithDebInfo
       - name: test
         run: |
-          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./build/run-test262 -m -c test262.conf -a
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./build/run-test262 -m -c test262.conf -c test262-fast.conf -a

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ test: $(QJS)
 test262: $(QJS)
 	$(RUN262) -m -c test262.conf -a
 
+test262-fast: $(QJS)
+	$(RUN262) -m -c test262.conf -c test262-fast.conf -a
+
 test262-update: $(QJS)
 	$(RUN262) -u -c test262.conf -a
 

--- a/run-test262.c
+++ b/run-test262.c
@@ -1922,12 +1922,12 @@ void show_progress(int force) {
             fputc(c, stderr);
             if (force || ++dots % 60 == 0) {
                 fprintf(stderr, " %d/%d/%d\n",
-                        test_failed, test_index, test_skipped);
+                        test_failed, test_count, test_skipped);
             }
         } else {
             /* output progress indicator: erase end of line and return to col 0 */
             fprintf(stderr, "%d/%d/%d\033[K\r",
-                    test_failed, test_index, test_skipped);
+                    test_failed, test_count, test_skipped);
         }
         fflush(stderr);
     }

--- a/run-test262.c
+++ b/run-test262.c
@@ -1922,12 +1922,12 @@ void show_progress(int force) {
             fputc(c, stderr);
             if (force || ++dots % 60 == 0) {
                 fprintf(stderr, " %d/%d/%d\n",
-                        test_failed, test_count, test_skipped);
+                        test_failed, test_index, test_skipped);
             }
         } else {
             /* output progress indicator: erase end of line and return to col 0 */
             fprintf(stderr, "%d/%d/%d\033[K\r",
-                    test_failed, test_count, test_skipped);
+                    test_failed, test_index, test_skipped);
         }
         fflush(stderr);
     }

--- a/test262-fast.conf
+++ b/test262-fast.conf
@@ -1,0 +1,132 @@
+[exclude]
+# list excluded tests and directories here for faster operation
+
+# lengthy constructed regexp (>500 ms)
+test262/test/annexB/built-ins/RegExp/RegExp-leading-escape-BMP.js
+test262/test/annexB/built-ins/RegExp/RegExp-trailing-escape-BMP.js
+
+# slow notifications (> 600 ms)
+test262/test/built-ins/Atomics/notify/notify-in-order-one-time.js
+test262/test/built-ins/Atomics/notify/notify-in-order.js
+test262/test/built-ins/Atomics/wait/bigint/waiterlist-order-of-operations-is-fifo.js
+test262/test/built-ins/Atomics/wait/waiterlist-order-of-operations-is-fifo.js
+
+# lengthy constructed regexp (>200 ms)
+test262/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+test262/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+test262/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+test262/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+test262/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+test262/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+test262/test/built-ins/RegExp/character-class-escape-non-whitespace.js
+
+# 417 lengty tests with huge constructed regexp (>200 ms)
+test262/test/built-ins/RegExp/property-escapes/generated/
+
+# lengthy constructed URLS (>200 ms)
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.2_T1.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.2_T2.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.10_T1.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.11_T1.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.11_T2.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.12_T1.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.12_T2.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A1.12_T3.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A2.5_T1.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.2_T1.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.2_T2.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.10_T1.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T1.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.11_T2.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T1.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T2.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A1.12_T3.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
+
+# lengthy comment tests
+test262/test/language/comments/S7.4_A5.js
+test262/test/language/comments/S7.4_A6.js
+
+# lengthy unicode level tests
+test262/test/language/identifiers/start-unicode-5.2.0-class-escaped.js
+test262/test/language/identifiers/start-unicode-5.2.0-class.js
+test262/test/language/identifiers/start-unicode-8.0.0-class-escaped.js
+test262/test/language/identifiers/start-unicode-8.0.0-class.js
+test262/test/language/identifiers/start-unicode-9.0.0-class-escaped.js
+test262/test/language/identifiers/start-unicode-9.0.0-class.js
+test262/test/language/identifiers/start-unicode-10.0.0-class-escaped.js
+test262/test/language/identifiers/start-unicode-10.0.0-class.js
+test262/test/language/identifiers/start-unicode-13.0.0-class-escaped.js
+test262/test/language/identifiers/start-unicode-13.0.0-class.js
+test262/test/language/identifiers/start-unicode-15.0.0-class-escaped.js
+test262/test/language/identifiers/start-unicode-15.0.0-class.js
+
+# Atomics tests with 2 second delays
+test262/test/built-ins/Atomics/notify/bigint/notify-all-on-loc.js
+test262/test/built-ins/Atomics/notify/negative-count.js
+test262/test/built-ins/Atomics/notify/notify-all-on-loc.js
+test262/test/built-ins/Atomics/notify/notify-all.js
+test262/test/built-ins/Atomics/notify/notify-nan.js
+test262/test/built-ins/Atomics/notify/notify-one.js
+test262/test/built-ins/Atomics/notify/notify-two.js
+test262/test/built-ins/Atomics/notify/notify-zero.js
+
+# Atomics tests with 400 millisecond delays
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-no-operation.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-add.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-and.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-compareExchange.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-exchange.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-or.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-sub.js
+test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-xor.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-no-operation.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-add.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-and.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-compareExchange.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-exchange.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-or.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-store.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-sub.js
+test262/test/built-ins/Atomics/wait/no-spurious-wakeup-on-xor.js
+
+# Atomics tests with 200 millisecond delays
+test262/test/built-ins/Atomics/notify/count-defaults-to-infinity-missing.js
+test262/test/built-ins/Atomics/notify/count-defaults-to-infinity-undefined.js
+test262/test/built-ins/Atomics/notify/notify-renotify-noop.js
+test262/test/built-ins/Atomics/notify/undefined-index-defaults-to-zero.js
+test262/test/built-ins/Atomics/wait/bigint/false-for-timeout-agent.js
+test262/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
+test262/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
+test262/test/built-ins/Atomics/wait/bigint/value-not-equal.js
+test262/test/built-ins/Atomics/wait/bigint/was-woken-before-timeout.js
+test262/test/built-ins/Atomics/wait/false-for-timeout-agent.js
+test262/test/built-ins/Atomics/wait/nan-for-timeout.js
+test262/test/built-ins/Atomics/wait/negative-timeout-agent.js
+test262/test/built-ins/Atomics/wait/null-for-timeout-agent.js
+test262/test/built-ins/Atomics/wait/object-for-timeout-agent.js
+test262/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws-agent.js
+test262/test/built-ins/Atomics/wait/symbol-for-index-throws-agent.js
+test262/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
+test262/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
+test262/test/built-ins/Atomics/wait/true-for-timeout-agent.js
+test262/test/built-ins/Atomics/wait/undefined-for-timeout.js
+test262/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js
+test262/test/built-ins/Atomics/wait/value-not-equal.js
+test262/test/built-ins/Atomics/wait/wait-index-value-not-equal.js
+test262/test/built-ins/Atomics/wait/was-woken-before-timeout.js
+
+# lengthy regexp literal construction (>500 ms)
+test262/test/language/literals/regexp/S7.8.5_A1.1_T2.js
+test262/test/language/literals/regexp/S7.8.5_A1.4_T2.js
+test262/test/language/literals/regexp/S7.8.5_A2.1_T2.js
+test262/test/language/literals/regexp/S7.8.5_A2.4_T2.js
+
+# lengthy built-ins tests (100-200 ms)
+test262/test/built-ins/Function/prototype/toString/built-in-function-object.js
+test262/test/built-ins/decodeURI/S15.1.3.1_A2.4_T1.js
+test262/test/built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js
+test262/test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js
+test262/test/built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1.js
+test262/test/language/expressions/dynamic-import/await-import-evaluation.js


### PR DESCRIPTION
- add test262-fast.conf with lengthy tests disabled
- add test262-fast corresponding target
- make valgrind use test262-fast
- output `test_index` instead of `test_count` in `show_progess()`