### PR TITLE
Fix crash in deserializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ unicode/
 test262_*.txt
 .idea
 cmake-*
+fuzz

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ endif
 
 all: $(QJS)
 
+fuzz:
+	clang -g -O1 -fsanitize=fuzzer -o fuzz fuzz.c
+	./fuzz
+
 $(BUILD_DIR):
 	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 
@@ -106,4 +110,4 @@ unicode_gen: $(BUILD_DIR)
 libunicode-table.h: unicode_gen
 	$(BUILD_DIR)/unicode_gen unicode $@
 
-.PHONY: all debug install clean codegen distclean stats test test262 test262-update test262-check microbench unicode_gen $(QJS) $(QJSC)
+.PHONY: all debug fuzz install clean codegen distclean stats test test262 test262-update test262-check microbench unicode_gen $(QJS) $(QJSC)

--- a/fuzz.c
+++ b/fuzz.c
@@ -1,0 +1,23 @@
+// clang -g -O1 -fsanitize=fuzzer -o fuzz fuzz.c
+#include "quickjs.h"
+#include "quickjs.c"
+#include "cutils.c"
+#include "libbf.c"
+#include "libregexp.c"
+#include "libunicode.c"
+#include <stdlib.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    JSRuntime *rt = JS_NewRuntime();
+    if (!rt)
+        exit(1);
+    JSContext *ctx = JS_NewContext(rt);
+    if (!ctx)
+        exit(1);
+    JSValueConst val = JS_ReadObject(ctx, buf, len, /*flags*/0);
+    JS_FreeValue(ctx, val);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+    return 0;
+}

--- a/quickjs.c
+++ b/quickjs.c
@@ -35587,6 +35587,10 @@ static int JS_ReadObjectAtoms(BCReaderState *s)
         if (type == 0) {
             if (bc_get_u32(s, &atom))
                 return -1;
+            if (!__JS_AtomIsConst(atom)) {
+                JS_ThrowInternalError(s->ctx, "out of range atom");
+                return -1;
+            }
         } else {
             if (type < JS_ATOM_TYPE_STRING || type >= JS_ATOM_TYPE_PRIVATE) {
                 JS_ThrowInternalError(s->ctx, "invalid symbol type %d", type);


### PR DESCRIPTION
Check inside the deserializer that const atoms are indeed const, don't trust the input. The serializer only writes type 0 records for const atoms but the byte stream may have been corrupted or manipulated.

Overlooked during review of c25aad7 ("Add ability to (de)serialize symbols")

Found with libfuzzer and it found it _really_ fast. Great tool.

<hr>

It already found more. For future reference:
```diff
diff --git a/tests/test_bjson.js b/tests/test_bjson.js
index 5807ab1..f0c16f2 100644
--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -231,6 +231,10 @@ function bjson_test_fuzz()
 {
     const corpus = [
         "EBAAAAAABGA=",
+        // hang
+        "EObm5oIt",
+        // crash
+        "EAARABMGBgYGBgYGBgYGBv////8QABEALxH/vy8R/78=",
     ];
     for (const input of corpus) {
         const buf = base64decode(input)
```