### PR TITLE
Fix NULL deref in JS_NewRuntime2

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1795,14 +1795,14 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
     rt = mf->js_calloc(opaque, 1, sizeof(JSRuntime));
     if (!rt)
         return NULL;
-    /* Inline what js_malloc_rt does since we cannot use it here. */
-    ms.malloc_count++;
-    ms.malloc_size += mf->js_malloc_usable_size(rt) + MALLOC_OVERHEAD;
     rt->mf = *mf;
     if (!rt->mf.js_malloc_usable_size) {
         /* use dummy function if none provided */
         rt->mf.js_malloc_usable_size = js_malloc_usable_size_unknown;
     }
+    /* Inline what js_malloc_rt does since we cannot use it here. */
+    ms.malloc_count++;
+    ms.malloc_size += rt->mf.js_malloc_usable_size(rt) + MALLOC_OVERHEAD;
     rt->malloc_state = ms;
     rt->malloc_gc_threshold = 256 * 1024;
 


### PR DESCRIPTION
The API allows for the malloc_usable_size callback to be NULL, so it must not be dereferenced before the NULL check.