### PR TITLE
Add support for MSVC 2019 without c11 atomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,31 @@ jobs:
           build\${{matrix.buildType}}\run-test262.exe -c tests.conf
           build\${{matrix.buildType}}\function_source.exe
 
+  windows-msvc-2019:
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, Win32]
+        buildType: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        run: |
+          cmake -B build -DBUILD_EXAMPLES=ON -G "Visual Studio 16 2019" -A ${{matrix.arch}}
+          cmake --build build --config ${{matrix.buildType}}
+      - name: stats
+        run: |
+          build\${{matrix.buildType}}\qjs.exe -qd
+      - name: test
+        run: |
+          cp build\${{matrix.buildType}}\fib.dll examples\
+          cp build\${{matrix.buildType}}\point.dll examples\
+          build\${{matrix.buildType}}\qjs.exe examples\test_fib.js
+          build\${{matrix.buildType}}\qjs.exe examples\test_point.js
+          build\${{matrix.buildType}}\run-test262.exe -c tests.conf
+          build\${{matrix.buildType}}\function_source.exe
+
   windows-clang:
     runs-on: windows-latest
     strategy:

--- a/quickjs.c
+++ b/quickjs.c
@@ -63,8 +63,12 @@
 #endif
 
 #if !defined(EMSCRIPTEN) && !defined(__wasi__) && !defined(__STDC_NO_ATOMICS__)
+#if defined(_MSC_VER) && _MSC_VER < 1941
+#pragma message("This msvc is too old to support c11atomics, so atomics are disabled.")
+#else
 #include "quickjs-c-atomics.h"
 #define CONFIG_ATOMICS
+#endif
 #endif
 
 #ifndef __GNUC__


### PR DESCRIPTION
Linked to https://github.com/rizinorg/jsdec/pull/60