### PR TITLE
Use brace-initialisation for `JS_MKVAL` under c++

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -178,7 +178,11 @@ typedef struct JSValue {
 #define JS_VALUE_GET_FLOAT64(v) ((v).u.float64)
 #define JS_VALUE_GET_PTR(v) ((v).u.ptr)
 
+#ifdef __cplusplus
+#define JS_MKVAL(tag, val) JSValue{ { val }, tag }
+#else
 #define JS_MKVAL(tag, val) (JSValue){ (JSValueUnion){ .int32 = val }, tag }
+#endif
 #define JS_MKPTR(tag, p) (JSValue){ (JSValueUnion){ .ptr = p }, tag }
 
 #define JS_TAG_IS_FLOAT64(tag) ((unsigned)(tag) == JS_TAG_FLOAT64)


### PR DESCRIPTION
Including `quickjs.h`  in C++ code gives warnings for compound literals and designated initialisers, due to the use of the `JS_MKVAL` macro in defining the various constants (e.g., `JS_UNDEFINED`).

As the `JSValueUnion` is being initialised with an `int32_t` (the first member), `JS_MKVAL` can be equivalently defined using brace-initialisation when compiled under C++