### PR TITLE
Fix c++ error caused by c99 static array size

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -118,7 +118,7 @@ static void *__builtin_frame_address(unsigned int level) {
 #define container_of(ptr, type, member) ((type *)((uint8_t *)(ptr) - offsetof(type, member)))
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__cplusplus)
 #define minimum_length(n) n
 #else
 #define minimum_length(n) static n


### PR DESCRIPTION
Due to the changes in [PR 593](https://github.com/quickjs-ng/quickjs/pull/593), quickjs-ng cannot be compiled in C++ mode.

C++ does not support the `T val[static n]` array syntax, which will cause the compiler to report an error: `error: static array size is a C99 feature, not permitted in C++`(clang).

This commit avoids entering the `static n` branch in C++ mode.