### PR TITLE
Update stack limit in ASan builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,10 +165,6 @@ endif()
 
 if(CONFIG_UBSAN)
 message(STATUS "Building with UBSan")
-# __has_feature(undefined_sanitizer) or __SANITIZE_UNDEFINED__ don't exist
-add_compile_definitions(
-    __UBSAN__=1
-)
 add_compile_options(
     -fsanitize=undefined
     -fno-sanitize-recover=all

--- a/cutils.h
+++ b/cutils.h
@@ -54,14 +54,6 @@ extern "C" {
 #include <pthread.h>
 #endif
 
-#if defined(__SANITIZE_ADDRESS__)
-# define __ASAN__ 1
-#elif defined(__has_feature)
-# if __has_feature(address_sanitizer)
-#  define __ASAN__ 1
-# endif
-#endif
-
 #if defined(_MSC_VER) && !defined(__clang__)
 #  define likely(x)       (x)
 #  define unlikely(x)     (x)

--- a/qjs.c
+++ b/qjs.c
@@ -208,9 +208,6 @@ static const JSCFunctionListEntry navigator_proto_funcs[] = {
 
 static const JSCFunctionListEntry global_obj[] = {
     JS_CFUNC_DEF("gc", 0, js_gc),
-#if defined(__ASAN__) || defined(__UBSAN__)
-    JS_PROP_INT32_DEF("__running_with_sanitizer__", 1, JS_PROP_C_W_E ),
-#endif
 };
 
 /* also used to initialize the worker context */

--- a/quickjs.c
+++ b/quickjs.c
@@ -2517,7 +2517,7 @@ JSRuntime *JS_GetRuntime(JSContext *ctx)
 
 static void update_stack_limit(JSRuntime *rt)
 {
-#if defined(__wasi__) || (defined(__ASAN__) && !defined(NDEBUG))
+#if defined(__wasi__)
     rt->stack_limit = 0; /* no limit */
 #else
     if (rt->stack_size == 0) {

--- a/tests/bug775.js
+++ b/tests/bug775.js
@@ -1,0 +1,7 @@
+/*---
+negative:
+  phase: runtime
+  type: RangeError
+---*/
+function f() { f() } // was problematic under ASan
+f()

--- a/tests/bug776.js
+++ b/tests/bug776.js
@@ -1,0 +1,7 @@
+/*---
+negative:
+  phase: runtime
+  type: RangeError
+---*/
+function f() { f.apply(null) } // was problematic under ASan
+f()

--- a/tests/test_std.js
+++ b/tests/test_std.js
@@ -258,8 +258,6 @@ function test_timeout()
 
 function test_timeout_order()
 {
-    if (globalThis.__running_with_sanitizer__) return;
-
     var s = "";
     os.setTimeout(a, 0);
     os.setTimeout(b, 100);


### PR DESCRIPTION
Otherwise recursive calls keep going until they trip ASan checks.

Remove the `__ASAN__` and `__UBSAN__` defines; no longer necessary.

Remove `globalThis.__running_with_sanitizer__` from qjs; likewise.

Fixes: https://github.com/quickjs-ng/quickjs/issues/671
Fixes: https://github.com/quickjs-ng/quickjs/issues/775
Fixes: https://github.com/quickjs-ng/quickjs/issues/776