### PR TITLE
Fix regexp split with zero-length capture group

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -43835,9 +43835,14 @@ static JSValue js_regexp_Symbol_split(JSContext *ctx, JSValue this_val,
                 if (js_get_length64(ctx, &numberOfCaptures, z))
                     goto exception;
                 for(i = 1; i < numberOfCaptures; i++) {
-                    sub = JS_ToStringFree(ctx, JS_GetPropertyInt64(ctx, z, i));
+                    sub = JS_GetPropertyInt64(ctx, z, i);
                     if (JS_IsException(sub))
                         goto exception;
+                    if (!JS_IsUndefined(sub)) {
+                        sub = JS_ToStringFree(ctx, sub);
+                        if (JS_IsException(sub))
+                            goto exception;
+                    }
                     if (JS_DefinePropertyValueInt64(ctx, A, lengthA++, sub, JS_PROP_C_W_E | JS_PROP_THROW) < 0)
                         goto exception;
                     if (lengthA == lim)

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -783,6 +783,8 @@ function test_regexp()
     assert(a, ["a", undefined]);
     a = /(?:|[\w])+([0-9])/.exec("123a23");
     assert(a, ["123a23", "3"]);
+    a = "ab".split(/(c)*/);
+    assert(a, ["a", undefined, "b"]);
 }
 
 function test_symbol()


### PR DESCRIPTION
The expected result of `"ab".split(/(c)*/)[1]` is `undefined` but was in fact `"undefined"` due to unintentional stringification.

Fixes: https://github.com/quickjs-ng/quickjs/issues/565