### PR TITLE
Fix declaring property named get/set/async

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -20889,7 +20889,7 @@ static int __exception js_parse_property_name(JSParseState *s,
                 goto fail1;
             if (s->token.val == ':' || s->token.val == ',' ||
                 s->token.val == '}' || s->token.val == '(' ||
-                s->token.val == '=') {
+                s->token.val == '=' || s->token.val == ';') {
                 is_non_reserved_ident = TRUE;
                 goto ident_found;
             }
@@ -20906,7 +20906,7 @@ static int __exception js_parse_property_name(JSParseState *s,
                 goto fail1;
             if (s->token.val == ':' || s->token.val == ',' ||
                 s->token.val == '}' || s->token.val == '(' ||
-                s->token.val == '=') {
+                s->token.val == '=' || s->token.val == ';') {
                 is_non_reserved_ident = TRUE;
                 goto ident_found;
             }

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -349,10 +349,17 @@ function test_class()
     assert(S.z === 42);
     
     class P {
+        get;
+        set;
+        async;
         get = () => "123";
+        set = () => "456";
+        async = () => "789";
         static() { return 42; }
     }
     assert(new P().get() === "123");
+    assert(new P().set() === "456");
+    assert(new P().async() === "789");
     assert(new P().static() === 42);
 };
 


### PR DESCRIPTION
```js    
    class P {
        get;
        get = () => "123";
    }
```
Got `SyntaxError: invalid property name`.
This PR fixes it.