### PR TITLE
Fix comment of JS_NewClassID

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -3519,7 +3519,7 @@ static inline BOOL JS_IsEmptyString(JSValue v)
 
 /* JSClass support */
 
-/* a new class ID is allocated if *pclass_id != 0 */
+/* a new class ID is allocated if *pclass_id == 0, otherwise *pclass_id is left unchanged */
 JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id)
 {
     JSClassID class_id = *pclass_id;


### PR DESCRIPTION
The comment of the function JS_NewClassID is wrong. This patch fix it.

Best regards 