### PR TITLE
Disable rejected promise tracker in REPL

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -680,6 +680,7 @@ start:
                 goto fail;
         }
         if (interactive) {
+            JS_SetHostPromiseRejectionTracker(rt, NULL, NULL);
             js_std_eval_binary(ctx, qjsc_repl, qjsc_repl_size, 0);
         }
         if (standalone || compile_file) {


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/814