### PR TITLE
Add 'extern' statements to public headers for C++ compatibility

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -29,13 +29,14 @@
 #include <string.h>
 #include <inttypes.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if defined(_WIN32)
-#include <windows.h>
-#endif
 #if defined(_MSC_VER)
 #include <winsock2.h>
 #include <malloc.h>

--- a/cutils.h
+++ b/cutils.h
@@ -29,6 +29,10 @@
 #include <string.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #endif
@@ -212,7 +216,7 @@ static inline int clz64(uint64_t a)
         return clz32((unsigned)(a >> 32));
     else
         return clz32((unsigned)a) + 32;
-#endif	
+#endif
 #else
     return __builtin_clzll(a);
 #endif
@@ -526,5 +530,9 @@ void js_cond_wait(js_cond_t *cond, js_mutex_t *mutex);
 int js_cond_timedwait(js_cond_t *cond, js_mutex_t *mutex, uint64_t timeout);
 
 #endif /* !defined(EMSCRIPTEN) && !defined(__wasi__) */
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
 
 #endif  /* CUTILS_H */

--- a/libbf.h
+++ b/libbf.h
@@ -27,6 +27,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if INTPTR_MAX >= INT64_MAX && !defined(_WIN32) && !defined(__TINYC__)
 #define LIMB_LOG2_BITS 6
 #else
@@ -531,5 +535,9 @@ static inline int bfdec_resize(bfdec_t *r, limb_t len)
     return bf_resize((bf_t *)r, len);
 }
 int bfdec_normalize_and_round(bfdec_t *r, limb_t prec1, bf_flags_t flags);
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
 
 #endif /* LIBBF_H */

--- a/libregexp.h
+++ b/libregexp.h
@@ -28,6 +28,10 @@
 
 #include "libunicode.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LRE_BOOL  int       /* for documentation purposes */
 
 #define LRE_FLAG_GLOBAL     (1 << 0)
@@ -83,5 +87,9 @@ static inline int lre_js_is_ident_next(int c)
 }
 
 #undef LRE_BOOL
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
 
 #endif /* LIBREGEXP_H */

--- a/libunicode.h
+++ b/libunicode.h
@@ -27,6 +27,10 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LRE_BOOL  int       /* for documentation purposes */
 
 #define LRE_CC_RES_LEN_MAX 3
@@ -114,5 +118,9 @@ int unicode_general_category(CharRange *cr, const char *gc_name);
 int unicode_prop(CharRange *cr, const char *prop_name);
 
 #undef LRE_BOOL
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
 
 #endif /* LIBUNICODE_H */

--- a/list.h
+++ b/list.h
@@ -28,6 +28,10 @@
 #include <stddef.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct list_head {
     struct list_head *prev;
     struct list_head *next;
@@ -95,5 +99,9 @@ static inline int list_empty(struct list_head *el)
 #define list_for_each_prev_safe(el, el1, head)           \
     for(el = (head)->prev, el1 = el->prev; el != (head); \
         el = el1, el1 = el->prev)
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
 
 #endif /* LIST_H */


### PR DESCRIPTION
Currently only the `quickjs.h` and `quicks-libc.h` have `extern "C"` statements for compiling under C++, this PR adds them to the other public headers