### PR TITLE
fix: missing math.h for NAN

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <math.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
According to cppreference, NAN macro in defined in math.h.
https://github.com/quickjs-ng/quickjs/blob/8ac7c0d51fe536be82563a8cde086b44821a9116/quickjs.h#L93
https://en.cppreference.com/w/cpp/numeric/math/NAN
https://en.cppreference.com/w/c/numeric/math/NAN