### PR TITLE
Add string eq function

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1273,10 +1273,8 @@ static JSValue js_promise_resolve(JSContext *ctx, JSValue this_val,
                                   int argc, JSValue *argv, int magic);
 static JSValue js_promise_then(JSContext *ctx, JSValueConst this_val,
                                int argc, JSValueConst *argv);
-static BOOL js_string_eq(JSContext *ctx,
-                             const JSString *p1, const JSString *p2);
-static int js_string_compare(JSContext *ctx,
-                             const JSString *p1, const JSString *p2);
+static BOOL js_string_eq(const JSString *p1, const JSString *p2);
+static int js_string_compare(const JSString *p1, const JSString *p2);
 static JSValue JS_ToNumber(JSContext *ctx, JSValue val);
 static int JS_SetPropertyValue(JSContext *ctx, JSValue this_obj,
                                JSValue prop, JSValue val, int flags);
@@ -3369,7 +3367,7 @@ static JSValue JS_AtomIsNumericIndex1(JSContext *ctx, JSAtom atom)
         JS_FreeValue(ctx, num);
         return str;
     }
-    ret = js_string_eq(ctx, p, JS_VALUE_GET_STRING(str));
+    ret = js_string_eq(p, JS_VALUE_GET_STRING(str));
     JS_FreeValue(ctx, str);
     if (ret) {
         return num;
@@ -4278,15 +4276,14 @@ static int js_string_memcmp(const JSString *p1, const JSString *p2, int len)
     return res;
 }
 
-static BOOL js_string_eq(JSContext *ctx, const JSString *p1, const JSString *p2) {
+static BOOL js_string_eq(const JSString *p1, const JSString *p2) {
     if (p1->len != p2->len)
         return FALSE;
     return js_string_memcmp(p1, p2, p1->len) == 0;
 }
 
 /* return < 0, 0 or > 0 */
-static int js_string_compare(JSContext *ctx,
-                             const JSString *p1, const JSString *p2)
+static int js_string_compare(const JSString *p1, const JSString *p2)
 {
     int res, len;
     len = min_int(p1->len, p2->len);
@@ -12947,7 +12944,7 @@ static no_inline int js_relational_slow(JSContext *ctx, JSValue *sp,
         JSString *p1, *p2;
         p1 = JS_VALUE_GET_STRING(op1);
         p2 = JS_VALUE_GET_STRING(op2);
-        res = js_string_compare(ctx, p1, p2);
+        res = js_string_compare(p1, p2);
         switch(op) {
         case OP_lt:
             res = (res < 0);
@@ -13238,7 +13235,7 @@ static BOOL js_strict_eq2(JSContext *ctx, JSValue op1, JSValue op2,
             } else {
                 p1 = JS_VALUE_GET_STRING(op1);
                 p2 = JS_VALUE_GET_STRING(op2);
-                res = js_string_eq(ctx, p1, p2);
+                res = js_string_eq(p1, p2);
             }
         }
         break;
@@ -26882,7 +26879,7 @@ static int exported_names_cmp(const void *p1, const void *p2, void *opaque)
         /* XXX: raise an error ? */
         ret = 0;
     } else {
-        ret = js_string_compare(ctx, JS_VALUE_GET_STRING(str1),
+        ret = js_string_compare(JS_VALUE_GET_STRING(str1),
                                 JS_VALUE_GET_STRING(str2));
     }
     JS_FreeValue(ctx, str1);
@@ -39804,7 +39801,7 @@ static int js_array_cmp_generic(const void *a, const void *b, void *opaque) {
                 goto exception;
             bp->str = JS_VALUE_GET_STRING(str);
         }
-        cmp = js_string_compare(ctx, ap->str, bp->str);
+        cmp = js_string_compare(ap->str, bp->str);
     }
     if (cmp != 0)
         return cmp;

--- a/quickjs.c
+++ b/quickjs.c
@@ -1273,6 +1273,8 @@ static JSValue js_promise_resolve(JSContext *ctx, JSValue this_val,
                                   int argc, JSValue *argv, int magic);
 static JSValue js_promise_then(JSContext *ctx, JSValueConst this_val,
                                int argc, JSValueConst *argv);
+static BOOL js_string_eq(JSContext *ctx,
+                             const JSString *p1, const JSString *p2);
 static int js_string_compare(JSContext *ctx,
                              const JSString *p1, const JSString *p2);
 static JSValue JS_ToNumber(JSContext *ctx, JSValue val);
@@ -3367,9 +3369,9 @@ static JSValue JS_AtomIsNumericIndex1(JSContext *ctx, JSAtom atom)
         JS_FreeValue(ctx, num);
         return str;
     }
-    ret = js_string_compare(ctx, p, JS_VALUE_GET_STRING(str));
+    ret = js_string_eq(ctx, p, JS_VALUE_GET_STRING(str));
     JS_FreeValue(ctx, str);
-    if (ret == 0) {
+    if (ret) {
         return num;
     } else {
         JS_FreeValue(ctx, num);
@@ -4274,6 +4276,12 @@ static int js_string_memcmp(const JSString *p1, const JSString *p2, int len)
             res = memcmp16(p1->u.str16, p2->u.str16, len);
     }
     return res;
+}
+
+static BOOL js_string_eq(JSContext *ctx, const JSString *p1, const JSString *p2) {
+    if (p1->len != p2->len)
+        return false;
+    return js_string_memcmp(p1, p2, p1->len) == 0;
 }
 
 /* return < 0, 0 or > 0 */
@@ -13230,7 +13238,7 @@ static BOOL js_strict_eq2(JSContext *ctx, JSValue op1, JSValue op2,
             } else {
                 p1 = JS_VALUE_GET_STRING(op1);
                 p2 = JS_VALUE_GET_STRING(op2);
-                res = (js_string_compare(ctx, p1, p2) == 0);
+                res = js_string_eq(ctx, p1, p2);
             }
         }
         break;

--- a/quickjs.c
+++ b/quickjs.c
@@ -4280,7 +4280,7 @@ static int js_string_memcmp(const JSString *p1, const JSString *p2, int len)
 
 static BOOL js_string_eq(JSContext *ctx, const JSString *p1, const JSString *p2) {
     if (p1->len != p2->len)
-        return false;
+        return FALSE;
     return js_string_memcmp(p1, p2, p1->len) == 0;
 }
 


### PR DESCRIPTION
This function avoids checking equality in string if length already missmatches.
Not super critical but if we have a lot of common prefixes with different lengths this is be beneficial. 