### PR TITLE
Run FinalizationRegistry callback in the job queue

### DIFF
--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -998,14 +998,19 @@ function test_finalization_registry()
         let expected = {};
         let actual;
         let finrec = new FinalizationRegistry(v => { actual = v });
-        finrec.register({}, expected); // {} goes out of scope immediately
-        assert(actual, expected);
+        finrec.register({}, expected);
+        queueMicrotask(() => {
+            assert(actual, expected);
+        });
     }
     {
+        let expected = 42;
         let actual;
         let finrec = new FinalizationRegistry(v => { actual = v });
-        finrec.register({}, 42); // {} goes out of scope immediately
-        assert(actual, 42);
+        finrec.register({}, expected);
+        queueMicrotask(() => {
+            assert(actual, expected);
+        });
     }
 }
 


### PR DESCRIPTION
The spec says HostMakeJobCallback has to be used on the callback: https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-cleanup-callback

That makes the following (arguably contrived) example run forever until memory is exhausted.

```js
let count = 0;
function main() {
    console.log(`main! ${++count}`);
    const registry = new FinalizationRegistry(() => {
        globalThis.foo = main();
    });
    registry.register([]);
    registry.register([]);
    return registry;
}
main();

console.log(count);
```

That is unlike V8, which runs 0 times. This can be explained by the difference in GC implementations and since FinRec makes GC observable, here we are!

Fixes: https://github.com/quickjs-ng/quickjs/issues/432