### PR TITLE
Align JS_SetOpaque with other similar APIs

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -10096,7 +10096,7 @@ void JS_ResetUncatchableError(JSContext *ctx)
     JS_SetUncatchableError(ctx, ctx->rt->current_exception, FALSE);
 }
 
-JS_BOOL JS_SetOpaque(JSValue obj, void *opaque)
+int JS_SetOpaque(JSValue obj, void *opaque)
 {
     JSObject *p;
     if (JS_VALUE_GET_TAG(obj) == JS_TAG_OBJECT) {
@@ -10108,7 +10108,7 @@ JS_BOOL JS_SetOpaque(JSValue obj, void *opaque)
         }
     }
 
-    return 1;
+    return -1;
 }
 
 /* |obj| must be a JSObject of an internal class. */

--- a/quickjs.h
+++ b/quickjs.h
@@ -755,7 +755,8 @@ JS_EXTERN int JS_DefinePropertyValueStr(JSContext *ctx, JSValue this_obj,
 JS_EXTERN int JS_DefinePropertyGetSet(JSContext *ctx, JSValue this_obj,
                                       JSAtom prop, JSValue getter, JSValue setter,
                                       int flags);
-JS_EXTERN JS_BOOL JS_SetOpaque(JSValue obj, void *opaque);
+/* Only supported for custom classes, returns 0 on success < 0 otherwise. */
+JS_EXTERN int JS_SetOpaque(JSValue obj, void *opaque);
 JS_EXTERN void *JS_GetOpaque(JSValue obj, JSClassID class_id);
 JS_EXTERN void *JS_GetOpaque2(JSContext *ctx, JSValue obj, JSClassID class_id);
 JS_EXTERN void *JS_GetAnyOpaque(JSValue obj, JSClassID *class_id);


### PR DESCRIPTION
Returns < 0 on failure. Also document it in the header file.

Fixes: https://github.com/quickjs-ng/quickjs/issues/695