### PR TITLE
Remove linux-gcc48 buildbot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,36 +91,6 @@ jobs:
       - name: test
         run: |
           make test
-  linux-gcc48:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:14.04
-    steps:
-      - name: install dependencies
-        run: |
-          apt update && apt -y install make gcc-4.8 wget time software-properties-common
-          # git in default ppa repository is too old to run submodule checkout
-          add-apt-repository -y ppa:git-core/ppa
-          apt update
-          apt install -y git
-          wget -nv https://github.com/Kitware/CMake/releases/download/v3.28.0-rc5/cmake-3.28.0-rc5-linux-x86_64.sh
-          sh cmake-3.28.0-rc5-linux-x86_64.sh --skip-license --prefix=/usr
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: build
-        run: |
-          CC=gcc-4.8 make
-      - name: stats
-        run: |
-          make stats
-      - name: test
-        run: |
-          make test
-      - name: test 262
-        run: |
-          time make test262
   linux-examples:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It regularly fails to run because it can't download the necessary dependencies and I personally don't really feel the need to support such an ancient gcc version, not if it adds a lot of friction to the development process.

Fixes: https://github.com/quickjs-ng/quickjs/issues/389