### PR TITLE
Fix harmless -Wsign-compare warning

### DIFF
--- a/cutils.c
+++ b/cutils.c
@@ -190,7 +190,7 @@ int __attribute__((format(printf, 2, 3))) dbuf_printf(DynBuf *s,
     va_start(ap, fmt);
     len = vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
-    if (len < sizeof(buf)) {
+    if (len < (int)sizeof(buf)) {
         /* fast case */
         return dbuf_put(s, (uint8_t *)buf, len);
     } else {


### PR DESCRIPTION
`sizeof(buf) == 128` so the signed comparison is always within range.