### PR TITLE
Refactor JSMallocFunctions to simplify the implementation

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -283,18 +283,11 @@ typedef JSValue JSCFunction(JSContext *ctx, JSValue this_val, int argc, JSValue 
 typedef JSValue JSCFunctionMagic(JSContext *ctx, JSValue this_val, int argc, JSValue *argv, int magic);
 typedef JSValue JSCFunctionData(JSContext *ctx, JSValue this_val, int argc, JSValue *argv, int magic, JSValue *func_data);
 
-typedef struct JSMallocState {
-    size_t malloc_count;
-    size_t malloc_size;
-    size_t malloc_limit;
-    void *opaque; /* user opaque */
-} JSMallocState;
-
 typedef struct JSMallocFunctions {
-    void *(*js_calloc)(JSMallocState *s, size_t count, size_t size);
-    void *(*js_malloc)(JSMallocState *s, size_t size);
-    void (*js_free)(JSMallocState *s, void *ptr);
-    void *(*js_realloc)(JSMallocState *s, void *ptr, size_t size);
+    void *(*js_calloc)(void *opaque, size_t count, size_t size);
+    void *(*js_malloc)(void *opaque, size_t size);
+    void (*js_free)(void *opaque, void *ptr);
+    void *(*js_realloc)(void *opaque, void *ptr, size_t size);
     size_t (*js_malloc_usable_size)(const void *ptr);
 } JSMallocFunctions;
 


### PR DESCRIPTION
Rather than having the user take care of JSMallocState, take care of the bookkeeping internally (and make JSMallocState non-public since it's no longer necessary) and keep the allocation functions to the bare minimum.

This has the advantage that using a different allocator is just a few lines of code, and there is no need to copy the default implementation just to moficy the call to the allocation function.

Fixes: https://github.com/quickjs-ng/quickjs/issues/285