### PR TITLE
Fix Error.prepareStackTrace tests on Windows

### DIFF
--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -40,15 +40,15 @@ function test_exception_prepare_stack()
         e = _e;
     }
 
+    Error.prepareStackTrace = undefined;
+
     assert(e.stack.length === 2);
     const f = e.stack[0];
     assert(f.getFunctionName() === 'test_exception_prepare_stack');
-    assert(f.getFileName() === 'tests/test_builtin.js');
+    assert(f.getFileName().endsWith('test_builtin.js'));
     assert(f.getLineNumber() === 38);
     assert(f.getColumnNumber() === 19);
     assert(!f.isNative());
-
-    Error.prepareStackTrace = undefined;
 }
 
 // Keep this at the top; it tests source positions.
@@ -68,16 +68,16 @@ function test_exception_stack_size_limit()
         e = _e;
     }
 
+    Error.stackTraceLimit = 10;
+    Error.prepareStackTrace = undefined;
+
     assert(e.stack.length === 1);
     const f = e.stack[0];
     assert(f.getFunctionName() === 'test_exception_stack_size_limit');
-    assert(f.getFileName() === 'tests/test_builtin.js');
+    assert(f.getFileName().endsWith('test_builtin.js'));
     assert(f.getLineNumber() === 66);
     assert(f.getColumnNumber() === 19);
     assert(!f.isNative());
-
-    Error.stackTraceLimit = 10;
-    Error.prepareStackTrace = undefined;
 }
 
 function assert(actual, expected, message) {


### PR DESCRIPTION
- Reset state before doing assertions since they also throw errors
- Make the path check independent of the path separator