### PR TITLE
Document `qjsc -s` flag in help output

### DIFF
--- a/qjsc.c
+++ b/qjsc.c
@@ -332,6 +332,7 @@ void help(void)
            "-D module_name         compile a dynamically loaded module or worker\n"
            "-M module_name[,cname] add initialization code for an external C module\n"
            "-p prefix   set the prefix of the generated C names\n"
+           "-s          strip the source code, specify twice to also strip debug info\n"
            "-S n        set the maximum stack size to 'n' bytes (default=%d)\n",
            JS_GetVersion(),
            JS_DEFAULT_STACK_SIZE);


### PR DESCRIPTION
The `-s` flag added in #388 was missing in the `-h` help output.