### PR TITLE
Make build_backtrace public

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -6622,9 +6622,9 @@ static const char *get_func_name(JSContext *ctx, JSValue func)
 
 /* if filename != NULL, an additional level is added with the filename
    and line number information (used for parse error). */
-static void build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
-                            const char *filename, int line_num, int col_num,
-                            int backtrace_flags)
+void build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
+                     const char *filename, int line_num, int col_num,
+                     int backtrace_flags)
 {
     JSStackFrame *sf, *sf_start;
     JSValue stack, prepare, saved_exception;

--- a/quickjs.c
+++ b/quickjs.c
@@ -6622,9 +6622,9 @@ static const char *get_func_name(JSContext *ctx, JSValue func)
 
 /* if filename != NULL, an additional level is added with the filename
    and line number information (used for parse error). */
-void build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
-                     const char *filename, int line_num, int col_num,
-                     int backtrace_flags)
+void js_build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
+                        const char *filename, int line_num, int col_num,
+                        int backtrace_flags)
 {
     JSStackFrame *sf, *sf_start;
     JSValue stack, prepare, saved_exception;
@@ -6831,7 +6831,7 @@ static JSValue JS_MakeError(JSContext *ctx, JSErrorEnum error_num,
                                JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
     }
     if (add_backtrace)
-        build_backtrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, 0);
+        js_build_backtrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, 0);
     return obj;
 }
 
@@ -17417,7 +17417,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValue func_obj,
            before if the exception happens in a bytecode
            operation */
         sf->cur_pc = pc;
-        build_backtrace(ctx, rt->current_exception, JS_UNDEFINED, NULL, 0, 0, 0);
+        js_build_backtrace(ctx, rt->current_exception, JS_UNDEFINED, NULL, 0, 0, 0);
     }
     if (!JS_IsUncatchableError(ctx, rt->current_exception)) {
         while (sp > stack_buf) {
@@ -19006,8 +19006,8 @@ int __attribute__((format(printf, 2, 3))) js_parse_error(JSParseState *s, const 
     backtrace_flags = 0;
     if (s->cur_func && s->cur_func->backtrace_barrier)
         backtrace_flags = JS_BACKTRACE_FLAG_SINGLE_LEVEL;
-    build_backtrace(ctx, ctx->rt->current_exception, JS_UNDEFINED, s->filename,
-                    s->line_num, s->col_num, backtrace_flags);
+    js_build_backtrace(ctx, ctx->rt->current_exception, JS_UNDEFINED, s->filename,
+                       s->line_num, s->col_num, backtrace_flags);
     return -1;
 }
 
@@ -23479,11 +23479,11 @@ static __exception int js_parse_postfix_expr(JSParseState *s, int parse_flags)
                 backtrace_flags = 0;
                 if (s->cur_func && s->cur_func->backtrace_barrier)
                     backtrace_flags = JS_BACKTRACE_FLAG_SINGLE_LEVEL;
-                build_backtrace(s->ctx, s->ctx->rt->current_exception, JS_UNDEFINED,
-                                s->filename,
-                                s->token.line_num,
-                                s->token.col_num,
-                                backtrace_flags);
+                js_build_backtrace(s->ctx, s->ctx->rt->current_exception, JS_UNDEFINED,
+                                   s->filename,
+                                   s->token.line_num,
+                                   s->token.col_num,
+                                   backtrace_flags);
                 return -1;
             }
             ret = emit_push_const(s, str, 0);
@@ -37923,7 +37923,7 @@ static JSValue js_error_constructor(JSContext *ctx, JSValue new_target,
     }
 
     /* skip the Error() function in the backtrace */
-    build_backtrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL);
+    js_build_backtrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL);
     return obj;
  exception:
     JS_FreeValue(ctx, obj);
@@ -38019,7 +38019,7 @@ static JSValue js_error_capture_stack_trace(JSContext *ctx, JSValue this_val,
     JSValue v = argv[0];
     if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
         return JS_ThrowTypeErrorNotAnObject(ctx);
-    build_backtrace(ctx, v, argv[1], NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL|JS_BACKTRACE_FLAG_FILTER_FUNC);
+    js_build_backtrace(ctx, v, argv[1], NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL|JS_BACKTRACE_FLAG_FILTER_FUNC);
     return JS_UNDEFINED;
 }
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -6622,7 +6622,7 @@ static const char *get_func_name(JSContext *ctx, JSValue func)
 
 /* if filename != NULL, an additional level is added with the filename
    and line number information (used for parse error). */
-void js_build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
+void JS_BuildBacktrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
                         const char *filename, int line_num, int col_num,
                         int backtrace_flags)
 {
@@ -6831,7 +6831,7 @@ static JSValue JS_MakeError(JSContext *ctx, JSErrorEnum error_num,
                                JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
     }
     if (add_backtrace)
-        js_build_backtrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, 0);
+        JS_BuildBacktrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, 0);
     return obj;
 }
 
