### PR TITLE
Fix Linux with GCC 4.8 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:18.04
+    # Work around an issue where the node from actions/checkout is too new
+    # to run inside the old container image.
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: install dependencies
         run: |


### PR DESCRIPTION
Complains in the post-ckeckout step:

```
 Post job cleanup.
/usr/bin/docker exec  f32fc88d37a181d710e2802cbad0646c9780efe4af35a093fe68d09d8201a74e sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```