### PR TITLE
Fix exception in WeakRef.prototype.deref

### DIFF
--- a/tests/bug652.js
+++ b/tests/bug652.js
@@ -1,0 +1,4 @@
+import { assert } from "./assert.js"
+const ref = new WeakRef({})
+const val = ref.deref() // should not throw
+assert(val, undefined)


### PR DESCRIPTION
Set the object's opaque to a sentinel value instead of NULL, to stop JS_GetOpaque2 from raising an "illegal class" exception.

Fixes: https://github.com/quickjs-ng/quickjs/issues/651