### PR TITLE
Fix Date.prototype.set* when date is invalid

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -50378,7 +50378,10 @@ static JSValue set_date_field(JSContext *ctx, JSValue this_val,
         fields[first_field + i] = trunc(a);
     }
 
-    if (res && argc > 0)
+    if (!res)
+        return JS_NAN;
+
+    if (argc > 0)
         d = set_date_fields(fields, is_local);
 
     return JS_SetThisTimeValue(ctx, this_val, d);
@@ -51144,6 +51147,8 @@ static JSValue js_date_setYear(JSContext *ctx, JSValue this_val,
     if (JS_ThisTimeValue(ctx, &y, this_val) || JS_ToFloat64(ctx, &y, argv[0]))
         return JS_EXCEPTION;
     y = +y;
+    if (isnan(y))
+        return JS_SetThisTimeValue(ctx, this_val, y);
     if (isfinite(y)) {
         y = trunc(y);
         if (y >= 0 && y < 100)

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -18,30 +18,6 @@ test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-retu
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js:72: strict mode: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js:66: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js:66: strict mode: TypeError: $DONE() not called
-test262/test/built-ins/Date/prototype/setDate/date-value-read-before-tonumber-when-date-is-invalid.js:25: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setDate/date-value-read-before-tonumber-when-date-is-invalid.js:25: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setHours/date-value-read-before-tonumber-when-date-is-invalid.js:28: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setHours/date-value-read-before-tonumber-when-date-is-invalid.js:28: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js:25: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js:25: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setMinutes/date-value-read-before-tonumber-when-date-is-invalid.js:27: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setMinutes/date-value-read-before-tonumber-when-date-is-invalid.js:27: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setMonth/date-value-read-before-tonumber-when-date-is-invalid.js:26: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setMonth/date-value-read-before-tonumber-when-date-is-invalid.js:26: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setSeconds/date-value-read-before-tonumber-when-date-is-invalid.js:26: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setSeconds/date-value-read-before-tonumber-when-date-is-invalid.js:26: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCDate/date-value-read-before-tonumber-when-date-is-invalid.js:25: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCDate/date-value-read-before-tonumber-when-date-is-invalid.js:25: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCHours/date-value-read-before-tonumber-when-date-is-invalid.js:28: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCHours/date-value-read-before-tonumber-when-date-is-invalid.js:28: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js:25: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js:25: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCMinutes/date-value-read-before-tonumber-when-date-is-invalid.js:27: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCMinutes/date-value-read-before-tonumber-when-date-is-invalid.js:27: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCMonth/date-value-read-before-tonumber-when-date-is-invalid.js:26: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCMonth/date-value-read-before-tonumber-when-date-is-invalid.js:26: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCSeconds/date-value-read-before-tonumber-when-date-is-invalid.js:26: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
-test262/test/built-ins/Date/prototype/setUTCSeconds/date-value-read-before-tonumber-when-date-is-invalid.js:26: strict mode: Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true
 test262/test/built-ins/Iterator/prototype/constructor/prop-desc.js:10: Test262Error: Expected SameValue(«"undefined"», «"function"») to be true
 test262/test/built-ins/Iterator/prototype/constructor/prop-desc.js:10: strict mode: Test262Error: Expected SameValue(«"undefined"», «"function"») to be true
 test262/test/built-ins/Iterator/prototype/constructor/weird-setter.js:23: TypeError: cannot read property 'call' of undefined


### PR DESCRIPTION
setYear required special handing since calling date.setYear(NaN) has specific defined behavior.