### PR TITLE
Avoid macro redefinitions and function name collisions between sources

### DIFF
--- a/libbf.c
+++ b/libbf.c
@@ -2833,7 +2833,7 @@ int bf_mul_pow_radix(bf_t *r, const bf_t *T, limb_t radix,
     return ret;
 }
 
-static inline int to_digit(int c)
+static inline int bf_to_digit(int c)
 {
     if (c >= '0' && c <= '9')
         return c - '0';
@@ -2940,7 +2940,7 @@ static int bf_atof_internal(bf_t *r, slimb_t *pexponent,
             goto no_prefix;
         }
         /* there must be a digit after the prefix */
-        if (to_digit((uint8_t)*p) >= radix) {
+        if (bf_to_digit((uint8_t)*p) >= radix) {
             bf_set_nan(r);
             ret = 0;
             goto done;
@@ -2988,14 +2988,14 @@ static int bf_atof_internal(bf_t *r, slimb_t *pexponent,
     int_len = digit_count = 0;
     for(;;) {
         limb_t c;
-        if (*p == '.' && (p > p_start || to_digit(p[1]) < radix)) {
+        if (*p == '.' && (p > p_start || bf_to_digit(p[1]) < radix)) {
             if (has_decpt)
                 break;
             has_decpt = TRUE;
             int_len = digit_count;
             p++;
         }
-        c = to_digit(*p);
+        c = bf_to_digit(*p);
         if (c >= radix)
             break;
         digit_count++;
@@ -3076,7 +3076,7 @@ static int bf_atof_internal(bf_t *r, slimb_t *pexponent,
         }
         for(;;) {
             int c;
-            c = to_digit(*p);
+            c = bf_to_digit(*p);
             if (c >= 10)
                 break;
             if (unlikely(expn > ((BF_RAW_EXP_MAX - 2 - 9) / 10))) {
@@ -8410,3 +8410,7 @@ int bf_get_fft_size(int *pdpl, int *pnb_mods, limb_t len)
 }
 
 #endif /* !USE_FFT_MUL */
+
+#undef malloc
+#undef free
+#undef realloc

--- a/libregexp.c
+++ b/libregexp.c
@@ -109,7 +109,7 @@ static const REOpCode reopcode_info[REOP_COUNT] = {
 
 #define RE_HEADER_LEN 8
 
-static inline int is_digit(int c) {
+static inline int lre_is_digit(int c) {
     return c >= '0' && c <= '9';
 }
 
@@ -577,7 +577,7 @@ int lre_parse_escape(const uint8_t **pp, int allow_utf16)
         c -= '0';
         if (allow_utf16 == 2) {
             /* only accept \0 not followed by digit */
-            if (c != 0 || is_digit(*p))
+            if (c != 0 || lre_is_digit(*p))
                 return -1;
         } else {
             /* parse a legacy octal sequence */
@@ -1285,7 +1285,7 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
     case '{':
         if (s->is_unicode) {
             return re_parse_error(s, "syntax error");
-        } else if (!is_digit(p[1])) {
+        } else if (!lre_is_digit(p[1])) {
             /* Annex B: we accept '{' not followed by digits as a
                normal atom */
             goto parse_class_atom;
@@ -1295,7 +1295,7 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
             parse_digits(&p1, TRUE);
             if (*p1 == ',') {
                 p1++;
-                if (is_digit(*p1)) {
+                if (lre_is_digit(*p1)) {
                     parse_digits(&p1, TRUE);
                 }
             }
@@ -1443,7 +1443,7 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
             p += 2;
             c = 0;
             if (s->is_unicode) {
-                if (is_digit(*p)) {
+                if (lre_is_digit(*p)) {
                     return re_parse_error(s, "invalid decimal escape in regular expression");
                 }
             } else {
@@ -1565,7 +1565,7 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
                 const uint8_t *p1 = p;
                 /* As an extension (see ES6 annex B), we accept '{' not
                    followed by digits as a normal atom */
-                if (!is_digit(p[1])) {
+                if (!lre_is_digit(p[1])) {
                     if (s->is_unicode)
                         goto invalid_quant_count;
                     break;
@@ -1575,7 +1575,7 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
                 quant_max = quant_min;
                 if (*p == ',') {
                     p++;
-                    if (is_digit(*p)) {
+                    if (lre_is_digit(*p)) {
                         quant_max = parse_digits(&p, TRUE);
                         if (quant_max < quant_min) {
                         invalid_quant_count:
@@ -1812,7 +1812,7 @@ static int re_parse_disjunction(REParseState *s, BOOL is_backward_dir)
 }
 
 /* the control flow is recursive so the analysis can be linear */
-static int compute_stack_size(const uint8_t *bc_buf, int bc_buf_len)
+static int lre_compute_stack_size(const uint8_t *bc_buf, int bc_buf_len)
 {
     int stack_size, stack_size_max, pos, opcode, len;
     uint32_t val;
@@ -1925,7 +1925,7 @@ uint8_t *lre_compile(int *plen, char *error_msg, int error_msg_size,
         goto error;
     }
 
-    stack_size = compute_stack_size(s->byte_code.buf, s->byte_code.size);
+    stack_size = lre_compute_stack_size(s->byte_code.buf, s->byte_code.size);
     if (stack_size < 0) {
         re_parse_error(s, "too many imbricated quantifiers");
         goto error;

--- a/quickjs.c
+++ b/quickjs.c
@@ -47750,7 +47750,7 @@ static int64_t math_mod(int64_t a, int64_t b) {
     return m + (m < 0) * b;
 }
 
-static int64_t floor_div(int64_t a, int64_t b) {
+static int64_t floor_div_int64(int64_t a, int64_t b) {
     /* integer division rounding toward -Infinity */
     int64_t m = a % b;
     return (a - (m + (m < 0) * b)) / b;
@@ -47784,8 +47784,8 @@ static JSValue JS_SetThisTimeValue(JSContext *ctx, JSValue this_val, double v)
 }
 
 static int64_t days_from_year(int64_t y) {
-    return 365 * (y - 1970) + floor_div(y - 1969, 4) -
-        floor_div(y - 1901, 100) + floor_div(y - 1601, 400);
+    return 365 * (y - 1970) + floor_div_int64(y - 1969, 4) -
+        floor_div_int64(y - 1901, 100) + floor_div_int64(y - 1601, 400);
 }
 
 static int64_t days_in_year(int64_t y) {
@@ -47795,7 +47795,7 @@ static int64_t days_in_year(int64_t y) {
 /* return the year, update days */
 static int64_t year_from_days(int64_t *days) {
     int64_t y, d1, nd, d = *days;
-    y = floor_div(d * 10000, 3652425) + 1970;
+    y = floor_div_int64(d * 10000, 3652425) + 1970;
     /* the initial approximation is very good, so only a few
        iterations are necessary */
     for(;;) {
@@ -53183,3 +53183,7 @@ static void _JS_AddIntrinsicCallSite(JSContext *ctx)
                                js_callsite_proto_funcs,
                                countof(js_callsite_proto_funcs));
 }
+
+#undef malloc
+#undef free
+#undef realloc

--- a/run-test262.c
+++ b/run-test262.c
@@ -371,7 +371,7 @@ static void enumerate_tests(const char *path)
           namelist_cmp_indirect);
 }
 
-static JSValue js_print(JSContext *ctx, JSValue this_val,
+static JSValue js_print_262(JSContext *ctx, JSValue this_val,
                         int argc, JSValue *argv)
 {
     int i;
@@ -404,7 +404,7 @@ static JSValue js_detachArrayBuffer(JSContext *ctx, JSValue this_val,
     return JS_UNDEFINED;
 }
 
-static JSValue js_evalScript(JSContext *ctx, JSValue this_val,
+static JSValue js_evalScript_262(JSContext *ctx, JSValue this_val,
                              int argc, JSValue *argv)
 {
     const char *str;
@@ -764,7 +764,7 @@ static JSValue add_helpers1(JSContext *ctx)
     global_obj = JS_GetGlobalObject(ctx);
 
     JS_SetPropertyStr(ctx, global_obj, "print",
-                      JS_NewCFunction(ctx, js_print, "print", 1));
+                      JS_NewCFunction(ctx, js_print_262, "print", 1));
 
     /* $262 special object used by the tests */
     obj262 = JS_NewObject(ctx);
@@ -772,7 +772,7 @@ static JSValue add_helpers1(JSContext *ctx)
                       JS_NewCFunction(ctx, js_detachArrayBuffer,
                                       "detachArrayBuffer", 1));
     JS_SetPropertyStr(ctx, obj262, "evalScript",
-                      JS_NewCFunction(ctx, js_evalScript,
+                      JS_NewCFunction(ctx, js_evalScript_262,
                                       "evalScript", 1));
     JS_SetPropertyStr(ctx, obj262, "codePointRange",
                       JS_NewCFunction(ctx, js_string_codePointRange,
@@ -1258,7 +1258,7 @@ static int eval_buf(JSContext *ctx, const char *buf, size_t buf_len,
             if (!is_error)
                 fprintf(outfile, "%sThrow: ", (eval_flags & JS_EVAL_FLAG_STRICT) ?
                         "strict mode: " : "");
-            js_print(ctx, JS_NULL, 1, &exception_val);
+            js_print_262(ctx, JS_NULL, 1, &exception_val);
         }
         if (is_error) {
             JSValue name, stack;
@@ -1849,7 +1849,7 @@ int run_test262_harness_test(const char *filename, BOOL is_module)
     JSValue res_val;
     BOOL can_block;
 
-    outfile = stdout; /* for js_print */
+    outfile = stdout; /* for js_print_262 */
 
     rt = JS_NewRuntime();
     if (rt == NULL) {


### PR DESCRIPTION
When experimenting with a jumbo build for the quickjs sources, I found a few cases of functions/macros with the same name in multiple sources.

This PR simply renames the offending functions and removes unused macros, but it could also be resolved by adding them to the public API for a given header