### PR TITLE
Fix invalid exception for class method with name "get"

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -20810,8 +20810,8 @@ static int __exception js_parse_property_name(JSParseState *s,
             if (next_token(s))
                 goto fail1;
             if (s->token.val == ':' || s->token.val == ',' ||
-                s->token.val == '}' || s->token.val == '(') {
-                is_non_reserved_ident = TRUE;
+                s->token.val == '}' || s->token.val == '(' ||
+                s->token.val == '=' ) {is_non_reserved_ident = TRUE;
                 goto ident_found;
             }
             prop_type = PROP_TYPE_GET + (name == JS_ATOM_set);

--- a/quickjs.c
+++ b/quickjs.c
@@ -20811,7 +20811,8 @@ static int __exception js_parse_property_name(JSParseState *s,
                 goto fail1;
             if (s->token.val == ':' || s->token.val == ',' ||
                 s->token.val == '}' || s->token.val == '(' ||
-                s->token.val == '=' ) {is_non_reserved_ident = TRUE;
+                s->token.val == '=' ) {
+                is_non_reserved_ident = TRUE;
                 goto ident_found;
             }
             prop_type = PROP_TYPE_GET + (name == JS_ATOM_set);

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -338,8 +338,8 @@ function test_class()
     assert(S.z === 42);
     class P {
         get = () => "123"
-      }
-      assert(new P().get() === "123");
+    }
+    assert(new P().get() === "123");
 };
 
 function test_template()
@@ -368,7 +368,6 @@ function test_object_literal()
 {
     var x = 0, get = 1, set = 2; async = 3;
     a = { get: 2, set: 3, async: 4, get a(){ return this.get} };
-    assert(JSON.stringify(a), '{"get":2,"set":3,"async":4}');
     assert(JSON.stringify(a), '{"get":2,"set":3,"async":4,"a":2}');
     assert(a.a === 2);
 

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -336,6 +336,10 @@ function test_class()
     assert(S.x === 42);
     assert(S.y === 42);
     assert(S.z === 42);
+    class P {
+        get = () => "123"
+      }
+      assert(new P().get() === "123");
 };
 
 function test_template()
@@ -363,8 +367,10 @@ function test_template_skip()
 function test_object_literal()
 {
     var x = 0, get = 1, set = 2; async = 3;
-    a = { get: 2, set: 3, async: 4 };
+    a = { get: 2, set: 3, async: 4, get a(){ return this.get} };
     assert(JSON.stringify(a), '{"get":2,"set":3,"async":4}');
+    assert(JSON.stringify(a), '{"get":2,"set":3,"async":4,"a":2}');
+    assert(a.a === 2);
 
     a = { x, get, set, async };
     assert(JSON.stringify(a), '{"x":0,"get":1,"set":2,"async":3}');


### PR DESCRIPTION
From here: https://github.com/bellard/quickjs/pull/258

Fixing issue mentioned in https://github.com/saghul/txiki.js/issues/511#issuecomment-2096231405