### PR TITLE
enable windows binary module import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,9 @@ endif()
 
 add_library(qjs ${qjs_sources})
 target_compile_definitions(qjs PRIVATE ${qjs_defines})
+if(NOT MSVC)
+    target_compile_options(qjs PRIVATE -fPIC)
+endif()
 target_include_directories(qjs PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if(BUILD_SHARED_LIBS)
     message(STATUS "Building a shared library")
 endif()
 
-xoption(BUILD_EXAMPLES "Build examples" OFF)
+xoption(BUILD_EXAMPLES "Build examples" ON)
 xoption(BUILD_STATIC_QJS_EXE "Build a static qjs executable" OFF)
 xoption(CONFIG_ASAN "Enable AddressSanitizer (ASan)" OFF)
 xoption(CONFIG_MSAN "Enable MemorySanitizer (MSan)" OFF)
@@ -275,7 +275,7 @@ target_link_libraries(function_source ${qjs_libs})
 # Examples
 #
 
-if(BUILD_EXAMPLES AND NOT WIN32)
+if(BUILD_EXAMPLES) #  AND NOT WIN32
     add_executable(hello
         gen/hello.c
     )
@@ -292,12 +292,14 @@ if(BUILD_EXAMPLES AND NOT WIN32)
     target_compile_definitions(hello_module PRIVATE ${qjs_defines})
     target_link_libraries(hello_module ${qjs_libs})
 
-    if(NOT WIN32)
+    # if(NOT WIN32)
         add_library(fib MODULE examples/fib.c)
         set_target_properties(fib PROPERTIES
             PREFIX ""
             C_VISIBILITY_PRESET default
         )
+        target_include_directories(fib PRIVATE .)
+        target_link_libraries(fib PRIVATE qjs)
         target_compile_definitions(fib PRIVATE JS_SHARED_LIBRARY)
         if(APPLE)
             target_link_options(fib PRIVATE -undefined dynamic_lookup)
@@ -308,11 +310,13 @@ if(BUILD_EXAMPLES AND NOT WIN32)
             PREFIX ""
             C_VISIBILITY_PRESET default
         )
+        target_include_directories(point PRIVATE .)
+        target_link_libraries(point PRIVATE qjs)
         target_compile_definitions(point PRIVATE JS_SHARED_LIBRARY)
         if(APPLE)
             target_link_options(point PRIVATE -undefined dynamic_lookup)
         endif()
-    endif()
+    # endif()
 
     add_executable(test_fib
         examples/fib.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,9 @@ endif()
 
 add_library(qjs ${qjs_sources})
 target_compile_definitions(qjs PRIVATE ${qjs_defines})
+if(NOT MSVC)
+    target_compile_options(qjs PRIVATE -fPIC)
+endif()
 if(CMAKE_BUILD_TYPE MATCHES Debug OR DUMP_LEAKS)
     target_compile_definitions(qjs PRIVATE
         DUMP_LEAKS

--- a/examples/fib.c
+++ b/examples/fib.c
@@ -21,7 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include "../quickjs.h"
+#include "quickjs.h"
+
+#if defined(_WIN32)
+#define FIB_API  __declspec(dllexport)
+#else
+#define FIB_API
+#endif
 
 #define countof(x) (sizeof(x) / sizeof((x)[0]))
 
@@ -61,7 +67,7 @@ static int js_fib_init(JSContext *ctx, JSModuleDef *m)
 #define JS_INIT_MODULE js_init_module_fib
 #endif
 
-JSModuleDef *JS_INIT_MODULE(JSContext *ctx, const char *module_name)
+FIB_API JSModuleDef *JS_INIT_MODULE(JSContext *ctx, const char *module_name)
 {
     JSModuleDef *m;
     m = JS_NewCModule(ctx, module_name, js_fib_init);

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -508,7 +508,7 @@ static JSModuleDef *js_module_loader_so(JSContext *ctx,
         goto fail;
     }
 
-    init = (JSInitModuleFunc *)GetProcAddress(hd, "js_init_module");
+    init = (JSInitModuleFunc *)(uintptr_t)GetProcAddress(hd, "js_init_module");
     if (!init) {
         JS_ThrowReferenceError(
             ctx, "could not load module filename '%s': js_init_module not found",


### PR DESCRIPTION
enable wondows binary module importing, which allow no modification of the origin scripts using binary module importing in project.

try run on windows:
```
$ mkdir build
$ cd build
$ cmake .. -DBUILD_EXAMPLES=ON
$ cmake --build . --config Release
```

And after the above, try copy the target file `qjs.exe`, `fib.dll`, `point.dll` to dir `examples` and run the following:
```cmd
$ .\qjs.exe .\test_fib.js
$ .\qjs.exe .\test_point.js
```

And the output is all right.