### PR TITLE
Fix FinalizationRegistry refcounting bug

### DIFF
--- a/tests/bug648.js
+++ b/tests/bug648.js
@@ -1,0 +1,13 @@
+/*---
+negative:
+  phase: runtime
+  type: Error
+---*/
+let finrec = new FinalizationRegistry(v => {})
+let object = {object:"object"}
+finrec.register(object, {held:"held"}, {token:"token"})
+object = undefined
+// abrupt termination should not leak |held|
+// unfortunately only shows up in qjs, not run-test262,
+// but still good to have a regression test
+throw Error("ok")


### PR DESCRIPTION
Introduced in commit 61c8fe6 from last month that moved the callback into the job queue:

1. It leaked `fre->held_val` when no job was enqueued

2. It fumbled the reference count when enqueuing; JS_EnqueueJob already takes care of incrementing and decrementing it

Reverts commit 0a70623 from earlier today because that didn't turn out to be a complete fix.

Fixes: https://github.com/quickjs-ng/quickjs/issues/648