### PR TITLE
Expose ctx->function_proto

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -2319,7 +2319,7 @@ JSValue JS_GetClassProto(JSContext *ctx, JSClassID class_id)
     return js_dup(ctx->class_proto[class_id]);
 }
 
-JSValueConst JS_GetFunctionProto(JSContext *ctx)
+JSValue JS_GetFunctionProto(JSContext *ctx)
 {
     return js_dup(ctx->function_proto);
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -2319,6 +2319,11 @@ JSValue JS_GetClassProto(JSContext *ctx, JSClassID class_id)
     return js_dup(ctx->class_proto[class_id]);
 }
 
+JSValueConst JS_GetFunctionProto(JSContext *ctx)
+{
+    return js_dup(ctx->function_proto);
+}
+
 typedef enum JSFreeModuleEnum {
     JS_FREE_MODULE_ALL,
     JS_FREE_MODULE_NOT_RESOLVED,

--- a/quickjs.h
+++ b/quickjs.h
@@ -326,7 +326,7 @@ JS_EXTERN void JS_SetContextOpaque(JSContext *ctx, void *opaque);
 JS_EXTERN JSRuntime *JS_GetRuntime(JSContext *ctx);
 JS_EXTERN void JS_SetClassProto(JSContext *ctx, JSClassID class_id, JSValue obj);
 JS_EXTERN JSValue JS_GetClassProto(JSContext *ctx, JSClassID class_id);
-JS_EXTERN JSValueConst JS_GetFunctionProto(JSContext *ctx);
+JS_EXTERN JSValue JS_GetFunctionProto(JSContext *ctx);
 
 /* the following functions are used to select the intrinsic object to
    save memory */

--- a/quickjs.h
+++ b/quickjs.h
@@ -326,6 +326,7 @@ JS_EXTERN void JS_SetContextOpaque(JSContext *ctx, void *opaque);
 JS_EXTERN JSRuntime *JS_GetRuntime(JSContext *ctx);
 JS_EXTERN void JS_SetClassProto(JSContext *ctx, JSClassID class_id, JSValue obj);
 JS_EXTERN JSValue JS_GetClassProto(JSContext *ctx, JSClassID class_id);
+JS_EXTERN JSValueConst JS_GetFunctionProto(JSContext *ctx);
 
 /* the following functions are used to select the intrinsic object to
    save memory */


### PR DESCRIPTION
This is the last patch required by rquickjs. Would be nice to get rid of it :)

