### PR TITLE
Support Worker API on mingw if winpthread is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,9 @@ if(WIN32)
 endif()
 list(APPEND qjs_libs qjs ${CMAKE_DL_LIBS})
 find_package(Threads)
+if(MINGW AND CMAKE_USE_PTHREADS_INIT)
+    list(APPEND qjs_defines USE_WINPTHREAD)
+endif()
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
     list(APPEND qjs_libs ${CMAKE_THREAD_LIBS_INIT})
 endif()
@@ -235,7 +238,7 @@ endif()
 #
 
 # run-test262 uses pthreads.
-if(NOT WIN32 AND NOT EMSCRIPTEN)
+if((NOT WIN32 AND NOT EMSCRIPTEN) OR (MINGW AND CMAKE_USE_PTHREADS_INIT))
     add_executable(run-test262
         quickjs-libc.c
         run-test262.c

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -58,6 +58,9 @@
 #define rmdir _rmdir
 #define getcwd _getcwd
 #define chdir _chdir
+#ifdef USE_WINPTHREAD
+#define pipe(fds) _pipe(fds,1024, _O_BINARY)
+#endif
 #else
 #include <sys/ioctl.h>
 #if !defined(__wasi__)
@@ -80,7 +83,7 @@ extern char **environ;
 
 #endif /* _WIN32 */
 
-#if !defined(_WIN32) && !defined(__wasi__)
+#if (!defined(_WIN32) || defined(USE_WINPTHREAD)) && !defined(__wasi__)
 /* enable the os.Worker API. IT relies on POSIX threads */
 #define USE_WORKER
 #endif


### PR DESCRIPTION
This PR enables the Worker API on Windows if the winpthreads library is available in mingw (usually installed by default as a dependency of gcc/clang), which is already checked as part of cmake's `find_package(Threads)` call.

The only part that I'm unsure about is that mingw does not have a native `pipe()` function - so I've wrapped the Windows [`_pipe()`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/pipe?view=msvc-170) for compatibility

