### PR TITLE
Disable stack checks when running with ASAN in Debug builds

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -2352,7 +2352,7 @@ JSRuntime *JS_GetRuntime(JSContext *ctx)
 
 static void update_stack_limit(JSRuntime *rt)
 {
-#if defined(__wasi__)
+#if defined(__wasi__) || (defined(__ASAN__) && !defined(NDEBUG))
     rt->stack_limit = 0; /* no limit */
 #else
     if (rt->stack_size == 0) {


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/502