### PR TITLE
Make js_get_stack_pointer more portable

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -62,10 +62,6 @@ extern "C" {
 #  define __maybe_unused
 #  define __attribute__(x)
 #  define __attribute(x)
-#  include <intrin.h>
-static void *__builtin_frame_address(unsigned int level) {
-    return (void *)((char*)_AddressOfReturnAddress() - sizeof(int *) - level * sizeof(int *));
-}
 #else
 #  define likely(x)       __builtin_expect(!!(x), 1)
 #  define unlikely(x)     __builtin_expect(!!(x), 0)

--- a/quickjs.c
+++ b/quickjs.c
@@ -1778,9 +1778,7 @@ static int init_class_range(JSRuntime *rt, JSClassShortDef const *tab,
 /* Uses code from LLVM project. */
 static inline uintptr_t js_get_stack_pointer(void)
 {
-#if defined(__has_builtin) && __has_builtin(__builtin_frame_address)
-    return (uintptr_t)__builtin_frame_address(0);
-#elif defined(__GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
     return (uintptr_t)__builtin_frame_address(0);
 #elif defined(_MSC_VER)
     return (uintptr_t)_AddressOfReturnAddress();

--- a/quickjs.c
+++ b/quickjs.c
@@ -1774,10 +1774,25 @@ static int init_class_range(JSRuntime *rt, JSClassShortDef const *tab,
     return 0;
 }
 
-/* Note: OS and CPU dependent */
+/* Uses code from LLVM project. */
 static inline uintptr_t js_get_stack_pointer(void)
 {
+#ifdef _MSC_VER
+    return (uintptr_t)_AddressOfReturnAddress();
+#elif defined(__has_builtin) && __has_builtin(__builtin_frame_address)
     return (uintptr_t)__builtin_frame_address(0);
+#elif defined(__GNUC__)
+    return (uintptr_t)__builtin_frame_address(0);
+#else
+    char CharOnStack = 0;
+    // The volatile store here is intended to escape the local variable, to
+    // prevent the compiler from optimizing CharOnStack into anything other
+    // than a char on the stack.
+    //
+    // Tested on: MSVC 2015 - 2019, GCC 4.9 - 9, Clang 3.2 - 9, ICC 13 - 19.
+    char *volatile Ptr = &CharOnStack;
+    return (uintptr_t) Ptr;
+#endif
 }
 
 static inline BOOL js_check_stack_overflow(JSRuntime *rt, size_t alloca_size)

--- a/quickjs.c
+++ b/quickjs.c
@@ -33,6 +33,7 @@
 #if !defined(_MSC_VER)
 #include <sys/time.h>
 #if defined(_WIN32)
+#include <intrin.h>
 #include <timezoneapi.h>
 #endif
 #endif

--- a/quickjs.c
+++ b/quickjs.c
@@ -1778,12 +1778,12 @@ static int init_class_range(JSRuntime *rt, JSClassShortDef const *tab,
 /* Uses code from LLVM project. */
 static inline uintptr_t js_get_stack_pointer(void)
 {
-#ifdef _MSC_VER
-    return (uintptr_t)_AddressOfReturnAddress();
-#elif defined(__has_builtin) && __has_builtin(__builtin_frame_address)
+#if defined(__has_builtin) && __has_builtin(__builtin_frame_address)
     return (uintptr_t)__builtin_frame_address(0);
 #elif defined(__GNUC__)
     return (uintptr_t)__builtin_frame_address(0);
+#elif defined(_MSC_VER)
+    return (uintptr_t)_AddressOfReturnAddress();
 #else
     char CharOnStack = 0;
     // The volatile store here is intended to escape the local variable, to


### PR DESCRIPTION
By using code from LLVM.

https://github.com/llvm/llvm-project/blob/3f7905733820851bc4f65cb4af693c3101cbf20d/clang/lib/Basic/Stack.cpp#L23-L38