### PR TITLE
chore: move JS_{Dup,Free}Value and the RT variants from header, reduced duplication

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1366,11 +1366,13 @@ static JSValue js_dup(JSValue v)
     return v;
 }
 
-JSValue JS_DupValue(JSContext *ctx, JSValue v){
+JSValue JS_DupValue(JSContext *ctx, JSValue v)
+{
     return js_dup(v);
 }
 
-JSValue JS_DupValueRT(JSRuntime *rt, JSValue v){
+JSValue JS_DupValueRT(JSRuntime *rt, JSValue v)
+{
     return js_dup(v);
 }
 
@@ -5616,7 +5618,7 @@ void JS_FreeValueRT(JSRuntime *rt, JSValue v)
 
 void JS_FreeValue(JSContext *ctx, JSValue v)
 {
-    JS_FreeValueRT(ctx->rt,v);
+    JS_FreeValueRT(ctx->rt, v);
 }
 
 /* garbage collection */

--- a/quickjs.h
+++ b/quickjs.h
@@ -87,10 +87,6 @@ enum {
     /* any larger tag is FLOAT64 if JS_NAN_BOXING */
 };
 
-typedef struct JSRefCountHeader {
-    int ref_count;
-} JSRefCountHeader;
-
 #define JS_FLOAT64_NAN NAN
 #define JSValueConst JSValue /* For backwards compatibility. */
 
@@ -591,44 +587,11 @@ JS_EXTERN JSValue __js_printf_like(2, 3) JS_ThrowInternalError(JSContext *ctx, c
 JS_EXTERN JSValue JS_ThrowOutOfMemory(JSContext *ctx);
 
 JS_EXTERN void __JS_FreeValue(JSContext *ctx, JSValue v);
-static inline void JS_FreeValue(JSContext *ctx, JSValue v)
-{
-    if (JS_VALUE_HAS_REF_COUNT(v)) {
-        JSRefCountHeader *p = (JSRefCountHeader *)JS_VALUE_GET_PTR(v);
-        if (--p->ref_count <= 0) {
-            __JS_FreeValue(ctx, v);
-        }
-    }
-}
+JS_EXTERN void JS_FreeValue(JSContext *ctx, JSValue v);
 JS_EXTERN void __JS_FreeValueRT(JSRuntime *rt, JSValue v);
-static inline void JS_FreeValueRT(JSRuntime *rt, JSValue v)
-{
-    if (JS_VALUE_HAS_REF_COUNT(v)) {
-        JSRefCountHeader *p = (JSRefCountHeader *)JS_VALUE_GET_PTR(v);
-        if (--p->ref_count <= 0) {
-            __JS_FreeValueRT(rt, v);
-        }
-    }
-}
-
-static inline JSValue JS_DupValue(JSContext *ctx, JSValue v)
-{
-    if (JS_VALUE_HAS_REF_COUNT(v)) {
-        JSRefCountHeader *p = (JSRefCountHeader *)JS_VALUE_GET_PTR(v);
-        p->ref_count++;
-    }
-    return v;
-}
-
-static inline JSValue JS_DupValueRT(JSRuntime *rt, JSValue v)
-{
-    if (JS_VALUE_HAS_REF_COUNT(v)) {
-        JSRefCountHeader *p = (JSRefCountHeader *)JS_VALUE_GET_PTR(v);
-        p->ref_count++;
-    }
-    return v;
-}
-
+JS_EXTERN void JS_FreeValueRT(JSRuntime *rt, JSValue v);
+JS_EXTERN JSValue JS_DupValue(JSContext *ctx, JSValue v);
+JS_EXTERN JSValue JS_DupValueRT(JSRuntime *rt, JSValue v);
 JS_EXTERN int JS_ToBool(JSContext *ctx, JSValue val); /* return -1 for JS_EXCEPTION */
 JS_EXTERN int JS_ToInt32(JSContext *ctx, int32_t *pres, JSValue val);
 static inline int JS_ToUint32(JSContext *ctx, uint32_t *pres, JSValue val)

--- a/quickjs.h
+++ b/quickjs.h
@@ -585,10 +585,7 @@ JS_EXTERN JSValue __js_printf_like(2, 3) JS_ThrowReferenceError(JSContext *ctx, 
 JS_EXTERN JSValue __js_printf_like(2, 3) JS_ThrowRangeError(JSContext *ctx, const char *fmt, ...);
 JS_EXTERN JSValue __js_printf_like(2, 3) JS_ThrowInternalError(JSContext *ctx, const char *fmt, ...);
 JS_EXTERN JSValue JS_ThrowOutOfMemory(JSContext *ctx);
-
-JS_EXTERN void __JS_FreeValue(JSContext *ctx, JSValue v);
 JS_EXTERN void JS_FreeValue(JSContext *ctx, JSValue v);
-JS_EXTERN void __JS_FreeValueRT(JSRuntime *rt, JSValue v);
 JS_EXTERN void JS_FreeValueRT(JSRuntime *rt, JSValue v);
 JS_EXTERN JSValue JS_DupValue(JSContext *ctx, JSValue v);
 JS_EXTERN JSValue JS_DupValueRT(JSRuntime *rt, JSValue v);


### PR DESCRIPTION
js_dup and JS_DupValue is the same function expect for different parameters. However the `ctx` parameter is not used.

Similarly a few functions have unused CTX parameter.

This PR removes duplicate code by using `JS_DupValue` instead of `js_dup` and also removing unused `ctx` parameter in a few other functions.


