### PR TITLE
Actuall fix zero-length gnu_printf format string warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ xcheck_add_c_compiler_flag(-Wno-unused-parameter)
 xcheck_add_c_compiler_flag(-Wno-unused-but-set-variable)
 xcheck_add_c_compiler_flag(-Wno-array-bounds)
 xcheck_add_c_compiler_flag(-Wno-format-truncation)
+xcheck_add_c_compiler_flag(-Wno-format-zero-length)
 xcheck_add_c_compiler_flag(-funsigned-char)
 
 # ClangCL is command line compatible with MSVC, so 'MSVC' is set.

--- a/quickjs.c
+++ b/quickjs.c
@@ -34057,7 +34057,6 @@ typedef struct BCReaderState {
 } BCReaderState;
 
 #ifdef DUMP_READ_OBJECT
-#pragma GCC diagnostic ignored "-Wformat-zero-length"
 static void __attribute__((format(printf, 2, 3))) bc_read_trace(BCReaderState *s, const char *fmt, ...) {
     va_list ap;
     int i, n, n0;
@@ -34091,7 +34090,6 @@ static void __attribute__((format(printf, 2, 3))) bc_read_trace(BCReaderState *s
     if (strchr(fmt, '{'))
         s->level++;
 }
-#pragma GCC diagnostic warning "-Wformat-zero-length"
 #else
 #define bc_read_trace(...)
 #endif


### PR DESCRIPTION
Turns out it cannot be disabled through the pragma.