### PR TITLE
Fix member accesses for non-decimal numeric literals

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -10264,9 +10264,8 @@ static JSValue js_atof2(JSContext *ctx, const char *str, const char **pp,
                 to_digit((uint8_t)p[1]) < radix)) {
         p++;
     }
-    if (!(flags & ATOD_INT_ONLY)) {
-        if (*p == '.' && radix == 10 &&
-            (p > p_start || to_digit((uint8_t)p[1]) < radix)) {
+    if (!(flags & ATOD_INT_ONLY) && radix == 10) {
+        if (*p == '.' && (p > p_start || to_digit((uint8_t)p[1]) < radix)) {
             is_float = TRUE;
             p++;
             if (*p == sep)
@@ -10275,9 +10274,7 @@ static JSValue js_atof2(JSContext *ctx, const char *str, const char **pp,
                    (*p == sep && to_digit((uint8_t)p[1]) < radix))
                 p++;
         }
-        if (p > p_start &&
-            (((*p == 'e' || *p == 'E') && radix == 10) ||
-             ((*p == 'p' || *p == 'P') && (radix == 2 || radix == 8 || radix == 16)))) {
+        if (p > p_start && (*p == 'e' || *p == 'E')) {
             const char *p1 = p + 1;
             is_float = TRUE;
             if (*p1 == '+') {
@@ -10318,11 +10315,7 @@ static JSValue js_atof2(JSContext *ctx, const char *str, const char **pp,
         if (*p == 'n') {
             p++;
             atod_type = ATOD_TYPE_BIG_INT;
-        } else if (is_float && radix != 10) {
-            goto fail;
         }
-    } else if ((atod_type == ATOD_TYPE_FLOAT64) && is_float && radix != 10) {
-        goto fail;
     }
 
     switch(atod_type) {

--- a/quickjs.c
+++ b/quickjs.c
@@ -10265,7 +10265,8 @@ static JSValue js_atof2(JSContext *ctx, const char *str, const char **pp,
         p++;
     }
     if (!(flags & ATOD_INT_ONLY)) {
-        if (*p == '.' && (p > p_start || to_digit((uint8_t)p[1]) < radix)) {
+        if (*p == '.' && radix == 10 &&
+            (p > p_start || to_digit((uint8_t)p[1]) < radix)) {
             is_float = TRUE;
             p++;
             if (*p == sep)

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -593,6 +593,16 @@ function test_reserved_names()
     test_name('static', SyntaxError);
 }
 
+function test_number_literals()
+{
+    assert(0.1.a, undefined);
+    assert(0x1.a, undefined);
+    assert(0b1.a, undefined);
+    assert(01.a, undefined);
+    assert(0o1.a, undefined);
+    test_expr('0.a', SyntaxError);
+}
+
 test_op1();
 test_cvt();
 test_eq();
@@ -613,3 +623,4 @@ test_function_length();
 test_argument_scope();
 test_function_expr_name();
 test_reserved_names();
+test_number_literals();


### PR DESCRIPTION
```
$ node -e 'console.log(0x0.a)'
undefined
$ qjs -e 'console.log(0x0.a)'
SyntaxError: invalid number literal
    at <cmdline>:1:1
```

(I have run into a polyfill that depends on this.)

To fix it I just added a base-10 check to the part of js_atof2 which
consumes the fraction part.

(I *think* there is no place where parsing non-decimal floats makes
sense; it could be useful for error messages if it really were an error,
but it isn't one.)

I've also added some tests to illustrate what should work.
