### PR TITLE
Allow 'undefined' in let or const declaration

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -22709,9 +22709,17 @@ static __exception int js_define_var(JSParseState *s, JSAtom name, int tok)
     &&  fd->is_strict_mode) {
         return js_parse_error(s, "invalid variable name in strict mode");
     }
-    if ((name == JS_ATOM_let || name == JS_ATOM_undefined)
-    &&  (tok == TOK_LET || tok == TOK_CONST)) {
-        return js_parse_error(s, "invalid lexical variable name");
+    if (tok == TOK_LET || tok == TOK_CONST) {
+        if (name == JS_ATOM_let)
+            return js_parse_error(s, "invalid lexical variable name 'let'");
+        // |undefined| is allowed as an identifier except at the global
+        // scope of a classic script; sloppy or strict doesn't matter
+        if (name == JS_ATOM_undefined
+        && fd->scope_level == 1
+        && fd->is_global_var
+        && !fd->module) {
+            return js_parse_error(s, "'undefined' already declared");
+        }
     }
     switch(tok) {
     case TOK_LET:

--- a/run-test262.c
+++ b/run-test262.c
@@ -1783,6 +1783,7 @@ int run_test(const char *filename, int *msec)
     char *error_type;
     int ret, eval_flags, use_strict, use_nostrict;
     BOOL is_negative, is_nostrict, is_onlystrict, is_async, is_module, skip;
+    BOOL detect_module = TRUE;
     BOOL can_block;
     namelist_t include_list = { 0 }, *ip = &include_list;
 
@@ -1837,6 +1838,9 @@ int run_test(const char *filename, int *msec)
                 else if (str_equal(option, "async")) {
                     is_async = TRUE;
                     skip |= skip_async;
+                }
+                else if (str_equal(option, "qjs:no-detect-module")) {
+                    detect_module = FALSE;
                 }
                 else if (str_equal(option, "module")) {
                     is_module = TRUE;
@@ -1920,7 +1924,7 @@ int run_test(const char *filename, int *msec)
         atomic_inc(&test_skipped);
         ret = -2;
     } else {
-        if (local) {
+        if (local && detect_module) {
             is_module = JS_DetectModule(buf, buf_len);
         }
         if (is_module) {

--- a/tests/bug633/0.js
+++ b/tests/bug633/0.js
@@ -1,0 +1,7 @@
+/*---
+flags: [qjs:no-detect-module]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+const undefined = 42 // SyntaxError at global scope

--- a/tests/bug633/1.js
+++ b/tests/bug633/1.js
@@ -1,0 +1,4 @@
+/*---
+flags: [qjs:no-detect-module, module]
+---*/
+const undefined = 42 // not a SyntaxError at toplevel module scope

--- a/tests/bug633/2.js
+++ b/tests/bug633/2.js
@@ -1,0 +1,4 @@
+/*---
+flags: [qjs:no-detect-module]
+---*/
+{ const undefined = 42 } // not a SyntaxError, not at global scope

--- a/tests/bug633/3.js
+++ b/tests/bug633/3.js
@@ -1,0 +1,4 @@
+/*---
+flags: [qjs:no-detect-module]
+---*/
+;(function() { const undefined = 42 })() // not a SyntaxError, not at global scope


### PR DESCRIPTION
Except at the global scope of a classic script because... who knows, that's just how it is.

Fixes: https://github.com/quickjs-ng/quickjs/issues/633