### PR TITLE
fix: nested member access in JS_NAN

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -182,7 +182,7 @@ typedef struct JSValue {
 
 #define JS_TAG_IS_FLOAT64(tag) ((unsigned)(tag) == JS_TAG_FLOAT64)
 
-#define JS_NAN (JSValue){ .u.float64 = JS_FLOAT64_NAN, JS_TAG_FLOAT64 }
+#define JS_NAN (JSValue){ (JSValueUnion){ .float64 = JS_FLOAT64_NAN }, JS_TAG_FLOAT64 }
 
 static inline JSValue __JS_NewFloat64(double d)
 {


### PR DESCRIPTION
Similar to implementation of JS_MKVAL and JS_MKPTR, using a C++ compatible initialization.