### PR TITLE
Enforce buffer length in utf8_encode definition

### DIFF
--- a/cutils.c
+++ b/cutils.c
@@ -246,7 +246,7 @@ size_t utf8_encode_len(uint32_t c)
    No null byte is stored after the encoded bytes.
    Return value is in range 1..4
  */
-size_t utf8_encode(uint8_t *buf, uint32_t c)
+size_t utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c)
 {
     if (c < 0x80) {
         buf[0] = c;

--- a/cutils.h
+++ b/cutils.h
@@ -481,7 +481,7 @@ enum {
 };
 int utf8_scan(const char *buf, size_t len, size_t *plen);
 size_t utf8_encode_len(uint32_t c);
-size_t utf8_encode(uint8_t *buf, uint32_t c);
+size_t utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c);
 uint32_t utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp);
 uint32_t utf8_decode(const uint8_t *p, const uint8_t **pp);
 size_t utf8_decode_buf8(uint8_t *dest, size_t dest_len, const char *src, size_t src_len);


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/464