### PR TITLE
Don't automatically update test262 submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
       - name: test 262
         if: ${{ matrix.config.runTest262 }}
         run: |
+          git submodule update --init --checkout --depth 1
           time make test262
 
   linux-gcc48:
@@ -259,6 +260,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: build
         run: |
+          git submodule update --init --checkout --depth 1
           cmake -B build -DBUILD_EXAMPLES=ON -G "Visual Studio 17 2022" -T ClangCL
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
@@ -291,6 +293,7 @@ jobs:
           ninja.exe --version
       - name: build
         run: |
+          git submodule update --init --checkout --depth 1
           cmake -B build -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -G "Ninja"
           cmake --build build
       - name: stats

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: aarch64
@@ -19,6 +17,7 @@ jobs:
       - name: build
         shell: alpine.sh {0}
         run: |
+          git submodule update --init --checkout --depth 1
           mkdir build
           cd build
           cmake -DBUILD_STATIC_QJS_EXE=ON ..
@@ -40,8 +39,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: riscv64
@@ -49,6 +46,7 @@ jobs:
       - name: build
         shell: alpine.sh {0}
         run: |
+          git submodule update --init --checkout --depth 1
           mkdir build
           cd build
           cmake -DBUILD_STATIC_QJS_EXE=ON ..
@@ -70,8 +68,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: x86
@@ -79,6 +75,7 @@ jobs:
       - name: build
         shell: alpine.sh {0}
         run: |
+          git submodule update --init --checkout --depth 1
           mkdir build
           cd build
           cmake -DBUILD_STATIC_QJS_EXE=ON ..
@@ -101,8 +98,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: x86_64
@@ -110,6 +105,7 @@ jobs:
       - name: build
         shell: alpine.sh {0}
         run: |
+          git submodule update --init --checkout --depth 1
           mkdir build
           cd build
           cmake -DBUILD_STATIC_QJS_EXE=ON ..
@@ -132,10 +128,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: build
         run: |
+          git submodule update --init --checkout --depth 1
           mkdir build
           cd build
           cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" ..
@@ -158,8 +153,6 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -173,6 +166,7 @@ jobs:
             toolchain:p
       - name: build
         run: |
+          git submodule update --init --checkout --depth 1
           make
           mv build/qjs.exe build/qjs-windows-x86.exe
           mv build/qjsc.exe build/qjsc-windows-x86.exe
@@ -192,8 +186,6 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -207,6 +199,7 @@ jobs:
             toolchain:p
       - name: build
         run: |
+          git submodule update --init --checkout --depth 1
           make
           mv build/qjs.exe build/qjs-windows-x86_64.exe
           mv build/qjsc.exe build/qjsc-windows-x86_64.exe
@@ -223,14 +216,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: setup wasi-sdk
         run: |
           wget -nv https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk_21.0_amd64.deb -P /tmp
           sudo apt install /tmp/wasi-sdk*.deb
       - name: build
         run: |
+          git submodule update --init --checkout --depth 1
           cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake
           make -C build qjs_exe
           mv build/qjs build/qjs-wasi.wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: aarch64
@@ -38,6 +40,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: riscv64
@@ -66,6 +70,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: x86
@@ -95,6 +101,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: jirutka/setup-alpine@v1
         with:
           arch: x86_64
@@ -124,6 +132,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: build
         run: |
           mkdir build
@@ -148,6 +158,8 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -180,6 +192,8 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -209,6 +223,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: setup wasi-sdk
         run: |
           wget -nv https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk_21.0_amd64.deb -P /tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = test262
 	url = https://github.com/tc39/test262
 	shallow = true
+	update = none


### PR DESCRIPTION
When quickjs-ng now is used a dependency of rquickjs, cargo automatically pulls in all submodules when checking out sources. This causes errors on windows hosts where the filepath becomes to long:

> path too long: 'C:/Users/runneradmin/.cargo/git/checkouts/rquickjs-c5d9b5f474075f2d/9e0229a/sys/quickjs/test262/test/built-ins/Object/seal/object-seal-configurable-attribute-of-own-data-property-of-o-is-set-from-true-to-false-and-other-attributes-of-the-property-are-unaltered.js'; class=Filesystem (30)