### PR TITLE
Don't segfault on missing line number data

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -6507,6 +6507,8 @@ static int find_line_num(JSContext *ctx, JSFunctionBytecode *b,
 
     *col = 1;
     p = b->pc2line_buf;
+    if (!p)
+        goto fail;
     p_end = p + b->pc2line_len;
     pc = 0;
     line_num = b->line_num;


### PR DESCRIPTION
Can be reproduced on the CLI but not from a script:

    # should throw "unsupported object class" TypeError
    $ qjs --std -e 'bjson.write(function(){})'
    /path/to/quickjs.c:6510:15: runtime error: applying zero offset to null pointer

Note: ASan+UBSan build.