### PR TITLE
Avoid warnings when compiling under `Wpedantic`

### DIFF
--- a/libbf.c
+++ b/libbf.c
@@ -5365,19 +5365,20 @@ int bf_acos(bf_t *r, const bf_t *a, limb_t prec, bf_flags_t flags)
 #if LIMB_BITS == 64
 
 /* Note: we assume __int128 is available */
+/* uint128_t defined in libbf.h          */
 #define muldq(r1, r0, a, b)                     \
     do {                                        \
-        unsigned __int128 __t;                          \
-        __t = (unsigned __int128)(a) * (unsigned __int128)(b);  \
+        uint128_t __t;                          \
+        __t = (uint128_t)(a) * (uint128_t)(b);  \
         r0 = __t;                               \
         r1 = __t >> 64;                         \
     } while (0)
 
 #define divdq(q, r, a1, a0, b)                  \
     do {                                        \
-        unsigned __int128 __t;                  \
+        uint128_t __t;                  \
         limb_t __b = (b);                       \
-        __t = ((unsigned __int128)(a1) << 64) | (a0);   \
+        __t = ((uint128_t)(a1) << 64) | (a0);   \
         q = __t / __b;                                  \
         r = __t % __b;                                  \
     } while (0)

--- a/libbf.h
+++ b/libbf.h
@@ -36,8 +36,8 @@
 #define LIMB_BITS (1 << LIMB_LOG2_BITS)
 
 #if LIMB_BITS == 64
-typedef __int128 int128_t;
-typedef unsigned __int128 uint128_t;
+__extension__ typedef __int128 int128_t;
+__extension__ typedef unsigned __int128 uint128_t;
 typedef int64_t slimb_t;
 typedef uint64_t limb_t;
 typedef uint128_t dlimb_t;

--- a/libbf.h
+++ b/libbf.h
@@ -36,8 +36,10 @@
 #define LIMB_BITS (1 << LIMB_LOG2_BITS)
 
 #if LIMB_BITS == 64
+#ifndef INT128_MAX
 __extension__ typedef __int128 int128_t;
 __extension__ typedef unsigned __int128 uint128_t;
+#endif
 typedef int64_t slimb_t;
 typedef uint64_t limb_t;
 typedef uint128_t dlimb_t;

