### PR TITLE
Use 0 for disabling automatic GC

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1341,7 +1341,7 @@ static void js_trigger_gc(JSRuntime *rt, size_t size)
     force_gc = TRUE;
 #else
     force_gc = ((rt->malloc_state.malloc_size + size) >
-                rt->malloc_gc_threshold);
+                rt->malloc_gc_threshold - 1);
 #endif
     if (force_gc) {
 #ifdef DUMP_GC
@@ -1755,7 +1755,7 @@ void JS_SetDumpFlags(JSRuntime *rt, uint64_t flags)
     rt->dump_flags = flags;
 }
 
-/* use -1 to disable automatic GC */
+/* use 0 to disable automatic GC */
 void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold)
 {
     rt->malloc_gc_threshold = gc_threshold;

--- a/quickjs.c
+++ b/quickjs.c
@@ -1755,6 +1755,10 @@ void JS_SetDumpFlags(JSRuntime *rt, uint64_t flags)
     rt->dump_flags = flags;
 }
 
+size_t JS_GetGCThreshold(JSRuntime *rt) {
+    return rt->malloc_gc_threshold;
+}
+
 /* use 0 to disable automatic GC */
 void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold)
 {

--- a/quickjs.h
+++ b/quickjs.h
@@ -301,6 +301,7 @@ JS_EXTERN void JS_SetRuntimeInfo(JSRuntime *rt, const char *info);
 /* use 0 to disable memory limit */
 JS_EXTERN void JS_SetMemoryLimit(JSRuntime *rt, size_t limit);
 JS_EXTERN void JS_SetDumpFlags(JSRuntime *rt, uint64_t flags);
+JS_EXTERN size_t JS_GetGCThreshold(JSRuntime *rt);
 /* use 0 to disable automatic GC */
 JS_EXTERN void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold);
 /* use 0 to disable maximum stack size check */

--- a/quickjs.h
+++ b/quickjs.h
@@ -301,6 +301,7 @@ JS_EXTERN void JS_SetRuntimeInfo(JSRuntime *rt, const char *info);
 /* use 0 to disable memory limit */
 JS_EXTERN void JS_SetMemoryLimit(JSRuntime *rt, size_t limit);
 JS_EXTERN void JS_SetDumpFlags(JSRuntime *rt, uint64_t flags);
+/* use 0 to disable automatic GC */
 JS_EXTERN void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold);
 /* use 0 to disable maximum stack size check */
 JS_EXTERN void JS_SetMaxStackSize(JSRuntime *rt, size_t stack_size);


### PR DESCRIPTION
Similarly to other limits such as memory or stack limit, 0 means unlimited.