### PR TITLE
Fix FinalizationRegistry with primitive held value

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -53083,7 +53083,7 @@ static void reset_weak_ref(JSRuntime *rt, JSWeakRefRecord **first_weak_ref)
             /**
              * During the GC sweep phase the held object might be collected first.
              */
-            if (JS_IsLiveObject(frd->ctx->rt, fre->held_val)) {
+            if (!JS_IsObject(fre->held_val) || JS_IsLiveObject(frd->ctx->rt, fre->held_val)) {
                 JSValue func = js_dup(frd->cb);
                 JSValue ret = JS_Call(frd->ctx, func, JS_UNDEFINED, 1, &fre->held_val);
                 JS_FreeValueRT(rt, func);

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -992,6 +992,23 @@ function test_proxy_is_array()
   }
 }
 
+function test_finalization_registry()
+{
+    {
+        let expected = {};
+        let actual;
+        let finrec = new FinalizationRegistry(v => { actual = v });
+        finrec.register({}, expected); // {} goes out of scope immediately
+        assert(actual, expected);
+    }
+    {
+        let actual;
+        let finrec = new FinalizationRegistry(v => { actual = v });
+        finrec.register({}, 42); // {} goes out of scope immediately
+        assert(actual, 42);
+    }
+}
+
 function test_cur_pc()
 {
     var a = [];
@@ -1059,6 +1076,7 @@ test_weak_set();
 test_generator();
 test_proxy_iter();
 test_proxy_is_array();
+test_finalization_registry();
 test_exception_source_pos();
 test_function_source_pos();
 test_exception_prepare_stack();


### PR DESCRIPTION
Apparently test262 does not test FinalizationRegistry#register() with held values that are not objects.

Fixes: https://github.com/quickjs-ng/quickjs/issues/494