### PR TITLE
Remove NetBSD CI buildbot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,21 +420,6 @@ jobs:
             gmake
             gmake stats
 
-  netbsd:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: build + test
-        uses: vmactions/netbsd-vm@v1
-        with:
-          usesh: true
-          prepare: |
-            /usr/sbin/pkg_add cmake gmake
-          run: |
-            gmake
-            gmake stats
-            gmake test
-
   android:
     runs-on: ubuntu-latest
     container: reactnativecommunity/react-native-android:v13.0


### PR DESCRIPTION
It's been super flaky due to GHA changes or the vmactions/netbsd-vm@v1 action it depends on, and I'm not invested enough to investigate.

If someone is motivated enough to fix it up, we can bring it back.

Fixes: https://github.com/quickjs-ng/quickjs/issues/600