### PR TITLE
Introduce JS_ReadObject2

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -33928,7 +33928,7 @@ static int JS_WriteObjectAtoms(BCWriterState *s)
 }
 
 uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
-                         int flags, uint8_t ***psab_tab, size_t *psab_tab_len)
+                         int flags, JSSABTab *psab_tab)
 {
     BCWriterState ss, *s = &ss;
 
@@ -33955,12 +33955,12 @@ uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
     js_free(ctx, s->atom_to_idx);
     js_free(ctx, s->idx_to_atom);
     *psize = s->dbuf.size;
-    if (psab_tab)
-        *psab_tab = s->sab_tab;
-    else
+    if (psab_tab) {
+        psab_tab->tab = s->sab_tab;
+        psab_tab->len = s->sab_tab_len;
+    } else {
         js_free(ctx, s->sab_tab);
-    if (psab_tab_len)
-        *psab_tab_len = s->sab_tab_len;
+    }
     return s->dbuf.buf;
  fail:
     js_object_list_end(ctx, &s->object_list);
@@ -33968,17 +33968,17 @@ uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
     js_free(ctx, s->idx_to_atom);
     dbuf_free(&s->dbuf);
     *psize = 0;
-    if (psab_tab)
-        *psab_tab = NULL;
-    if (psab_tab_len)
-        *psab_tab_len = 0;
+    if (psab_tab) {
+        psab_tab->tab = NULL;
+        psab_tab->len = 0;
+    }
     return NULL;
 }
 
 uint8_t *JS_WriteObject(JSContext *ctx, size_t *psize, JSValue obj,
                         int flags)
 {
-    return JS_WriteObject2(ctx, psize, obj, flags, NULL, NULL);
+    return JS_WriteObject2(ctx, psize, obj, flags, NULL);
 }
 
 typedef struct BCReaderState {
@@ -35165,7 +35165,7 @@ static void bc_reader_free(BCReaderState *s)
 }
 
 JSValue JS_ReadObject2(JSContext *ctx, const uint8_t *buf, size_t buf_len,
-                       int flags, uint8_t ***psab_tab, size_t *psab_tab_len)
+                       int flags, JSSABTab *psab_tab)
 {
     BCReaderState ss, *s = &ss;
     JSValue obj;
@@ -35190,12 +35190,12 @@ JSValue JS_ReadObject2(JSContext *ctx, const uint8_t *buf, size_t buf_len,
     } else {
         obj = JS_ReadObjectRec(s);
     }
-    if (psab_tab)
-        *psab_tab = s->sab_tab;
-    else
+    if (psab_tab) {
+        psab_tab->tab = s->sab_tab;
+        psab_tab->len = s->sab_tab_len;
+    } else {
         js_free(ctx, s->sab_tab);
-    if (psab_tab_len)
-        *psab_tab_len = s->sab_tab_len;
+    }
     bc_reader_free(s);
     return obj;
 }
@@ -35203,7 +35203,7 @@ JSValue JS_ReadObject2(JSContext *ctx, const uint8_t *buf, size_t buf_len,
 JSValue JS_ReadObject(JSContext *ctx, const uint8_t *buf, size_t buf_len,
                       int flags)
 {
-    return JS_ReadObject2(ctx, buf, buf_len, flags, NULL, NULL);
+    return JS_ReadObject2(ctx, buf, buf_len, flags, NULL);
 }
 
 /*******************************************************************/

--- a/quickjs.h
+++ b/quickjs.h
@@ -840,6 +840,12 @@ JS_EXTERN int JS_EnqueueJob(JSContext *ctx, JSJobFunc *job_func, int argc, JSVal
 JS_EXTERN JS_BOOL JS_IsJobPending(JSRuntime *rt);
 JS_EXTERN int JS_ExecutePendingJob(JSRuntime *rt, JSContext **pctx);
 
+/* Structure to retrieve (de)serialized SharedArrayBuffer objects. */
+typedef struct JSSABTab {
+    uint8_t **tab;
+    size_t len;
+} JSSABTab;
+
 /* Object Writer/Reader (currently only used to handle precompiled code) */
 #define JS_WRITE_OBJ_BYTECODE  (1 << 0) /* allow function/module */
 #define JS_WRITE_OBJ_BSWAP     (0)      /* byte swapped output (obsolete, handled transparently) */
@@ -849,7 +855,7 @@ JS_EXTERN int JS_ExecutePendingJob(JSRuntime *rt, JSContext **pctx);
 #define JS_WRITE_OBJ_STRIP_DEBUG   (1 << 5) /* do not write debug information */
 JS_EXTERN uint8_t *JS_WriteObject(JSContext *ctx, size_t *psize, JSValue obj, int flags);
 JS_EXTERN uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
-                                   int flags, uint8_t ***psab_tab, size_t *psab_tab_len);
+                                   int flags, JSSABTab *psab_tab);
 
 #define JS_READ_OBJ_BYTECODE  (1 << 0) /* allow function/module */
 #define JS_READ_OBJ_ROM_DATA  (0)      /* avoid duplicating 'buf' data (obsolete, broken by ICs) */
@@ -857,7 +863,7 @@ JS_EXTERN uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
 #define JS_READ_OBJ_REFERENCE (1 << 3) /* allow object references */
 JS_EXTERN JSValue JS_ReadObject(JSContext *ctx, const uint8_t *buf, size_t buf_len, int flags);
 JS_EXTERN JSValue JS_ReadObject2(JSContext *ctx, const uint8_t *buf, size_t buf_len,
-                                 int flags, uint8_t ***psab_tab, size_t *psab_tab_len);
+                                 int flags, JSSABTab *psab_tab);
 /* instantiate and evaluate a bytecode function. Only used when
    reading a script or module with JS_ReadObject() */
 JS_EXTERN JSValue JS_EvalFunction(JSContext *ctx, JSValue fun_obj);

--- a/quickjs.h
+++ b/quickjs.h
@@ -856,6 +856,8 @@ JS_EXTERN uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValue obj,
 #define JS_READ_OBJ_SAB       (1 << 2) /* allow SharedArrayBuffer */
 #define JS_READ_OBJ_REFERENCE (1 << 3) /* allow object references */
 JS_EXTERN JSValue JS_ReadObject(JSContext *ctx, const uint8_t *buf, size_t buf_len, int flags);
+JS_EXTERN JSValue JS_ReadObject2(JSContext *ctx, const uint8_t *buf, size_t buf_len,
+                                 int flags, uint8_t ***psab_tab, size_t *psab_tab_len);
 /* instantiate and evaluate a bytecode function. Only used when
    reading a script or module with JS_ReadObject() */
 JS_EXTERN JSValue JS_EvalFunction(JSContext *ctx, JSValue fun_obj);


### PR DESCRIPTION
Analogously to JS_WriteObject2, it allows the user to get a tab with all the SAB objects that were read.

This can help adjust reference counts in a scenario where a SAB that was written increased it and it's necessary to decrease it upon reading it.