### PR TITLE
Fixes timezone bias on Windows

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -43386,9 +43386,14 @@ static const JSCFunctionListEntry js_math_obj[] = {
    between UTC time and local time 'd' in minutes */
 static int getTimezoneOffset(int64_t time) {
 #if defined(_WIN32)
-    TIME_ZONE_INFORMATION time_zone_info;
-    GetTimeZoneInformation(&time_zone_info);
-    return (int)time_zone_info.Bias / 60;
+    DWORD r;
+    TIME_ZONE_INFORMATION t;
+    r = GetTimeZoneInformation(&t);
+    if (r == TIME_ZONE_ID_INVALID)
+        return 0;
+    if (r == TIME_ZONE_ID_DAYLIGHT)
+         return (int)(t.Bias + t.DaylightBias);
+    return (int)t.Bias;
 #else
     time_t ti;
     struct tm tm;


### PR DESCRIPTION
`GetTimeZoneInformation`returns the bias in minutes already, so no need to adjust it.

Also handle the return code since it determines if the time zone is in the daylight saving range.

Ref: https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-gettimezoneinformation
Fixes: https://github.com/saghul/txiki.js/issues/325