### PR TITLE
Use 1 MB as the default stack size

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -3636,7 +3636,7 @@ static JSValue js_worker_ctor(JSContext *ctx, JSValue new_target,
     /* no join at the end */
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     // musl libc gives threads 80 kb stacks, much smaller than
-    // JS_DEFAULT_STACK_SIZE (256 kb)
+    // JS_DEFAULT_STACK_SIZE (1 MB)
     pthread_attr_setstacksize(&attr, 2 << 20); // 2 MB, glibc default
     ret = pthread_create(&tid, &attr, worker_func, args);
     pthread_attr_destroy(&attr);

--- a/quickjs.c
+++ b/quickjs.c
@@ -1843,9 +1843,10 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
     rt->js_class_id_alloc = JS_CLASS_INIT_COUNT;
 
     rt->stack_size = JS_DEFAULT_STACK_SIZE;
-#ifdef __ASAN__
-    rt->stack_size *= 2; // stack frames are bigger under AddressSanitizer
+#ifdef __wasi__
+    rt->stack_size = 0;
 #endif
+
     JS_UpdateStackTop(rt);
 
     rt->current_exception = JS_UNINITIALIZED;

--- a/quickjs.h
+++ b/quickjs.h
@@ -280,10 +280,8 @@ static inline JS_BOOL JS_VALUE_IS_NAN(JSValue v)
 #define JS_PROP_DEFINE_PROPERTY  (1 << 18) /* internal use */
 #define JS_PROP_REFLECT_DEFINE_PROPERTY (1 << 19) /* internal use */
 
-#if defined(__wasi__)
-#define JS_DEFAULT_STACK_SIZE 0
-#else
-#define JS_DEFAULT_STACK_SIZE (256 * 1024)
+#ifndef JS_DEFAULT_STACK_SIZE
+#define JS_DEFAULT_STACK_SIZE (1024 * 1024)
 #endif
 
 /* JS_Eval() flags */

--- a/run-test262.c
+++ b/run-test262.c
@@ -515,7 +515,7 @@ static JSValue js_evalScript_262(JSContext *ctx, JSValue this_val,
 static void start_thread(js_thread_t *thrd, void *(*start)(void *), void *arg)
 {
     // musl libc gives threads 80 kb stacks, much smaller than
-    // JS_DEFAULT_STACK_SIZE (256 kb)
+    // JS_DEFAULT_STACK_SIZE (1 MB)
     static const unsigned stacksize = 2 << 20; // 2 MB, glibc default
 #ifdef _WIN32
     HANDLE h, cp;


### PR DESCRIPTION
In addition:

- Move the WASI override to quickjs.c
- Allow it to be user defined

Ref: https://github.com/quickjs-ng/quickjs/issues/749#issuecomment-2540167690