### PR TITLE
Provide a description for unitialized values in JS_ToStringInternal

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -11574,6 +11574,8 @@ JSValue JS_ToStringInternal(JSContext *ctx, JSValue val, BOOL is_ToPropertyKey)
         return js_dtoa(ctx, JS_VALUE_GET_FLOAT64(val), 0, JS_DTOA_TOSTRING);
     case JS_TAG_BIG_INT:
         return js_bigint_to_string(ctx, val);
+    case JS_TAG_UNINITIALIZED:
+        return js_new_string8(ctx, "[uninitialized]");
     default:
         return js_new_string8(ctx, "[unsupported type]");
     }


### PR DESCRIPTION
After 56da486312e655a2488bda74a284558682e93fda it's possible existing code relied on the current exception not being null to dump it, and the dumped value just said "[unsupported type]". This change provides a more descriptive value.