### PR TITLE
Don't throw oob exception when setting numeric indexes on TAs

### DIFF
--- a/tests/bug645/0.js
+++ b/tests/bug645/0.js
@@ -1,0 +1,4 @@
+"use strict";
+
+const u8 = new Uint8Array(1);
+u8[100] = 123; // Should not throw.

--- a/tests/bug645/1.js
+++ b/tests/bug645/1.js
@@ -1,0 +1,9 @@
+import { assert, assertThrows } from "../assert.js";
+const ab = new ArrayBuffer(1);
+const u8 = new Uint8Array(ab);
+assert(!ab.detached);
+// Detach the ArrayBuffer.
+ab.transfer();
+assert(ab.detached);
+u8[100] = 123; // Doesn't throw.
+assertThrows(TypeError, () => Object.defineProperty(u8, "100", { value: 123 }));

--- a/tests/bug645/2.js
+++ b/tests/bug645/2.js
@@ -1,0 +1,7 @@
+import { assert, assertThrows } from "../assert.js";
+const ab = new ArrayBuffer(16, { maxByteLength: 32 });
+const u8 = new Uint8Array(ab, 16);
+ab.resize(8);
+assert(ab.byteLength, 8);
+u8[1] = 123; // Doesn't throw.
+assertThrows(TypeError, () => Object.defineProperty(u8, "1", { value: 123 }));


### PR DESCRIPTION
Relevant spec section: https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-typedarraysetelement

It should only throw if the backing buffer is detached, which test262 tests for.

Fixes: https://github.com/quickjs-ng/quickjs/issues/645