### PR TITLE
Add `qjsc -n` parameter to override script name stored in bytecode

### DIFF
--- a/qjsc.c
+++ b/qjsc.c
@@ -261,6 +261,7 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
 
 static void compile_file(JSContext *ctx, FILE *fo,
                          const char *filename,
+                         const char *script_name,
                          const char *c_name1,
                          int module)
 {
@@ -284,7 +285,7 @@ static void compile_file(JSContext *ctx, FILE *fo,
         eval_flags |= JS_EVAL_TYPE_MODULE;
     else
         eval_flags |= JS_EVAL_TYPE_GLOBAL;
-    obj = JS_Eval(ctx, (const char *)buf, buf_len, filename, eval_flags);
+    obj = JS_Eval(ctx, (const char *)buf, buf_len, script_name ? script_name : filename, eval_flags);
     if (JS_IsException(obj)) {
         js_std_dump_error(ctx);
         exit(1);
@@ -327,6 +328,7 @@ void help(void)
            "options are:\n"
            "-e          output main() and bytecode in a C file\n"
            "-o output   set the output filename\n"
+           "-n script_name    set the script name (as used in stack traces)\n"
            "-N cname    set the C name of the generated data\n"
            "-m          compile as Javascript module (default=autodetect)\n"
            "-D module_name         compile a dynamically loaded module or worker\n"
@@ -346,7 +348,7 @@ typedef enum {
 int main(int argc, char **argv)
 {
     int c, i, verbose;
-    const char *out_filename, *cname;
+    const char *out_filename, *cname, *script_name;
     char cfilename[1024];
     FILE *fo;
     JSRuntime *rt;
@@ -357,6 +359,7 @@ int main(int argc, char **argv)
     namelist_t dynamic_module_list;
 
     out_filename = NULL;
+    script_name = NULL;
     output_type = OUTPUT_C;
     cname = NULL;
     module = -1;
@@ -369,8 +372,8 @@ int main(int argc, char **argv)
     namelist_add(&cmodule_list, "std", "std", 0);
     namelist_add(&cmodule_list, "os", "os", 0);
 
-    for(;;) {
-        c = getopt(argc, argv, "ho:N:mxesvM:p:S:D:");
+    for (;;) {
+        c = getopt(argc, argv, "ho:N:mn:mxesvM:p:S:D:");
         if (c == -1)
             break;
         switch(c) {
@@ -381,6 +384,9 @@ int main(int argc, char **argv)
             break;
         case 'e':
             output_type = OUTPUT_C_MAIN;
+            break;
+        case 'n':
+            script_name = optarg;
             break;
         case 'N':
             cname = optarg;
@@ -461,7 +467,7 @@ int main(int argc, char **argv)
 
     for(i = optind; i < argc; i++) {
         const char *filename = argv[i];
-        compile_file(ctx, fo, filename, cname, module);
+        compile_file(ctx, fo, filename, script_name, cname, module);
         cname = NULL;
     }
 

--- a/qjsc.c
+++ b/qjsc.c
@@ -372,7 +372,7 @@ int main(int argc, char **argv)
     namelist_add(&cmodule_list, "std", "std", 0);
     namelist_add(&cmodule_list, "os", "os", 0);
 
-    for (;;) {
+    for(;;) {
         c = getopt(argc, argv, "ho:N:mn:mxesvM:p:S:D:");
         if (c == -1)
             break;


### PR DESCRIPTION
I needed the ability to specify a different script name than the name of the input file (to add a URL prefix).

_Nit:_ this kinda only makes sense for single JS file inputs, which is fine for my use case. But open to suggestions if a different approach would be preferred.