### PR TITLE
cutils - Compatibility for compiling under c++

### DIFF
--- a/cutils.c
+++ b/cutils.c
@@ -121,7 +121,7 @@ int dbuf_realloc(DynBuf *s, size_t new_size)
         size = s->allocated_size * 3 / 2;
         if (size > new_size)
             new_size = size;
-        new_buf = s->realloc_func(s->opaque, s->buf, new_size);
+        new_buf = (uint8_t *)s->realloc_func(s->opaque, s->buf, new_size);
         if (!new_buf) {
             s->error = TRUE;
             return -1;
@@ -587,8 +587,7 @@ overflow:
    - return the string length
  */
 
-/* 2 <= base <= 36 */
-char const digits36[36] = "0123456789abcdefghijklmnopqrstuvwxyz";
+char const digits36[37] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 #define USE_SPECIAL_RADIX_10  1  // special case base 10 radix conversions
 #define USE_SINGLE_CASE_FAST  1  // special case single digit numbers
@@ -1039,7 +1038,7 @@ void rqsort(void *base, size_t nmemb, size_t size, cmp_f cmp, void *opaque)
             /* select median of 3 from 1/4, 1/2, 3/4 positions */
             /* should use median of 5 or 9? */
             m4 = (nmemb >> 2) * size;
-            m = med3(ptr + m4, ptr + 2 * m4, ptr + 3 * m4, cmp, opaque);
+            m = (uint8_t *)med3(ptr + m4, ptr + 2 * m4, ptr + 3 * m4, cmp, opaque);
             swap(ptr, m, size);  /* move the pivot to the start or the array */
             i = lt = 1;
             pi = plt = ptr + size;

--- a/cutils.h
+++ b/cutils.h
@@ -212,7 +212,7 @@ static inline int clz64(uint64_t a)
         return clz32((unsigned)(a >> 32));
     else
         return clz32((unsigned)a) + 32;
-#endif	
+#endif
 #else
     return __builtin_clzll(a);
 #endif
@@ -465,7 +465,7 @@ static inline uint8_t to_upper_ascii(uint8_t c) {
     return c >= 'a' && c <= 'z' ? c - 'a' + 'A' : c;
 }
 
-extern char const digits36[36];
+extern char const digits36[37];
 size_t u32toa(char buf[minimum_length(11)], uint32_t n);
 size_t i32toa(char buf[minimum_length(12)], int32_t n);
 size_t u64toa(char buf[minimum_length(21)], uint64_t n);


### PR DESCRIPTION
Minor changes needed for compiling `cutils.c` under C++:

- Explicitly cast when assigning from `void*` to other types
- `digits36` array length forgets null-terminator