### PR TITLE
Fix memory leak in JS_WriteObject2

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -33957,6 +33957,8 @@ uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
     *psize = s->dbuf.size;
     if (psab_tab)
         *psab_tab = s->sab_tab;
+    else
+        js_free(ctx, s->sab_tab);
     if (psab_tab_len)
         *psab_tab_len = s->sab_tab_len;
     return s->dbuf.buf;


### PR DESCRIPTION
If a SAB was written sab_tab will have been allocated. Free it if the user didn't provide a way to retrieve it.