### PR TITLE
Improve parsing error messages

### DIFF
--- a/run-test262.c
+++ b/run-test262.c
@@ -1299,11 +1299,15 @@ static int eval_buf(JSContext *ctx, const char *buf, size_t buf_len,
                 const char *msg;
 
                 msg = JS_ToCString(ctx, exception_val);
-                error_class = strdup_len(msg, strcspn(msg, ":"));
-                if (!str_equal(error_class, error_type))
+                if (msg == NULL) {
                     ret = -1;
-                free(error_class);
-                JS_FreeCString(ctx, msg);
+                } else {
+                    error_class = strdup_len(msg, strcspn(msg, ":"));
+                    if (!str_equal(error_class, error_type))
+                        ret = -1;
+                    free(error_class);
+                    JS_FreeCString(ctx, msg);
+                }
             }
         } else {
             ret = -1;

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -20,7 +20,14 @@ function assert_throws(expected_error, func, message)
     var err = false;
     var msg = message ? " (" + message + ")" : "";
     try {
-        func();
+        switch (typeof func) {
+        case 'string':
+            eval(func);
+            break;
+        case 'function':
+            func();
+            break;
+        }
     } catch(e) {
         err = true;
         if (!(e instanceof expected_error)) {
@@ -541,7 +548,7 @@ function test_function_expr_name()
 
 function test_expr(expr, err) {
     if (err)
-        assert_throws(err, () => eval(expr), `for ${expr}`);
+        assert_throws(err, expr, `for ${expr}`);
     else
         assert(1, eval(expr), `for ${expr}`);
 }
@@ -603,6 +610,26 @@ function test_number_literals()
     test_expr('0.a', SyntaxError);
 }
 
+function test_syntax()
+{
+    assert_throws(SyntaxError, "do");
+    assert_throws(SyntaxError, "do;");
+    assert_throws(SyntaxError, "do{}");
+    assert_throws(SyntaxError, "if");
+    assert_throws(SyntaxError, "if\n");
+    assert_throws(SyntaxError, "if 1");
+    assert_throws(SyntaxError, "if \0");
+    assert_throws(SyntaxError, "if ;");
+    assert_throws(SyntaxError, "if 'abc'");
+    assert_throws(SyntaxError, "if `abc`");
+    assert_throws(SyntaxError, "if /abc/");
+    assert_throws(SyntaxError, "if abc");
+    assert_throws(SyntaxError, "if abc\u0064");
+    assert_throws(SyntaxError, "if abc\\u0064");
+    assert_throws(SyntaxError, "if \u0123");
+    assert_throws(SyntaxError, "if \\u0123");
+}
+
 test_op1();
 test_cvt();
 test_eq();
@@ -624,3 +651,4 @@ test_argument_scope();
 test_function_expr_name();
 test_reserved_names();
 test_number_literals();
+test_syntax();


### PR DESCRIPTION
- output more informative error messages in `js_parse_expect`.

The previous code was bogus:
```
    return js_parse_error(s, "expecting '%c'", tok);
```
this was causing a bug on `eval("do;")` where `tok` is `TOK_WHILE` (-70, 0xBA) creating an invalid UTF-8 encoding (lone trailing byte). This would ultimately have caused a failure in `JS_ThrowError2` if `JS_NewString` failed when converting an error to a string if the conversion detects invalid UTF-8 encoding and throws an error (it currently does not, but should).

- test for `JS_NewString` failure in `JS_ThrowError2`
- test for `JS_FreeCString` failure in run-test262.c
- add more test cases