### PR TITLE
Update release CI action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  pull_request:
   push:
     tags:
       - "v*.*.*"
@@ -30,9 +31,9 @@ jobs:
         run: |
           file build/*-linux-aarch64
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-linux-aarch64
           path: build/*-linux-aarch64
   linux-riscv64:
     runs-on: ubuntu-20.04
@@ -58,9 +59,9 @@ jobs:
         run: |
           file build/*-linux-riscv64
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-linux-riscv64
           path: build/*-linux-riscv64
   linux-x86:
     runs-on: ubuntu-20.04
@@ -86,9 +87,9 @@ jobs:
         run: |
           file build/*-linux-x86
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-linux-x86
           path: build/*-linux-x86
 
   linux-x86_64:
@@ -115,9 +116,9 @@ jobs:
         run: |
           file build/*-linux-x86_64
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-linux-x86_64
           path: build/*-linux-x86_64
 
   macos:
@@ -136,9 +137,9 @@ jobs:
         run: |
           lipo -info build/qjs-darwin build/qjsc-darwin
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-darwin
           path: build/*-darwin
 
   windows-x86:
@@ -168,9 +169,9 @@ jobs:
         run: |
           ldd build/qjs-windows-x86.exe build/qjsc-windows-x86.exe
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-windows-x86
           path: build/*-windows-x86.exe
 
   windows-x86_64:
@@ -200,9 +201,9 @@ jobs:
         run: |
           ldd build/qjs-windows-x86_64.exe build/qjsc-windows-x86_64.exe
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-windows-x86_64
           path: build/*-windows-x86_64.exe
 
   wasi:
@@ -219,9 +220,9 @@ jobs:
           make -C build qjs_exe
           mv build/qjs build/qjs-wasi.wasm
       - name: upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: qjs
+          name: qjs-wasi
           path: build/qjs-wasi.wasm
 
   upload-to-release:
@@ -229,12 +230,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: get assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
+          pattern: qjs-*
           path: build
-      - name: release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            build/qjs/qjs-*
-            build/qjs/qjsc-*
+          merge-multiple: true
+      - run: ls -R build
+#      - name: release
+#        uses: softprops/action-gh-release@v1
+#        with:
+#          files: |
+#            build/qjs/qjs-*
+#            build/qjs/qjsc-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: release
 
 on:
-  pull_request:
   push:
     tags:
       - "v*.*.*"
@@ -236,9 +235,8 @@ jobs:
           path: build
           merge-multiple: true
       - run: ls -R build
-#      - name: release
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          files: |
-#            build/qjs/qjs-*
-#            build/qjs/qjsc-*
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            build/*


### PR DESCRIPTION
actions/upload-artifact@v3 will be deprecated soon. Migrate to v4.

Ref: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md