### PR TITLE
Explicit casting in JS_NewInt64 & JS_NewUint32

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -501,9 +501,9 @@ static js_force_inline JSValue JS_NewInt64(JSContext *ctx, int64_t val)
 {
     JSValue v;
     if (val >= INT32_MIN && val <= INT32_MAX) {
-        v = JS_NewInt32(ctx, val);
+        v = JS_NewInt32(ctx, (int32_t)val);
     } else {
-        v = JS_NewFloat64(ctx, val);
+        v = JS_NewFloat64(ctx, (double)val);
     }
     return v;
 }
@@ -512,9 +512,9 @@ static js_force_inline JSValue JS_NewUint32(JSContext *ctx, uint32_t val)
 {
     JSValue v;
     if (val <= 0x7fffffff) {
-        v = JS_NewInt32(ctx, val);
+        v = JS_NewInt32(ctx, (int32_t)val);
     } else {
-        v = JS_NewFloat64(ctx, val);
+        v = JS_NewFloat64(ctx, (double)val);
     }
     return v;
 }


### PR DESCRIPTION
This avoids the two GCC -Wconversion warnings for this public header, which is useful when using extensive error reporting from the compiler and treating warnings as errors.
Bellard's version uses such a casting in the first function, so I assume that there is no obvious performance penalty in being verbose.