--- a/libregexp.c
+++ b/libregexp.c
@@ -2064,7 +2064,7 @@ typedef struct REExecState {
     size_t count; /* only used for RE_EXEC_STATE_GREEDY_QUANT */
     const uint8_t *cptr;
     const uint8_t *pc;
-    void *buf[0];
+    void *buf[];
 } REExecState;
 
 typedef struct {

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -517,7 +517,7 @@ static JSModuleDef *js_module_loader_so(JSContext *ctx,
         goto fail;
     }
 
-    init = (JSInitModuleFunc *)dlsym(hd, "js_init_module");
+    *(void **) (&init) = dlsym(hd, "js_init_module");
     if (!init) {
         JS_ThrowReferenceError(ctx, "could not load module filename '%s': js_init_module not found",
                                module_name);

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -3231,7 +3231,7 @@ typedef struct {
 
 typedef struct {
     int ref_count;
-    uint64_t buf[0];
+    uint64_t buf[];
 } JSSABHeader;
 
 static JSClassID js_worker_class_id;

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -184,8 +184,7 @@ static JSValue js_printf_internal(JSContext *ctx,
     int64_t int64_arg;
     double double_arg;
     const char *string_arg;
-    /* Use indirect call to dbuf_printf to prevent gcc warning */
-    int (*dbuf_printf_fun)(DynBuf *s, const char *fmt, ...) = (void*)dbuf_printf;
+    int (*dbuf_printf_fun)(DynBuf *s, const char *fmt, ...) = dbuf_printf;
 
     js_std_dbuf_init(ctx, &dbuf);
 
@@ -518,7 +517,7 @@ static JSModuleDef *js_module_loader_so(JSContext *ctx,
         goto fail;
     }
 
-    init = dlsym(hd, "js_init_module");
+    init = (JSInitModuleFunc *)dlsym(hd, "js_init_module");
     if (!init) {
         JS_ThrowReferenceError(ctx, "could not load module filename '%s': js_init_module not found",
                                module_name);

--- a/quickjs.c
+++ b/quickjs.c
@@ -209,7 +209,7 @@ typedef enum {
     JS_GC_PHASE_REMOVE_CYCLES,
 } JSGCPhaseEnum;
 
-typedef enum OPCodeEnum OPCodeEnum;
+__extension__ typedef enum OPCodeEnum OPCodeEnum;
 
 struct JSRuntime {
     JSMallocFunctions mf;

--- a/quickjs.c
+++ b/quickjs.c
@@ -14584,13 +14584,13 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValue func_obj,
 #define DEFAULT         default
 #define BREAK           break
 #else
-    static const void * const dispatch_table[256] = {
+    __extension__ static const void * const dispatch_table[256] = {
 #define DEF(id, size, n_pop, n_push, f) && case_OP_ ## id,
 #define def(id, size, n_pop, n_push, f)
 #include "quickjs-opcode.h"
         [ OP_COUNT ... 255 ] = &&case_default
     };
-#define SWITCH(pc)      DUMP_BYTECODE_OR_DONT(pc) goto *dispatch_table[opcode = *pc++];
+#define SWITCH(pc)      DUMP_BYTECODE_OR_DONT(pc) __extension__ ({ goto *dispatch_table[opcode = *pc++]; });
 #define CASE(op)        case_ ## op
 #define DEFAULT         case_default
 #define BREAK           SWITCH(pc)

--- a/quickjs.c
+++ b/quickjs.c
@@ -209,8 +209,6 @@ typedef enum {
     JS_GC_PHASE_REMOVE_CYCLES,
 } JSGCPhaseEnum;
 
-__extension__ typedef enum OPCodeEnum OPCodeEnum;
-
 struct JSRuntime {
     JSMallocFunctions mf;
     JSMallocState malloc_state;
@@ -990,7 +988,7 @@ typedef enum OPCodeFormat {
 #undef FMT
 } OPCodeFormat;
 
-enum OPCodeEnum {
+typedef enum OPCodeEnum {
 #define FMT(f)
 #define DEF(id, size, n_pop, n_push, f) OP_ ## id,
 #define def(id, size, n_pop, n_push, f)
@@ -1010,7 +1008,7 @@ enum OPCodeEnum {
 #undef DEF
 #undef FMT
     OP_TEMP_END,
-};
+} OPCodeEnum;
 
 static int JS_InitAtoms(JSRuntime *rt);
 static JSAtom __JS_NewAtomInit(JSRuntime *rt, const char *str, int len,

--- a/quickjs.c
+++ b/quickjs.c
@@ -474,8 +474,8 @@ struct JSString {
     struct list_head link; /* string list */
 #endif
     union {
-        uint8_t str8[0]; /* 8 bit strings will get an extra null terminator */
-        uint16_t str16[0];
+        __extension__ uint8_t str8[0]; /* 8 bit strings will get an extra null terminator */
+        __extension__ uint16_t str16[0];
     } u;
 };
 
@@ -664,7 +664,7 @@ typedef struct JSBoundFunction {
     JSValue func_obj;
     JSValue this_val;
     int argc;
-    JSValue argv[0];
+    JSValue argv[];
 } JSBoundFunction;
 
 typedef enum JSIteratorKindEnum {
@@ -822,7 +822,7 @@ typedef struct JSJobEntry {
     JSContext *ctx;
     JSJobFunc *job_func;
     int argc;
-    JSValue argv[0];
+    JSValue argv[];
 } JSJobEntry;
 
 typedef struct JSProperty {
@@ -871,7 +871,7 @@ struct JSShape {
     int deleted_prop_count;
     JSShape *shape_hash_next; /* in JSRuntime.shape_hash[h] list */
     JSObject *proto;
-    JSShapeProperty prop[0]; /* prop_size elements */
+    JSShapeProperty prop[]; /* prop_size elements */
 };
 
 struct JSObject {
@@ -5015,7 +5015,7 @@ typedef struct JSCFunctionDataRecord {
     uint8_t length;
     uint8_t data_len;
     uint16_t magic;
-    JSValue data[0];
+    JSValue data[];
 } JSCFunctionDataRecord;
 
 static void js_c_function_data_finalizer(JSRuntime *rt, JSValue val)
@@ -27371,7 +27371,7 @@ static int js_inner_module_evaluation(JSContext *ctx, JSModuleDef *m,
         JSReqModuleEntry *rme = &m->req_module_entries[i];
         m1 = rme->module;
         index = js_inner_module_evaluation(ctx, m1, index, pstack_top, pvalue);
-        if (index < 0) 
+        if (index < 0)
             return -1;
         assert(m1->status == JS_MODULE_STATUS_EVALUATING ||
                m1->status == JS_MODULE_STATUS_EVALUATING_ASYNC ||


### PR DESCRIPTION
This PR suppresses warnings under `Wpedantic` compilation by explicitly marking GNU extensions with the `__extension__` keyword and replacing the use of GNU zero-length arrays with ISO C flexible arrays.

Let me know if I've missed anything or should approach this differently, thanks!

For context I maintain an [R interface for quickjs](https://github.com/andrjohns/QuickJSR), and the R package manager (CRAN) requires all C/C++ code to compile under `-Wpedantic` without warnings. I currently have to patch the code for each release, so it would be great if that wasn't necessary.

But as you can see here the patchset is fairly minor, so I completely understand if you'd rather keep the GNU-isms as-is!