### PR TITLE
Add typed array utility functions

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -52448,6 +52448,16 @@ static JSValue js_typed_array_get_byteOffset(JSContext *ctx, JSValue this_val)
     return js_uint32(ta->offset);
 }
 
+JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
+                         JSTypedArrayEnum type)
+{
+    if (type < JS_TYPED_ARRAY_UINT8C || type > JS_TYPED_ARRAY_FLOAT64)
+        return JS_ThrowRangeError(ctx, "invalid typed array type");
+
+    return js_typed_array_constructor(ctx, JS_UNDEFINED, argc, argv,
+                                      JS_CLASS_UINT8C_ARRAY + type);
+}
+
 /* Return the buffer associated to the typed array or an exception if
    it is not a typed array or if the buffer is detached. pbyte_offset,
    pbyte_length or pbytes_per_element can be NULL. */
@@ -54755,8 +54765,57 @@ JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len)
     return js_new_uint8array(ctx, buffer);
 }
 
+JS_BOOL JS_IsTypedArray(JSValue obj) {
+    JSClassID class_id = JS_GetClassID(obj);
+    return class_id >= JS_CLASS_INT8_ARRAY && class_id <= JS_CLASS_FLOAT64_ARRAY;
+}
+
+JS_BOOL JS_isUint8ClampedArray(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_UINT8C_ARRAY;
+}
+
+JS_BOOL JS_IsInt8Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_INT8_ARRAY;
+}
+
 JS_BOOL JS_IsUint8Array(JSValue obj) {
     return JS_GetClassID(obj) == JS_CLASS_UINT8_ARRAY;
+}
+
+JS_BOOL JS_IsInt16Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_INT16_ARRAY;
+}
+
+JS_BOOL JS_IsUint16Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_UINT16_ARRAY;
+}
+
+JS_BOOL JS_IsInt32Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_INT32_ARRAY;
+}
+
+JS_BOOL JS_IsUint32Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_UINT32_ARRAY;
+}
+
+JS_BOOL JS_IsBigInt64Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_BIG_INT64_ARRAY;
+}
+
+JS_BOOL JS_IsBigUint64Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_BIG_UINT64_ARRAY;
+}
+
+JS_BOOL JS_IsFloat16Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_FLOAT16_ARRAY;
+}
+
+JS_BOOL JS_IsFloat32Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_FLOAT32_ARRAY;
+}
+
+JS_BOOL JS_IsFloat64Array(JSValue obj) {
+    return JS_GetClassID(obj) == JS_CLASS_FLOAT64_ARRAY;
 }
 
 /* Atomics */

--- a/quickjs.c
+++ b/quickjs.c
@@ -54768,9 +54768,10 @@ JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len)
 int JS_GetTypedArrayType(JSValue obj)
 {
     JSClassID class_id = JS_GetClassID(obj);
-    int mask = -((class_id >= JS_CLASS_UINT8C_ARRAY) & (class_id <= JS_CLASS_FLOAT64_ARRAY));
-    int offset = (class_id - JS_CLASS_UINT8C_ARRAY) & mask;
-    return offset | (~mask & -1);
+    if (class_id >= JS_CLASS_UINT8C_ARRAY && class_id <= JS_CLASS_FLOAT64_ARRAY)
+        return class_id - JS_CLASS_UINT8C_ARRAY;
+    else
+        return -1;
 }
 
 /* Atomics */

--- a/quickjs.c
+++ b/quickjs.c
@@ -52448,7 +52448,7 @@ static JSValue js_typed_array_get_byteOffset(JSContext *ctx, JSValue this_val)
     return js_uint32(ta->offset);
 }
 
-JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
+JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValue *argv,
                          JSTypedArrayEnum type)
 {
     if (type < JS_TYPED_ARRAY_UINT8C || type > JS_TYPED_ARRAY_FLOAT64)

--- a/quickjs.c
+++ b/quickjs.c
@@ -54765,57 +54765,12 @@ JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len)
     return js_new_uint8array(ctx, buffer);
 }
 
-JS_BOOL JS_IsTypedArray(JSValue obj) {
+int JS_GetTypedArrayType(JSValue obj)
+{
     JSClassID class_id = JS_GetClassID(obj);
-    return class_id >= JS_CLASS_INT8_ARRAY && class_id <= JS_CLASS_FLOAT64_ARRAY;
-}
-
-JS_BOOL JS_isUint8ClampedArray(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_UINT8C_ARRAY;
-}
-
-JS_BOOL JS_IsInt8Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_INT8_ARRAY;
-}
-
-JS_BOOL JS_IsUint8Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_UINT8_ARRAY;
-}
-
-JS_BOOL JS_IsInt16Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_INT16_ARRAY;
-}
-
-JS_BOOL JS_IsUint16Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_UINT16_ARRAY;
-}
-
-JS_BOOL JS_IsInt32Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_INT32_ARRAY;
-}
-
-JS_BOOL JS_IsUint32Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_UINT32_ARRAY;
-}
-
-JS_BOOL JS_IsBigInt64Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_BIG_INT64_ARRAY;
-}
-
-JS_BOOL JS_IsBigUint64Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_BIG_UINT64_ARRAY;
-}
-
-JS_BOOL JS_IsFloat16Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_FLOAT16_ARRAY;
-}
-
-JS_BOOL JS_IsFloat32Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_FLOAT32_ARRAY;
-}
-
-JS_BOOL JS_IsFloat64Array(JSValue obj) {
-    return JS_GetClassID(obj) == JS_CLASS_FLOAT64_ARRAY;
+    int mask = -((class_id >= JS_CLASS_UINT8C_ARRAY) & (class_id <= JS_CLASS_FLOAT64_ARRAY));
+    int offset = (class_id - JS_CLASS_UINT8C_ARRAY) & mask;
+    return offset | (~mask & -1);
 }
 
 /* Atomics */

