### PR TITLE
Add JS_SetLength API function

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1232,6 +1232,8 @@ static __exception int js_get_length32(JSContext *ctx, uint32_t *pres,
                                        JSValue obj);
 static __exception int js_get_length64(JSContext *ctx, int64_t *pres,
                                        JSValue obj);
+static __exception int js_set_length64(JSContext *ctx, JSValue obj,
+                                       int64_t len);
 static void free_arg_list(JSContext *ctx, JSValue *tab, uint32_t len);
 static JSValue *build_arg_list(JSContext *ctx, uint32_t *plen,
                                JSValue array_arg);
@@ -6998,6 +7000,10 @@ static JSValue JS_GetPrototypeFree(JSContext *ctx, JSValue obj)
 
 int JS_GetLength(JSContext *ctx, JSValue obj, int64_t *pres) {
     return js_get_length64(ctx, pres, obj);
+}
+
+int JS_SetLength(JSContext *ctx, JSValue obj, int64_t len) {
+    return js_set_length64(ctx, obj, len);
 }
 
 /* return TRUE, FALSE or (-1) in case of exception */
@@ -36855,6 +36861,15 @@ static __exception int js_get_length64(JSContext *ctx, int64_t *pres,
         return -1;
     }
     return JS_ToLengthFree(ctx, pres, len_val);
+}
+
+static __exception int js_set_length64(JSContext *ctx, JSValue obj, int64_t len)
+{
+    JSValue len_val;
+    len_val = JS_NewInt64(ctx, len);
+    if (JS_IsException(len_val))
+        return -1;
+    return JS_SetProperty(ctx, obj, JS_ATOM_length, len_val);
 }
 
 static void free_arg_list(JSContext *ctx, JSValue *tab, uint32_t len)

--- a/quickjs.h
+++ b/quickjs.h
@@ -702,6 +702,7 @@ JS_EXTERN int JS_DeleteProperty(JSContext *ctx, JSValue obj, JSAtom prop, int fl
 JS_EXTERN int JS_SetPrototype(JSContext *ctx, JSValue obj, JSValue proto_val);
 JS_EXTERN JSValue JS_GetPrototype(JSContext *ctx, JSValue val);
 JS_EXTERN int JS_GetLength(JSContext *ctx, JSValue obj, int64_t *pres);
+JS_EXTERN int JS_SetLength(JSContext *ctx, JSValue obj, int64_t len);
 
 #define JS_GPN_STRING_MASK  (1 << 0)
 #define JS_GPN_SYMBOL_MASK  (1 << 1)


### PR DESCRIPTION
Partially addresses #443 by adding a new API function: `JS_SetLength` with corresponding internal function `js_set_length64` to complement the existing `JS_GetLength` function