### PR TITLE
Fixed CMakeLists.txt for Emscripten builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ endif()
 #
 
 # run-test262 uses pthreads.
-if(NOT WIN32)
+if(NOT WIN32 AND NOT EMSCRIPTEN)
     add_executable(run-test262
         quickjs-libc.c
         run-test262.c


### PR DESCRIPTION
The __run-test262__ target fails for Emscripten due to the `ftw()` usage.