### PR TITLE
Restrict atom count in deserializer to 1 million

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -35571,8 +35571,13 @@ static int JS_ReadObjectAtoms(BCReaderState *s)
     }
     if (bc_get_leb128(s, &s->idx_to_atom_count))
         return -1;
+    if (s->idx_to_atom_count > 1000*1000) {
+        JS_ThrowInternalError(s->ctx, "unreasonable atom count: %u",
+                              s->idx_to_atom_count);
+        return -1;
+    }
 
-    bc_read_trace(s, "%d atom indexes {\n", s->idx_to_atom_count);
+    bc_read_trace(s, "%u atom indexes {\n", s->idx_to_atom_count);
 
     if (s->idx_to_atom_count != 0) {
         s->idx_to_atom = js_mallocz(s->ctx, s->idx_to_atom_count *

--- a/quickjs.c
+++ b/quickjs.c
@@ -35361,7 +35361,12 @@ static JSValue JS_ReadRegExp(BCReaderState *s)
         return JS_EXCEPTION;
     }
 
-    assert(!bc->is_wide_char);
+    if (bc->is_wide_char) {
+        js_free_string(ctx->rt, pattern);
+        js_free_string(ctx->rt, bc);
+        return JS_ThrowInternalError(ctx, "bad regexp bytecode");
+    }
+
     if (is_be())
         lre_byte_swap(bc->u.str8, bc->len, /*is_byte_swapped*/TRUE);
 

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -232,6 +232,7 @@ function bjson_test_fuzz()
     var corpus = [
         "EBAAAAAABGA=",
         "EObm5oIt",
+        "EAARABMGBgYGBgYGBgYGBv////8QABEALxH/vy8R/78=",
     ];
     for (var input of corpus) {
         var buf = base64decode(input);

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -231,6 +231,7 @@ function bjson_test_fuzz()
 {
     var corpus = [
         "EBAAAAAABGA=",
+        "EObm5oIt",
     ];
     for (var input of corpus) {
         var buf = base64decode(input);


### PR DESCRIPTION
Otherwise it's too easy to tie up too many resources (cpu, memory) by crafting inputs with a very large atom count (up to 4 billion.)

This may need some finetuning. If the limit proves too restrictive for very large snapshots, we can make it relative to the size of the input.