### PR TITLE
Don't use _Thread_local in run-test262.c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           make cxxtest
 
       - name: test
-        if: ${{ matrix.config.configType != 'examples' && matrix.config.configType != 'tcc' }}
+        if: ${{ matrix.config.configType != 'examples' }}
         run: |
           make test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,14 +289,7 @@ endif()
 # Test262 runner
 #
 
-if(EMSCRIPTEN
-OR CMAKE_C_COMPILER_ID STREQUAL "TinyCC"
-OR (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 5))
-    # Empty. run-test262 uses pthreads, sorry Windows users.
-    # tcc and gcc 4.8 don't understand _Thread_local, whereas I
-    # don't understand why people still use 4.8 in this day and age
-    # but hey, here we are.
-else()
+if(NOT EMSCRIPTEN)
     add_executable(run-test262
         run-test262.c
     )

--- a/quickjs.c
+++ b/quickjs.c
@@ -298,6 +298,7 @@ struct JSRuntime {
     JSShape **shape_hash;
     bf_context_t bf_ctx;
     void *user_opaque;
+    void *libc_opaque;
     JSRuntimeFinalizerState *finalizers;
 };
 
@@ -55422,6 +55423,30 @@ BOOL JS_DetectModule(const char *input, size_t input_len)
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
     return is_module;
+}
+
+uintptr_t js_std_cmd(int cmd, ...) {
+    JSRuntime *rt;
+    uintptr_t rv;
+    va_list ap;
+
+    rv = 0;
+    va_start(ap, cmd);
+    switch (cmd) {
+    case 0: // GetOpaque
+        rt = va_arg(ap, JSRuntime *);
+        rv = (uintptr_t)rt->libc_opaque;
+        break;
+    case 1: // SetOpaque
+        rt = va_arg(ap, JSRuntime *);
+        rt->libc_opaque = va_arg(ap, void *);
+        break;
+    default:
+        rv = -1;
+    }
+    va_end(ap);
+
+    return rv;
 }
 
 #undef malloc

--- a/quickjs.h
+++ b/quickjs.h
@@ -1031,6 +1031,9 @@ JS_EXTERN int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
 
 JS_EXTERN const char* JS_GetVersion(void);
 
+/* Integration point for quickjs-libc.c, not for public use. */
+JS_EXTERN uintptr_t js_std_cmd(int cmd, ...);
+
 #undef JS_EXTERN
 #undef js_force_inline
 #undef __js_printf_like


### PR DESCRIPTION
Allows building with tcc and old gcc versions again.

Please heed the first commit where I unscrupulously add a backdoor <sub>so I can use JS_SetRuntimeOpaque in run-test262.c</sub>