### PR TITLE
Handle bytecode without IC state

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -837,6 +837,7 @@ static JSValue js_evalScript(JSContext *ctx, JSValue this_val,
     JSValue ret;
     JSValue options_obj;
     BOOL backtrace_barrier = FALSE;
+    BOOL compile_only = FALSE;
     BOOL is_async = FALSE;
     int flags;
 
@@ -844,6 +845,9 @@ static JSValue js_evalScript(JSContext *ctx, JSValue this_val,
         options_obj = argv[1];
         if (get_bool_option(ctx, &backtrace_barrier, options_obj,
                             "backtrace_barrier"))
+            return JS_EXCEPTION;
+        if (get_bool_option(ctx, &compile_only, options_obj,
+                            "compile_only"))
             return JS_EXCEPTION;
         if (get_bool_option(ctx, &is_async, options_obj,
                             "async"))
@@ -860,6 +864,8 @@ static JSValue js_evalScript(JSContext *ctx, JSValue this_val,
     flags = JS_EVAL_TYPE_GLOBAL;
     if (backtrace_barrier)
         flags |= JS_EVAL_FLAG_BACKTRACE_BARRIER;
+    if (compile_only)
+        flags |= JS_EVAL_FLAG_COMPILE_ONLY;
     if (is_async)
         flags |= JS_EVAL_FLAG_ASYNC;
     ret = JS_Eval(ctx, str, len, "<evalScript>", flags);

--- a/quickjs.c
+++ b/quickjs.c
@@ -35473,12 +35473,14 @@ static JSValue JS_ReadObjectRec(BCReaderState *s)
         break;
     case BC_TAG_FUNCTION_BYTECODE:
         if (!s->allow_bytecode)
-            goto invalid_tag;
+            goto no_allow_bytecode;
         obj = JS_ReadFunctionTag(s);
         break;
     case BC_TAG_MODULE:
-        if (!s->allow_bytecode)
-            goto invalid_tag;
+        if (!s->allow_bytecode) {
+        no_allow_bytecode:
+            return JS_ThrowSyntaxError(ctx, "no bytecode allowed");
+        }
         obj = JS_ReadModule(s);
         break;
     case BC_TAG_OBJECT:

--- a/quickjs.c
+++ b/quickjs.c
@@ -35019,7 +35019,8 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
         goto fail;
     if (b->source_len) {
         bc_read_trace(s, "source: %d bytes\n", b->source_len);
-        s->ptr_last += b->source_len;  // omit source code hex dump
+        if (s->ptr_last)
+            s->ptr_last += b->source_len;  // omit source code hex dump
         /* b->source is a UTF-8 encoded null terminated C string */
         b->source = js_mallocz(ctx, b->source_len + 1);
         if (!b->source)

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -1,3 +1,4 @@
+import * as std from "std";
 import * as bjson from "bjson";
 import { assert } from "./assert.js";
 
@@ -227,6 +228,25 @@ function bjson_test_symbol()
     assert(o, r);
 }
 
+function bjson_test_bytecode()
+{
+    var buf, o, r, e;
+
+    o = std.evalScript(";(function f(o){ return o.i })", {compile_only: true});
+    buf = bjson.write(o, /*JS_WRITE_OBJ_BYTECODE*/(1 << 0));
+    try {
+        bjson.read(buf, 0, buf.byteLength);
+    } catch (_e) {
+        e = _e;
+    }
+    assert(String(e), "SyntaxError: no bytecode allowed");
+
+    // can't really do anything with |o| at the moment,
+    // no way to pass it to JS_EvalFunction
+    o = bjson.read(buf, 0, buf.byteLength, /*JS_READ_OBJ_BYTECODE*/(1 << 0));
+    assert(String(o), "[function bytecode]");
+}
+
 function bjson_test_fuzz()
 {
     var corpus = [
@@ -277,6 +297,7 @@ function bjson_test_all()
     bjson_test_map();
     bjson_test_set();
     bjson_test_symbol();
+    bjson_test_bytecode();
     bjson_test_fuzz();
 }
 

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -230,7 +230,7 @@ function bjson_test_symbol()
 
 function bjson_test_bytecode()
 {
-    var buf, o, r, e;
+    var buf, o, r, e, i;
 
     o = std.evalScript(";(function f(o){ return o.i })", {compile_only: true});
     buf = bjson.write(o, /*JS_WRITE_OBJ_BYTECODE*/(1 << 0));
@@ -241,10 +241,10 @@ function bjson_test_bytecode()
     }
     assert(String(e), "SyntaxError: no bytecode allowed");
 
-    // can't really do anything with |o| at the moment,
-    // no way to pass it to JS_EvalFunction
     o = bjson.read(buf, 0, buf.byteLength, /*JS_READ_OBJ_BYTECODE*/(1 << 0));
     assert(String(o), "[function bytecode]");
+    o = std.evalScript(o, {eval_function: true});
+    for (i = 0; i < 42; i++) o({i}); // exercise o.i IC
 }
 
 function bjson_test_fuzz()


### PR DESCRIPTION
I split this into three commits. The second one segfaults, the third one fixes that.

Interestingly, starting qjs in REPL mode segfaulted but the other bytecode tests we have don't. Not quite sure what's up with that but `bc->ic` not pointing to anything was definitely the issue though.

I added two (for now undocumented) options to `std.evalScript` that may be useful in their own right.