### PR TITLE
Fix printing of slow tests with -T in run-test262

### DIFF
--- a/run-test262.c
+++ b/run-test262.c
@@ -1976,7 +1976,7 @@ void run_test_dir_list(namelist_t *lp, int start_index, int stop_index)
         } else {
             int msec = 0;
             run_test(p, test_index, &msec);
-            if (verbose > 1 || (msec > 0 && msec >= slow_test_threshold))
+            if (verbose > 1 || (slow_test_threshold && msec >= slow_test_threshold))
                 fprintf(stderr, "%s (%d ms)\n", p, msec);
             show_progress(FALSE);
         }


### PR DESCRIPTION
It's currently printing them whenever a test takes one millisecond or longer to complete.

Introduced in commit 7db24cc0da from earlier today, mea culpa.