### PR TITLE
Add JS_IsRegExp function

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -10086,6 +10086,13 @@ BOOL JS_SetConstructorBit(JSContext *ctx, JSValue func_obj, BOOL val)
     return TRUE;
 }
 
+JS_BOOL JS_IsRegExp(JSValue val)
+{
+    if (JS_VALUE_GET_TAG(val) != JS_TAG_OBJECT)
+        return FALSE;
+    return JS_VALUE_GET_OBJ(val)->class_id == JS_CLASS_REGEXP;
+}
+
 BOOL JS_IsError(JSContext *ctx, JSValue val)
 {
     JSObject *p;

--- a/quickjs.h
+++ b/quickjs.h
@@ -672,6 +672,8 @@ JS_EXTERN JS_BOOL JS_IsFunction(JSContext* ctx, JSValue val);
 JS_EXTERN JS_BOOL JS_IsConstructor(JSContext* ctx, JSValue val);
 JS_EXTERN JS_BOOL JS_SetConstructorBit(JSContext *ctx, JSValue func_obj, JS_BOOL val);
 
+JS_EXTERN JS_BOOL JS_IsRegExp(JSValue val);
+
 JS_EXTERN JSValue JS_NewArray(JSContext *ctx);
 JS_EXTERN int JS_IsArray(JSContext *ctx, JSValue val);
 


### PR DESCRIPTION
When using quickJS as a library, it is sometimes desired to treat regexps specially