### PR TITLE
Eval CLI included files as scripts

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -530,7 +530,7 @@ int main(int argc, char **argv)
         }
 
         for(i = 0; i < include_count; i++) {
-            if (eval_file(ctx, include_list[i], module))
+            if (eval_file(ctx, include_list[i], 0))
                 goto fail;
         }
 


### PR DESCRIPTION
After 8cd59bf7c439e3370143924813ad6684918795c5 any file included by qjs with -I that would parse as a module is eval'd as so, which is usually not the intent, but rather to define some global functions.