### PR TITLE
Fix cyclic import/export segfault

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -26774,6 +26774,11 @@ static JSValue js_build_module_ns(JSContext *ctx, JSModuleDef *m)
         case EXPORTED_NAME_NORMAL:
             {
                 JSVarRef *var_ref = en->u.var_ref;
+                if (!var_ref) {
+                    js_resolve_export_throw_error(ctx, JS_RESOLVE_RES_CIRCULAR,
+                                                  m, en->export_name);
+                    goto fail;
+                }
                 pr = add_property(ctx, p, en->export_name,
                                   JS_PROP_ENUMERABLE | JS_PROP_WRITABLE |
                                   JS_PROP_VARREF);

--- a/run-test262.c
+++ b/run-test262.c
@@ -1836,7 +1836,7 @@ int run_test(const char *filename, int *msec)
             if (q) {
                 while (isspace((unsigned char)*q))
                     q++;
-                error_type = strdup_len(q, strcspn(q, " \n"));
+                error_type = strdup_len(q, strcspn(q, " \r\n"));
             }
             is_negative = TRUE;
         }

--- a/tests.conf
+++ b/tests.conf
@@ -4,5 +4,6 @@ verbose=yes
 testdir=tests
 
 [exclude]
+tests/fixture_cyclic_import.js
 tests/microbench.js
 tests/test_worker_module.js

--- a/tests/fixture_cyclic_import.js
+++ b/tests/fixture_cyclic_import.js
@@ -1,0 +1,2 @@
+import * as a from "./test_cyclic_import.js"
+export function f(x) { return 2 * a.g(x) }

--- a/tests/test_cyclic_import.js
+++ b/tests/test_cyclic_import.js
@@ -1,0 +1,12 @@
+/*---
+negative:
+  phase: resolution
+  type: SyntaxError
+---*/
+// FIXME(bnoordhuis) shouldn't throw SyntaxError but that's still better
+// than segfaulting, see https://github.com/quickjs-ng/quickjs/issues/567
+import {assert} from "./assert.js"
+import {f} from "./fixture_cyclic_import.js"
+export {f}
+export function g(x) { return x + 1 }
+assert(f(1), 4)


### PR DESCRIPTION
Consider the following two files:

    // a.js
    import {f} from "b.js"
    export {f}

And:

    // b.js
    import * as a from "a.js"
    export function f() {}

Before this commit, it crashed with a nullptr dereference. Throw a "circular reference when looking for export" SyntaxError.

No test because the test suite currently isn't equipped for tests that throw exceptions at import time.

Fixes: https://github.com/quickjs-ng/quickjs/issues/567