@@ -17417,7 +17417,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValue func_obj,
            before if the exception happens in a bytecode
            operation */
         sf->cur_pc = pc;
-        js_build_backtrace(ctx, rt->current_exception, JS_UNDEFINED, NULL, 0, 0, 0);
+        JS_BuildBacktrace(ctx, rt->current_exception, JS_UNDEFINED, NULL, 0, 0, 0);
     }
     if (!JS_IsUncatchableError(ctx, rt->current_exception)) {
         while (sp > stack_buf) {
@@ -19006,7 +19006,7 @@ int __attribute__((format(printf, 2, 3))) js_parse_error(JSParseState *s, const 
     backtrace_flags = 0;
     if (s->cur_func && s->cur_func->backtrace_barrier)
         backtrace_flags = JS_BACKTRACE_FLAG_SINGLE_LEVEL;
-    js_build_backtrace(ctx, ctx->rt->current_exception, JS_UNDEFINED, s->filename,
+    JS_BuildBacktrace(ctx, ctx->rt->current_exception, JS_UNDEFINED, s->filename,
                        s->line_num, s->col_num, backtrace_flags);
     return -1;
 }
@@ -23479,7 +23479,7 @@ static __exception int js_parse_postfix_expr(JSParseState *s, int parse_flags)
                 backtrace_flags = 0;
                 if (s->cur_func && s->cur_func->backtrace_barrier)
                     backtrace_flags = JS_BACKTRACE_FLAG_SINGLE_LEVEL;
-                js_build_backtrace(s->ctx, s->ctx->rt->current_exception, JS_UNDEFINED,
+                JS_BuildBacktrace(s->ctx, s->ctx->rt->current_exception, JS_UNDEFINED,
                                    s->filename,
                                    s->token.line_num,
                                    s->token.col_num,
@@ -37923,7 +37923,7 @@ static JSValue js_error_constructor(JSContext *ctx, JSValue new_target,
     }
 
     /* skip the Error() function in the backtrace */
-    js_build_backtrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL);
+    JS_BuildBacktrace(ctx, obj, JS_UNDEFINED, NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL);
     return obj;
  exception:
     JS_FreeValue(ctx, obj);
@@ -38019,7 +38019,7 @@ static JSValue js_error_capture_stack_trace(JSContext *ctx, JSValue this_val,
     JSValue v = argv[0];
     if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
         return JS_ThrowTypeErrorNotAnObject(ctx);
-    js_build_backtrace(ctx, v, argv[1], NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL|JS_BACKTRACE_FLAG_FILTER_FUNC);
+    JS_BuildBacktrace(ctx, v, argv[1], NULL, 0, 0, JS_BACKTRACE_FLAG_SKIP_FIRST_LEVEL|JS_BACKTRACE_FLAG_FILTER_FUNC);
     return JS_UNDEFINED;
 }
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -1043,7 +1043,7 @@ JS_EXTERN int JS_SetModuleExport(JSContext *ctx, JSModuleDef *m, const char *exp
 JS_EXTERN int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
                                      const JSCFunctionListEntry *tab, int len);
 
-JS_EXTERN void js_build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
+JS_EXTERN void JS_BuildBacktrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
                                   const char *filename, int line_num, int col_num,
                                   int backtrace_flags);
 /* Version */

--- a/quickjs.h
+++ b/quickjs.h
@@ -1043,9 +1043,9 @@ JS_EXTERN int JS_SetModuleExport(JSContext *ctx, JSModuleDef *m, const char *exp
 JS_EXTERN int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
                                      const JSCFunctionListEntry *tab, int len);
 
-JS_EXTERN void build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
-                               const char *filename, int line_num, int col_num,
-                               int backtrace_flags);
+JS_EXTERN void js_build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
+                                  const char *filename, int line_num, int col_num,
+                                  int backtrace_flags);
 /* Version */
 
 #define QJS_VERSION_MAJOR 0

--- a/quickjs.h
+++ b/quickjs.h
@@ -1043,6 +1043,9 @@ JS_EXTERN int JS_SetModuleExport(JSContext *ctx, JSModuleDef *m, const char *exp
 JS_EXTERN int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
                                      const JSCFunctionListEntry *tab, int len);
 
+JS_EXTERN void build_backtrace(JSContext *ctx, JSValue error_obj, JSValue filter_func,
+                               const char *filename, int line_num, int col_num,
+                               int backtrace_flags);
 /* Version */
 
 #define QJS_VERSION_MAJOR 0


### PR DESCRIPTION
When using QuickJS as a JS engine it is desired sometimes to get a backtrace from outside JS and present it to user