### PR TITLE
fix: WeakRef should not throw on `deref` if value is gc'ed

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -54793,9 +54793,9 @@ static JSValue js_weakref_constructor(JSContext *ctx, JSValue new_target, int ar
 
 static JSValue js_weakref_deref(JSContext *ctx, JSValue this_val, int argc, JSValue *argv)
 {
-    JSWeakRefData *wrd = JS_GetOpaque2(ctx, this_val, JS_CLASS_WEAK_REF);
+    JSWeakRefData *wrd = JS_GetOpaque(this_val, JS_CLASS_WEAK_REF);
     if (!wrd)
-        return JS_EXCEPTION;
+        return JS_UNDEFINED;
     return js_dup(wrd->target);
 }
 


### PR DESCRIPTION
Right now QuickJS throws an exception if the value WeakRef points to has been garbage collected. Instead according to MDN, we should return `undefined`.

Closes #651 