### PR TITLE
chore: add build time flag for declaration used in test262

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ if(NOT WIN32 AND NOT EMSCRIPTEN)
         quickjs-libc.c
         run-test262.c
     )
-    target_compile_definitions(run-test262 PRIVATE ${qjs_defines})
+    target_compile_definitions(run-test262 PRIVATE ${qjs_defines} JS_RUN_TEST262)
     target_link_libraries(run-test262 ${qjs_libs})
 endif()
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -350,9 +350,13 @@ JS_EXTERN JS_BOOL JS_IsSameValue(JSContext *ctx, JSValue op1, JSValue op2);
 /* Similar to same-value equality, but +0 and -0 are considered equal. */
 JS_EXTERN JS_BOOL JS_IsSameValueZero(JSContext *ctx, JSValue op1, JSValue op2);
 
-/* Only used for running 262 tests. TODO(saghul) add build time flag. */
+#if defined(JS_RUN_TEST262)
+
+/* Only used for running 262 tests. */
 JS_EXTERN JSValue js_string_codePointRange(JSContext *ctx, JSValue this_val,
                                  int argc, JSValue *argv);
+
+#endif
 
 JS_EXTERN void *js_malloc_rt(JSRuntime *rt, size_t size);
 JS_EXTERN void js_free_rt(JSRuntime *rt, void *ptr);


### PR DESCRIPTION
With this PR, function `js_string_codePointRange` doesn't appear in header without macro `JS_RUN_TEST262`, while implementation do stay.

It's possible to disable function implementation too, but this may require a new cmake option like `BUILD_RUN_TEST262` to control both quickjs library and run test262 executable to add definition properly.

As unused functions in static library shall be filtered during linking, I think just keeping the implementation is enough.