### PR TITLE
Fix zero-length gnu_printf format string warning

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -6529,7 +6529,7 @@ static void build_backtrace(JSContext *ctx, JSValue error_obj,
                 line_num1 = find_line_num(ctx, b,
                                           sf->cur_pc - b->byte_code_buf - 1,
                                           &col_num1);
-                atom_str = JS_AtomToCString(ctx, b->filename);
+                atom_str = b->filename ? JS_AtomToCString(ctx, b->filename) : NULL;
                 dbuf_printf(&dbuf, " (%s", atom_str ? atom_str : "<null>");
                 JS_FreeCString(ctx, atom_str);
                 if (line_num1 != -1)


### PR DESCRIPTION
```
src/quickjs/quickjs.c: In function ‘JS_ReadString’:
src/quickjs/quickjs.c:34274:26: warning: zero-length gnu_printf format string [-Wformat-zero-length]
34274 |         bc_read_trace(s, "");  // hex dump and indentation
      |                          ^~
src/quickjs/quickjs.c: In function ‘JS_ReadFunctionBytecode’:
src/quickjs/quickjs.c:34334:30: warning: zero-length gnu_printf format string [-Wformat-zero-length]
34334 |             bc_read_trace(s, "");   // hex dump + indent
```

Ref: https://github.com/quickjs-ng/quickjs/issues/502