### PR TITLE
Add `qjsc -r` flag to output raw bytecode

### DIFF
--- a/qjsc.c
+++ b/qjsc.c
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
     namelist_add(&cmodule_list, "os", "os", 0);
 
     for(;;) {
-        c = getopt(argc, argv, "ho:N:mxesvM:p:S:D:");
+        c = getopt(argc, argv, "ho:N:mrxesvM:p:S:D:");
         if (c == -1)
             break;
         switch(c) {

--- a/qjsc.c
+++ b/qjsc.c
@@ -172,12 +172,9 @@ static void output_object_code(JSContext *ctx,
 
     namelist_add(&cname_list, c_name, NULL, load_only);
 
-    if (raw)
-    {
+    if (raw) {
         fwrite(out_buf, 1, out_buf_len, fo);
-    }
-    else
-    {
+    } else {
         fprintf(fo, "const uint32_t %s_size = %u;\n\n",
                 c_name, (unsigned int)out_buf_len);
         fprintf(fo, "const uint8_t %s[%u] = {\n",
@@ -461,42 +458,37 @@ int main(int argc, char **argv)
     *output_type_ptr = output_type;
     JS_SetModuleLoaderFunc(rt, NULL, jsc_module_loader, output_type_ptr);
 
-    if (output_type != OUTPUT_RAW)
-    {
+    if (output_type != OUTPUT_RAW) {
         fprintf(fo, "/* File generated automatically by the QuickJS-ng compiler. */\n"
-                    "\n");
+                "\n"
+                );
     }
 
-    if (output_type == OUTPUT_C_MAIN)
-    {
+    if (output_type == OUTPUT_C_MAIN) {
         fprintf(fo, "#include \"quickjs-libc.h\"\n"
-                    "\n");
-    }
-    else if (output_type == OUTPUT_C)
-    {
+                "\n"
+                );
+    } else if (output_type == OUTPUT_C) {
         fprintf(fo, "#include <inttypes.h>\n"
-                    "\n");
+                "\n"
+                );
     }
 
-    for (i = optind; i < argc; i++)
-    {
+    for(i = optind; i < argc; i++) {
         const char *filename = argv[i];
         compile_file(ctx, fo, filename, cname, module, output_type == OUTPUT_RAW);
         cname = NULL;
     }
 
-    for (i = 0; i < dynamic_module_list.count; i++)
-    {
-        if (!jsc_module_loader(ctx, dynamic_module_list.array[i].name, NULL))
-        {
+    for (i = 0; i < dynamic_module_list.count; i++) {
+        if (!jsc_module_loader(ctx, dynamic_module_list.array[i].name, NULL)) {
             fprintf(stderr, "Could not load dynamic module '%s'\n",
                     dynamic_module_list.array[i].name);
             exit(1);
         }
     }
 
-    if (output_type == OUTPUT_C_MAIN)
-    {
+    if (output_type == OUTPUT_C_MAIN) {
         fprintf(fo,
                 "static JSContext *JS_NewCustomContext(JSRuntime *rt)\n"
                 "{\n"

--- a/qjsc.c
+++ b/qjsc.c
@@ -39,6 +39,12 @@
 #include "cutils.h"
 #include "quickjs-libc.h"
 
+typedef enum {
+    OUTPUT_C,
+    OUTPUT_C_MAIN,
+    OUTPUT_RAW,
+} OutputTypeEnum;
+
 typedef struct {
     char *name;
     char *short_name;
@@ -220,7 +226,7 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
 {
     JSModuleDef *m;
     namelist_entry_t *e;
-    BOOL raw = *(BOOL *)opaque;
+    BOOL raw = *(BOOL *)opaque == OUTPUT_RAW;
 
     /* check if it is a declared C or system module */
     e = namelist_find(&cmodule_list, module_name);
@@ -345,12 +351,6 @@ void help(void)
            JS_DEFAULT_STACK_SIZE);
     exit(1);
 }
-
-typedef enum {
-    OUTPUT_C,
-    OUTPUT_C_MAIN,
-    OUTPUT_RAW,
-} OutputTypeEnum;
 
 int main(int argc, char **argv)
 {

--- a/qjsc.c
+++ b/qjsc.c
@@ -341,6 +341,7 @@ void help(void)
            "-D module_name         compile a dynamically loaded module or worker\n"
            "-M module_name[,cname] add initialization code for an external C module\n"
            "-p prefix   set the prefix of the generated C names\n"
+           "-r          output raw bytecode instead of C code\n"
            "-S n        set the maximum stack size to 'n' bytes (default=%d)\n",
            JS_GetVersion(),
            JS_DEFAULT_STACK_SIZE);

--- a/qjsc.c
+++ b/qjsc.c
@@ -480,7 +480,7 @@ int main(int argc, char **argv)
         cname = NULL;
     }
 
-    for (i = 0; i < dynamic_module_list.count; i++) {
+    for(i = 0; i < dynamic_module_list.count; i++) {
         if (!jsc_module_loader(ctx, dynamic_module_list.array[i].name, NULL)) {
             fprintf(stderr, "Could not load dynamic module '%s'\n",
                     dynamic_module_list.array[i].name);

--- a/qjsc.c
+++ b/qjsc.c
@@ -220,6 +220,7 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
 {
     JSModuleDef *m;
     namelist_entry_t *e;
+    BOOL raw = *(BOOL *)opaque;
 
     /* check if it is a declared C or system module */
     e = namelist_find(&cmodule_list, module_name);

--- a/qjsc.c
+++ b/qjsc.c
@@ -546,7 +546,6 @@ int main(int argc, char **argv)
         fputs(main_c_template2, fo);
     }
 
-    js_free(ctx, output_type_ptr);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
 


### PR DESCRIPTION
I want to allow users to ship a raw `.jsc` bytecode file for faster bootup times.