### PR TITLE
Add JS_IsDate function

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -51266,6 +51266,13 @@ JSValue JS_NewDate(JSContext *ctx, double epoch_ms)
     return obj;
 }
 
+JS_BOOL JS_IsDate(JSValue v)
+{
+    if (JS_VALUE_GET_TAG(v) != JS_TAG_OBJECT)
+        return FALSE;
+    return JS_VALUE_GET_OBJ(v)->class_id == JS_CLASS_DATE;
+}
+
 void JS_AddIntrinsicDate(JSContext *ctx)
 {
     JSValue obj;

--- a/quickjs.h
+++ b/quickjs.h
@@ -676,6 +676,7 @@ JS_EXTERN JSValue JS_NewArray(JSContext *ctx);
 JS_EXTERN int JS_IsArray(JSContext *ctx, JSValue val);
 
 JS_EXTERN JSValue JS_NewDate(JSContext *ctx, double epoch_ms);
+JS_EXTERN JS_BOOL JS_IsDate(JSValue v);
 
 JS_EXTERN JSValue JS_GetProperty(JSContext *ctx, JSValue this_obj, JSAtom prop);
 JS_EXTERN JSValue JS_GetPropertyUint32(JSContext *ctx, JSValue this_obj,


### PR DESCRIPTION
In order to properly convert JSValue to C++ types, this function is required.