### PR TITLE
regexp: fix non greedy quantizers with zero length matches

### DIFF
--- a/libregexp.c
+++ b/libregexp.c
@@ -1633,11 +1633,13 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
 
                 if (dbuf_error(&s->byte_code))
                     goto out_of_memory;
-                add_zero_advance_check = (re_check_advance(s->byte_code.buf + last_atom_start,
-                                                           s->byte_code.size - last_atom_start) == 0);
-            } else {
-                add_zero_advance_check = FALSE;
             }
+            /* the spec tells that if there is no advance when
+               running the atom after the first quant_min times,
+               then there is no match. We remove this test when we
+               are sure the atom always advances the position. */
+            add_zero_advance_check = (re_check_advance(s->byte_code.buf + last_atom_start,
+                                                       s->byte_code.size - last_atom_start) == 0);
 
             {
                 int len, pos;

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -768,6 +768,10 @@ function test_regexp()
 
     eval("/[\\-]/");
     eval("/[\\-]/u");
+
+    /* test zero length matches */
+    a = /()*?a/.exec(",");
+    assert(a, null);
 }
 
 function test_symbol()


### PR DESCRIPTION
Cherry-picked from:
https://github.com/bellard/quickjs/commit/36911f0d3ab1a4c190a4d5cbe7c2db225a455389