### PR TITLE
Add Set.prototype.symmetricDifference

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -46322,13 +46322,100 @@ fini:
     return newset;
 }
 
+static JSValue js_set_symmetricDifference(JSContext *ctx, JSValue this_val,
+                                          int argc, JSValue *argv)
+{
+    JSValue newset, item, iter, next, rv;
+    struct list_head *el;
+    JSMapState *s, *t;
+    JSMapRecord *mr;
+    int64_t size;
+    BOOL done, present;
+
+    s = JS_GetOpaque2(ctx, this_val, JS_CLASS_SET);
+    if (!s)
+        return JS_EXCEPTION;
+    // order matters! they're JS-observable side effects
+    if (js_setlike_get_size(ctx, argv[0], &size) < 0)
+        return JS_EXCEPTION;
+    if (js_setlike_get_has(ctx, argv[0], &rv) < 0)
+        return JS_EXCEPTION;
+    JS_FreeValue(ctx, rv);
+    newset = js_map_constructor(ctx, JS_UNDEFINED, 0, NULL, MAGIC_SET);
+    if (JS_IsException(newset))
+        return JS_EXCEPTION;
+    t = JS_GetOpaque(newset, JS_CLASS_SET);
+    iter = JS_UNDEFINED;
+    next = JS_UNDEFINED;
+    // can't clone this_val using js_map_constructor(),
+    // test262 mandates we don't call the .add method
+    list_for_each(el, &s->records) {
+        mr = list_entry(el, JSMapRecord, link);
+        if (mr->empty)
+            continue;
+        mr = map_add_record(ctx, t, js_dup(mr->key));
+        if (!mr)
+            goto exception;
+        mr->value = JS_UNDEFINED;
+    }
+    iter = JS_GetProperty(ctx, argv[0], JS_ATOM_keys);
+    if (JS_IsException(iter))
+        goto exception;
+    iter = JS_CallFree(ctx, iter, argv[0], 0, NULL);
+    if (JS_IsException(iter))
+        goto exception;
+    next = JS_GetProperty(ctx, iter, JS_ATOM_next);
+    if (JS_IsException(next))
+        goto exception;
+    for (;;) {
+        item = JS_IteratorNext(ctx, iter, next, 0, NULL, &done);
+        if (JS_IsException(item))
+            goto exception;
+        if (done) // item is JS_UNDEFINED
+            break;
+        // note the subtlety here: due to mutating iterators, it's
+        // possible for keys to disappear during iteration; test262
+        // still expects us to maintain insertion order though, so
+        // we first check |this|, then |new|; |new| is a copy of |this|
+        // - if item exists in |this|, delete (if it exists) from |new|
+        // - if item misses in |this| and |new|, add to |new|
+        // - if item exists in |new| but misses in |this|, *don't* add it,
+        //   mutating iterator erased it
+        item = map_normalize_key(ctx, item);
+        present = (NULL != map_find_record(ctx, s, item));
+        mr = map_find_record(ctx, t, item);
+        if (present) {
+            if (mr)
+                map_delete_record(ctx->rt, t, mr);
+            JS_FreeValue(ctx, item);
+        } else if (mr) {
+            JS_FreeValue(ctx, item);
+        } else {
+            mr = map_add_record(ctx, t, item);
+            if (!mr) {
+                JS_FreeValue(ctx, item);
+                goto exception;
+            }
+            mr->value = JS_UNDEFINED;
+        }
+    }
+    goto fini;
+exception:
+    JS_FreeValue(ctx, newset);
+    newset = JS_EXCEPTION;
+fini:
+    JS_FreeValue(ctx, next);
+    JS_FreeValue(ctx, iter);
+    return newset;
+}
+
 static JSValue js_set_union(JSContext *ctx, JSValue this_val,
                             int argc, JSValue *argv)
 {
     JSValue newset, item, iter, next, rv;
     struct list_head *el;
+    JSMapState *s, *t;
     JSMapRecord *mr;
-    JSMapState *s;
     int64_t size;
     BOOL done;
 
@@ -46344,16 +46431,17 @@ static JSValue js_set_union(JSContext *ctx, JSValue this_val,
     newset = js_map_constructor(ctx, JS_UNDEFINED, 0, NULL, MAGIC_SET);
     if (JS_IsException(newset))
         return JS_EXCEPTION;
+    t = JS_GetOpaque(newset, JS_CLASS_SET);
     iter = JS_UNDEFINED;
     next = JS_UNDEFINED;
     list_for_each(el, &s->records) {
         mr = list_entry(el, JSMapRecord, link);
         if (mr->empty)
             continue;
-        rv = js_map_set(ctx, newset, 1, &mr->key, MAGIC_SET);
-        if (JS_IsException(rv))
+        mr = map_add_record(ctx, t, js_dup(mr->key));
+        if (!mr)
             goto exception;
-        JS_FreeValue(ctx, rv);
+        mr->value = JS_UNDEFINED;
     }
     iter = JS_GetProperty(ctx, argv[0], JS_ATOM_keys);
     if (JS_IsException(iter))
@@ -46419,6 +46507,7 @@ static const JSCFunctionListEntry js_set_proto_funcs[] = {
     JS_CGETSET_MAGIC_DEF("size", js_map_get_size, NULL, MAGIC_SET ),
     JS_CFUNC_MAGIC_DEF("forEach", 1, js_map_forEach, MAGIC_SET ),
     JS_CFUNC_DEF("difference", 1, js_set_difference ),
+    JS_CFUNC_DEF("symmetricDifference", 1, js_set_symmetricDifference ),
     JS_CFUNC_DEF("union", 1, js_set_union ),
     JS_CFUNC_MAGIC_DEF("values", 0, js_create_map_iterator, (JS_ITERATOR_KIND_KEY << 2) | MAGIC_SET ),
     JS_ALIAS_DEF("keys", "values" ),

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -230,52 +230,6 @@ test262/test/built-ins/Set/prototype/isSupersetOf/size-is-a-number.js:24: Test26
 test262/test/built-ins/Set/prototype/isSupersetOf/size-is-a-number.js:24: strict mode: Test262Error: GetSetRecord coerces size Expected SameValue(«0», «1») to be true
 test262/test/built-ins/Set/prototype/isSupersetOf/subclass-receiver-methods.js:32: TypeError: not a function
 test262/test/built-ins/Set/prototype/isSupersetOf/subclass-receiver-methods.js:32: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/add-not-called.js:21: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/add-not-called.js:21: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/allows-set-like-class.js:31: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/allows-set-like-class.js:31: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/allows-set-like-object.js:29: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/allows-set-like-object.js:29: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/builtins.js:9: Test262Error: Built-in objects must be extensible. Expected SameValue(«false», «true») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/builtins.js:9: strict mode: Test262Error: Built-in objects must be extensible. Expected SameValue(«false», «true») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-Map.js:16: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-Map.js:16: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-empty-sets.js:13: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-empty-sets.js:13: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-itself.js:12: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-itself.js:12: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-same-sets.js:13: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-same-sets.js:13: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-sets.js:13: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/combines-sets.js:13: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/converts-negative-zero.js:25: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/converts-negative-zero.js:25: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/length.js:11: Test262Error: Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/length.js:11: strict mode: Test262Error: Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/name.js:11: Test262Error: Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/name.js:11: strict mode: Test262Error: Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/not-a-constructor.js:17: Test262Error: isConstructor invoked with a non-function value
-test262/test/built-ins/Set/prototype/symmetricDifference/not-a-constructor.js:17: strict mode: Test262Error: isConstructor invoked with a non-function value
-test262/test/built-ins/Set/prototype/symmetricDifference/require-internal-slot.js:17: Test262Error: Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/require-internal-slot.js:17: strict mode: Test262Error: Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/result-order.js:15: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/result-order.js:15: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/set-like-array.js:21: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/set-like-array.js:21: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/set-like-class-mutation.js:44: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/set-like-class-mutation.js:44: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/set-like-class-order.js:66: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/set-like-class-order.js:66: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/size-is-a-number.js:24: Test262Error: GetSetRecord coerces size Expected SameValue(«0», «1») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/size-is-a-number.js:24: strict mode: Test262Error: GetSetRecord coerces size Expected SameValue(«0», «1») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/subclass-receiver-methods.js:34: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/subclass-receiver-methods.js:34: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/subclass-symbol-species.js:20: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/subclass-symbol-species.js:20: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/subclass.js:15: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/subclass.js:15: strict mode: TypeError: not a function
-test262/test/built-ins/Set/prototype/symmetricDifference/symmetricDifference.js:10: Test262Error: `typeof Set.prototype.symmetricDifference` is `'function'` Expected SameValue(«undefined», «function») to be true
-test262/test/built-ins/Set/prototype/symmetricDifference/symmetricDifference.js:10: strict mode: Test262Error: `typeof Set.prototype.symmetricDifference` is `'function'` Expected SameValue(«undefined», «function») to be true
 test262/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js:35: Test262Error: value should not be coerced Expected SameValue(«22», «0») to be true
 test262/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js:35: strict mode: Test262Error: value should not be coerced Expected SameValue(«22», «0») to be true
 test262/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-canonical-invalid-index-reflect-set.js:35: Test262Error: value should not be coerced Expected SameValue(«32», «0») to be true


### PR DESCRIPTION
tc39 really went all out to make this one hard to implement efficiently :facepalm:

If and when we can reliably observe if we're dealing with un-monkey-patched objects, it should be possible to add fast paths, but right now that's just too fraught with peril /rant