### PR TITLE
Update `.gitignore` for CMake and Visual Studio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ unicode/
 test262_*.txt
 .idea
 cmake-*
+.vs
+out/
+CMakeUserPresets.json
 fuzz


### PR DESCRIPTION
For Visual Studio project:
`.vs` dir contains project related files
`out` dir is default VS cmake output dir.

For CMake:
`CMakeUserPresets.json` contains local presets should be added to the .gitignore.
Ref: [cmake-presets(7)](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#id3)