### PR TITLE
Run test262 tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,38 @@ jobs:
         run: |
           time make test262
 
+  linux-gcc48:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:18.04
+    # Work around an issue where the node from actions/checkout is too new
+    # to run inside the old container image.
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    steps:
+      - name: install dependencies
+        run: |
+          apt update && apt -y install make gcc-4.8 cmake software-properties-common
+          # git in default ppa repository is too old to run submodule checkout
+          add-apt-repository -y ppa:git-core/ppa
+          apt update && apt install -y git
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: build
+        env:
+          CC: gcc-4.8
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cd ..
+          make -C build -j$(getconf _NPROCESSORS_ONLN)
+      - name: stats
+        run: |
+          ./build/qjs -qd
+
   windows-msvc:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
           - { os: ubuntu-latest, configType: asan, runTest262: true }
           - { os: ubuntu-latest, configType: ubsan, runTest262: true }
           - { os: ubuntu-latest, configType: msan }
-          - { os: ubuntu-latest, configType: tcc }
           - { os: ubuntu-latest, arch: x86 }
           - { os: ubuntu-latest, arch: riscv64 }
           - { os: ubuntu-latest, arch: s390x }
@@ -83,20 +82,6 @@ jobs:
         if: ${{ matrix.config.os == 'ubuntu-latest' && (matrix.config.configType == 'asan' || matrix.config.configType == 'ubsan' || matrix.config.configType == 'msan')}}
         run: |
           sudo sysctl -w kernel.randomize_va_space=0
-
-      - name: install TCC
-        if: ${{ matrix.config.configType == 'tcc' }}
-        run: |
-          pushd /tmp
-          git clone https://repo.or.cz/tinycc.git
-          cd tinycc
-          git checkout 9d2068c6309dc50dfdbbc30a5d6757683d3f884c
-          ./configure
-          make
-          sudo make install
-          tcc -v
-          popd
-          echo "CC=tcc" >> $GITHUB_ENV;
 
       - name: Setup Alpine
         if: ${{ matrix.config.arch != '' }}
@@ -159,38 +144,6 @@ jobs:
         if: ${{ matrix.config.runTest262 }}
         run: |
           time make test262
-
-  linux-gcc48:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:18.04
-    # Work around an issue where the node from actions/checkout is too new
-    # to run inside the old container image.
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-    steps:
-      - name: install dependencies
-        run: |
-          apt update && apt -y install make gcc-4.8 cmake software-properties-common
-          # git in default ppa repository is too old to run submodule checkout
-          add-apt-repository -y ppa:git-core/ppa
-          apt update && apt install -y git
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: build
-        env:
-          CC: gcc-4.8
-        run: |
-          mkdir build
-          cd build
-          cmake ..
-          cd ..
-          make -C build -j$(getconf _NPROCESSORS_ONLN)
-      - name: stats
-        run: |
-          ./build/qjs -qd
 
   windows-msvc:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           - { os: ubuntu-latest, configType: asan, runTest262: true }
           - { os: ubuntu-latest, configType: ubsan, runTest262: true }
           - { os: ubuntu-latest, configType: msan }
+          - { os: ubuntu-latest, configType: tcc }
           - { os: ubuntu-latest, arch: x86 }
           - { os: ubuntu-latest, arch: riscv64 }
           - { os: ubuntu-latest, arch: s390x }
@@ -82,6 +83,20 @@ jobs:
         if: ${{ matrix.config.os == 'ubuntu-latest' && (matrix.config.configType == 'asan' || matrix.config.configType == 'ubsan' || matrix.config.configType == 'msan')}}
         run: |
           sudo sysctl -w kernel.randomize_va_space=0
+
+      - name: install TCC
+        if: ${{ matrix.config.configType == 'tcc' }}
+        run: |
+          pushd /tmp
+          git clone https://repo.or.cz/tinycc.git
+          cd tinycc
+          git checkout 9d2068c6309dc50dfdbbc30a5d6757683d3f884c
+          ./configure
+          make
+          sudo make install
+          tcc -v
+          popd
+          echo "CC=tcc" >> $GITHUB_ENV;
 
       - name: Setup Alpine
         if: ${{ matrix.config.arch != '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,8 +269,8 @@ endif()
 # Test262 runner
 #
 
-# run-test262 uses pthreads.
-if(NOT WIN32 AND NOT EMSCRIPTEN)
+# run-test262 uses pthreads. tcc does not understand _Thread_local.
+if(NOT WIN32 AND NOT EMSCRIPTEN AND NOT CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
     add_executable(run-test262
         run-test262.c
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,8 +269,15 @@ endif()
 # Test262 runner
 #
 
-# run-test262 uses pthreads. tcc does not understand _Thread_local.
-if(NOT WIN32 AND NOT EMSCRIPTEN AND NOT CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
+if(WIN32
+OR EMSCRIPTEN
+OR CMAKE_C_COMPILER_ID STREQUAL "TinyCC"
+OR CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 5)
+    # Empty. run-test262 uses pthreads, sorry Windows users.
+    # tcc and gcc 4.8 don't understand _Thread_local, whereas I
+    # don't understand why people still use 4.8 in this day and age
+    # but hey, here we are.
+else()
     add_executable(run-test262
         run-test262.c
     )

--- a/run-test262.c
+++ b/run-test262.c
@@ -2026,8 +2026,11 @@ int main(int argc, char **argv)
     init_thread_local_storage(tls);
     js_mutex_init(&stats_mutex);
 
+#if !defined(__MINGW32__)
     /* Date tests assume California local time */
     setenv("TZ", "America/Los_Angeles", 1);
+    nthreads = sysconf(_SC_NPROCESSORS_ONLN) - 1;
+#endif
 
     optind = 1;
     while (optind < argc) {
@@ -2097,8 +2100,6 @@ int main(int argc, char **argv)
         return run_test262_harness_test(argv[optind], is_module);
     }
 
-    if (!nthreads)
-        nthreads = sysconf(_SC_NPROCESSORS_ONLN) - 1;
     nthreads = max_int(nthreads, 1);
     nthreads = min_int(nthreads, countof(threads));
 

--- a/test262.conf
+++ b/test262.conf
@@ -37,9 +37,6 @@ errorfile=test262_errors.txt
 # exclude tests enumerated in this file (see also [exclude] section)
 #excludefile=test262_exclude.txt
 
-# report test results to this file
-reportfile=test262_report.txt
-
 # enumerate tests from this directory
 testdir=test262/test
 


### PR DESCRIPTION
This commit introduces a couple of changes in order to make run-test262 go brr and execute tests in parallel:

- Remove CONFIG_AGENT build option. The disabled version of the build was already broken and no one noticed, Remove the define altogether.

- Remove the -C switch. Hard to support in multi-threaded mode. I may bring it back some day because it _is_ useful.

- Remove the -r switch. Also hard to support and I never look at test262_report.txt anyway so on the chopping block it goes.

- Judicious use of thread-local storage so I don't have to thread through state everywhere and embiggen the diff even more.

This is what Real Programmers(TM) do: stay up coding way past midnight just so the test suite finishes in one minute instead of four.

Fixes: https://github.com/quickjs-ng/quickjs/issues/547