--- a/quickjs.h
+++ b/quickjs.h
@@ -793,7 +793,7 @@ typedef enum JSTypedArrayEnum {
     JS_TYPED_ARRAY_FLOAT64,
 } JSTypedArrayEnum;
 
-JS_EXTERN JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
+JS_EXTERN JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValue *argv,
                          JSTypedArrayEnum array_type);
 JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
                                          size_t *pbyte_offset,

--- a/quickjs.h
+++ b/quickjs.h
@@ -788,6 +788,7 @@ typedef enum JSTypedArrayEnum {
     JS_TYPED_ARRAY_UINT32,
     JS_TYPED_ARRAY_BIG_INT64,
     JS_TYPED_ARRAY_BIG_UINT64,
+    JS_TYPED_ARRAY_FLOAT16,
     JS_TYPED_ARRAY_FLOAT32,
     JS_TYPED_ARRAY_FLOAT64,
 } JSTypedArrayEnum;
@@ -801,19 +802,8 @@ JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
 JS_EXTERN JSValue JS_NewUint8Array(JSContext *ctx, uint8_t *buf, size_t len,
                                    JSFreeArrayBufferDataFunc *free_func, void *opaque,
                                    JS_BOOL is_shared);
-JS_EXTERN JS_BOOL JS_IsTypedArray(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsUint8ClampedArray(JSValue obj); 
-JS_EXTERN JS_BOOL JS_IsInt8Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsUint8Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsInt16Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsUint16Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsInt32Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsUint32Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsBigInt64Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsBigUint64Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsFloat16Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsFloat32Array(JSValue obj);
-JS_EXTERN JS_BOOL JS_IsFloat64Array(JSValue obj);
+/* returns -1 if not a typed array otherwise return a JSTypedArrayEnum value */
+JS_EXTERN int JS_GetTypedArrayType(JSValue obj);
 JS_EXTERN JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len);
 typedef struct {
     void *(*sab_alloc)(void *opaque, size_t size);

--- a/quickjs.h
+++ b/quickjs.h
@@ -777,6 +777,23 @@ JS_EXTERN void JS_DetachArrayBuffer(JSContext *ctx, JSValue obj);
 JS_EXTERN uint8_t *JS_GetArrayBuffer(JSContext *ctx, size_t *psize, JSValue obj);
 JS_EXTERN JS_BOOL JS_IsArrayBuffer(JSValue obj);
 JS_EXTERN uint8_t *JS_GetUint8Array(JSContext *ctx, size_t *psize, JSValue obj);
+
+typedef enum JSTypedArrayEnum {
+    JS_TYPED_ARRAY_UINT8C = 0,
+    JS_TYPED_ARRAY_INT8,
+    JS_TYPED_ARRAY_UINT8,
+    JS_TYPED_ARRAY_INT16,
+    JS_TYPED_ARRAY_UINT16,
+    JS_TYPED_ARRAY_INT32,
+    JS_TYPED_ARRAY_UINT32,
+    JS_TYPED_ARRAY_BIG_INT64,
+    JS_TYPED_ARRAY_BIG_UINT64,
+    JS_TYPED_ARRAY_FLOAT32,
+    JS_TYPED_ARRAY_FLOAT64,
+} JSTypedArrayEnum;
+
+JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
+                         JSTypedArrayEnum array_type);
 JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
                                          size_t *pbyte_offset,
                                          size_t *pbyte_length,
@@ -784,7 +801,19 @@ JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
 JS_EXTERN JSValue JS_NewUint8Array(JSContext *ctx, uint8_t *buf, size_t len,
                                    JSFreeArrayBufferDataFunc *free_func, void *opaque,
                                    JS_BOOL is_shared);
+JS_EXTERN JS_BOOL JS_IsTypedArray(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsUint8ClampedArray(JSValue obj); 
+JS_EXTERN JS_BOOL JS_IsInt8Array(JSValue obj);
 JS_EXTERN JS_BOOL JS_IsUint8Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsInt16Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsUint16Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsInt32Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsUint32Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsBigInt64Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsBigUint64Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsFloat16Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsFloat32Array(JSValue obj);
+JS_EXTERN JS_BOOL JS_IsFloat64Array(JSValue obj);
 JS_EXTERN JSValue JS_NewUint8ArrayCopy(JSContext *ctx, const uint8_t *buf, size_t len);
 typedef struct {
     void *(*sab_alloc)(void *opaque, size_t size);

--- a/quickjs.h
+++ b/quickjs.h
@@ -792,7 +792,7 @@ typedef enum JSTypedArrayEnum {
     JS_TYPED_ARRAY_FLOAT64,
 } JSTypedArrayEnum;
 
-JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
+JS_EXTERN JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
                          JSTypedArrayEnum array_type);
 JS_EXTERN JSValue JS_GetTypedArrayBuffer(JSContext *ctx, JSValue obj,
                                          size_t *pbyte_offset,


### PR DESCRIPTION
Expose a few utility functions to check and create typed arrays. Also add `JS_NewTypedArray` from upstream.

Fixes https://github.com/quickjs-ng/quickjs/issues/758

