### PR TITLE
Fix broken DUMP_BYTECODE debug option

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -28373,12 +28373,12 @@ static __maybe_unused void dump_pc2line(JSContext *ctx,
     while (p < p_end) {
         op = *p++;
         if (op == 0) {
-            v = unicode_from_utf8(p, p_end - p, &p_next);
+            v = utf8_decode_len(p, p_end - p, &p_next);
             if (v < 0)
                 goto fail;
             pc += v;
             p = p_next;
-            v = unicode_from_utf8(p, p_end - p, &p_next);
+            v = utf8_decode_len(p, p_end - p, &p_next);
             if (v < 0)
                 goto fail;
             if (v & 1) {
@@ -28393,7 +28393,7 @@ static __maybe_unused void dump_pc2line(JSContext *ctx,
             pc += (op / PC2LINE_RANGE);
             line_num += (op % PC2LINE_RANGE) + PC2LINE_BASE;
         }
-        v = unicode_from_utf8(p, p_end - p, &p_next);
+        v = utf8_decode_len(p, p_end - p, &p_next);
         if (v < 0)
             goto fail;
         if (v & 1) {


### PR DESCRIPTION
Broken in commit 1baa6763f8 when unicode_from_utf8 was renamed to utf8_decode_len.