### PR TITLE
Fix thread-safety issue in quickjs-libc

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -287,6 +287,11 @@ typedef struct JSMallocFunctions {
     size_t (*js_malloc_usable_size)(const void *ptr);
 } JSMallocFunctions;
 
+// Finalizers run in LIFO order at the very end of JS_FreeRuntime.
+// Intended for cleanup of associated resources; the runtime itself
+// is no longer usable.
+typedef void JSRuntimeFinalizer(JSRuntime *rt, void *arg);
+
 typedef struct JSGCObjectHeader JSGCObjectHeader;
 
 JS_EXTERN JSRuntime *JS_NewRuntime(void);
@@ -306,6 +311,8 @@ JS_EXTERN JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque);
 JS_EXTERN void JS_FreeRuntime(JSRuntime *rt);
 JS_EXTERN void *JS_GetRuntimeOpaque(JSRuntime *rt);
 JS_EXTERN void JS_SetRuntimeOpaque(JSRuntime *rt, void *opaque);
+JS_EXTERN int JS_AddRuntimeFinalizer(JSRuntime *rt,
+                                     JSRuntimeFinalizer *finalizer, void *arg);
 typedef void JS_MarkFunc(JSRuntime *rt, JSGCObjectHeader *gp);
 JS_EXTERN void JS_MarkValue(JSRuntime *rt, JSValue val, JS_MarkFunc *mark_func);
 JS_EXTERN void JS_RunGC(JSRuntime *rt);


### PR DESCRIPTION
`JS_NewClassID(rt, &class_id)` where `class_id` is a global variable is unsafe when called from multiple threads but that is exactly what quickjs-libc.c did.

Change the class ids in quickjs-libc.c to thread-locals, and change the function prototype of JS_NewClassID to hopefully make it harder for downstream users to introduce such bugs.

The gcc48 and tcc buildbots don't support _Thread_local and that is why this commit removes them.

I toyed with the idea of porting the uv_key_create/uv_key_get/etc. functions from libuv but because quickjs-libc doesn't know when it's safe to free the thread-local keys, that leads to memory leaks, and support for ancient or niche compilers isn't worth that.

Fixes: https://github.com/quickjs-ng/quickjs/issues/577