### PR TITLE
Fix compilation of quickjs-libc under emscripten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
         run: emcc -v
       - name: build
         run: |
-          emcmake cmake -B build
+          emcmake cmake -B build -DBUILD_QJS_LIBC=ON
           emmake make -C build qjs_wasm -j$(getconf _NPROCESSORS_ONLN)
       - name: result
         run: ls -lh build

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -3037,7 +3037,7 @@ static int my_execvpe(const char *filename, char **argv, char **envp)
 
 static void (*js_os_exec_closefrom)(int);
 
-#ifndef EMSCRIPTEN
+#if !defined(EMSCRIPTEN) && !defined(__wasi__)
 
 static js_once_t js_os_exec_once = JS_ONCE_INIT;
 
@@ -3167,7 +3167,7 @@ static JSValue js_os_exec(JSContext *ctx, JSValue this_val,
         }
     }
 
-#ifndef EMSCRIPTEN
+#if !defined(EMSCRIPTEN) && !defined(__wasi__)
     // should happen pre-fork because it calls dlsym()
     // and that's not an async-signal-safe function
     js_once(&js_os_exec_once, js_os_exec_once_init);


### PR DESCRIPTION
The addition of `js_once` calls to `js_os_exec` is causing compilation errors under emscripten with:
```
./quickjs/quickjs-libc.c:3038:8: error: unknown type name 'js_once_t'
 3038 | static js_once_t js_os_exec_once = JS_ONCE_INIT;
      |        ^
./quickjs/quickjs-libc.c:3038:36: error: use of undeclared identifier 'JS_ONCE_INIT'
 3038 | static js_once_t js_os_exec_once = JS_ONCE_INIT;
      |                                    ^
./quickjs/quickjs-libc.c:3168:5: error: call to undeclared function 'js_once'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 3168 |     js_once(&js_os_exec_once, js_os_exec_once_init);
      |     ^
```

This PR just gates the initialisation behind `ifdefs` so that it falls back to the non-threaded codepath gracefully.

I've also added quickjs-libc to the emscripten CI so that the changes are tested.

Thanks!