### PR TITLE
fix the windows vs x86 build

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -202,7 +202,7 @@ static inline int clz32(unsigned int a)
 /* WARNING: undefined if a = 0 */
 static inline int clz64(uint64_t a)
 {
-#if defined(_MSC_VER)&& defined(_WIN64) && !defined(__clang__)
+#if defined(_MSC_VER) && defined(_WIN64) && !defined(__clang__)
     unsigned long index;
     _BitScanReverse64(&index, a);
     return 63 - index;

--- a/cutils.h
+++ b/cutils.h
@@ -202,10 +202,18 @@ static inline int clz32(unsigned int a)
 /* WARNING: undefined if a = 0 */
 static inline int clz64(uint64_t a)
 {
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER)&& defined(_WIN64) && !defined(__clang__)
     unsigned long index;
     _BitScanReverse64(&index, a);
     return 63 - index;
+#elif(_MSC_VER)
+unsigned long i = 0, hi = 0;
+    if (_BitScanReverse(&hi, a>> 32))
+    {
+        return (int)hi + 32;
+    }
+    _BitScanReverse(&i, (uint32_t)a);
+    return (int)i;
 #else
     return __builtin_clzll(a);
 #endif

--- a/cutils.h
+++ b/cutils.h
@@ -202,18 +202,17 @@ static inline int clz32(unsigned int a)
 /* WARNING: undefined if a = 0 */
 static inline int clz64(uint64_t a)
 {
-#if defined(_MSC_VER) && defined(_WIN64) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__)
+#if INTPTR_MAX == INT64_MAX
     unsigned long index;
     _BitScanReverse64(&index, a);
     return 63 - index;
-#elif(_MSC_VER)
-unsigned long i = 0, hi = 0;
-    if (_BitScanReverse(&hi, a>> 32))
-    {
-        return (int)hi + 32;
-    }
-    _BitScanReverse(&i, (uint32_t)a);
-    return (int)i;
+#else
+    if (a >> 32)
+        return clz32((unsigned)(a >> 32));
+    else
+        return clz32((unsigned)a) + 32;
+#endif	
 #else
     return __builtin_clzll(a);
 #endif

--- a/tests/test_conv.c
+++ b/tests/test_conv.c
@@ -91,12 +91,21 @@ static inline int clz32(unsigned int a)
 }
 
 /* WARNING: undefined if a = 0 */
+/* WARNING: undefined if a = 0 */
 static inline int clz64(uint64_t a)
 {
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER)&& defined(_WIN64) && !defined(__clang__)
     unsigned long index;
     _BitScanReverse64(&index, a);
     return 63 - index;
+#elif(_MSC_VER)
+unsigned long i = 0, hi = 0;
+    if (_BitScanReverse(&hi, a>> 32))
+    {
+        return (int)hi + 32;
+    }
+    _BitScanReverse(&i, (uint32_t)a);
+    return (int)i;
 #else
     return __builtin_clzll(a);
 #endif

--- a/tests/test_conv.c
+++ b/tests/test_conv.c
@@ -91,26 +91,23 @@ static inline int clz32(unsigned int a)
 }
 
 /* WARNING: undefined if a = 0 */
-/* WARNING: undefined if a = 0 */
 static inline int clz64(uint64_t a)
 {
-#if defined(_MSC_VER)&& defined(_WIN64) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__)
+#if INTPTR_MAX == INT64_MAX
     unsigned long index;
     _BitScanReverse64(&index, a);
     return 63 - index;
-#elif(_MSC_VER)
-unsigned long i = 0, hi = 0;
-    if (_BitScanReverse(&hi, a>> 32))
-    {
-        return (int)hi + 32;
-    }
-    _BitScanReverse(&i, (uint32_t)a);
-    return (int)i;
+#else
+    if (a >> 32)
+        return clz32((unsigned)(a >> 32));
+    else
+        return clz32((unsigned)a) + 32;
+#endif	
 #else
     return __builtin_clzll(a);
 #endif
 }
-
 // prototypes for final functions
 extern char const digits36[36];
 size_t u32toa(char buf[minimum_length(11)], uint32_t n);


### PR DESCRIPTION
when i want to build the x86 quickjs and found the  _BitScanReverse used in the ctuils.h 
and i found the method like this :
https://github.com/tqfx/liba/commit/005abe2e121551cac42e6e9620f4446c7fd4e430
maybe it 's not correctly .
and in my computer ,it build success.
![image](https://github.com/quickjs-ng/quickjs/assets/898009/a8eefbcd-9c09-4a8d-8e8e-c10ddaa4bd84)
seems also fix #430 

