### PR TITLE
Auto-detect ASan at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,6 @@ xoption(CONFIG_UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" OFF)
 
 if(CONFIG_ASAN)
 message(STATUS "Building with ASan")
-add_compile_definitions(
-    __ASAN__=1
-)
 add_compile_options(
     -fsanitize=address
     -fno-sanitize-recover=all
@@ -168,6 +165,7 @@ endif()
 
 if(CONFIG_UBSAN)
 message(STATUS "Building with UBSan")
+# __has_feature(undefined_sanitizer) or __SANITIZE_UNDEFINED__ don't exist
 add_compile_definitions(
     __UBSAN__=1
 )

--- a/cutils.h
+++ b/cutils.h
@@ -54,6 +54,14 @@ extern "C" {
 #include <pthread.h>
 #endif
 
+#if defined(__SANITIZE_ADDRESS__)
+# define __ASAN__ 1
+#elif defined(__has_feature)
+# if __has_feature(address_sanitizer)
+#  define __ASAN__ 1
+# endif
+#endif
+
 #if defined(_MSC_VER) && !defined(__clang__)
 #  define likely(x)       (x)
 #  define unlikely(x)     (x)


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/636