### PR TITLE
Add JS_SealObject and JS_FreezeObject methods

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -37208,6 +37208,22 @@ exception:
     return JS_EXCEPTION;
 }
 
+int JS_SealObject(JSContext *ctx, JSValue obj)
+{
+    JSValue value = js_object_seal(ctx, JS_UNDEFINED, 1, &obj, 0);
+    int result = JS_IsException(value) ? -1 : TRUE;
+    JS_FreeValue(ctx, value);
+    return result;
+}
+
+int JS_FreezeObject(JSContext *ctx, JSValue obj)
+{
+    JSValue value = js_object_seal(ctx, JS_UNDEFINED, 1, &obj, 1);
+    int result = JS_IsException(value) ? -1 : TRUE;
+    JS_FreeValue(ctx, value);
+    return result;
+}
+
 static JSValue js_object_fromEntries(JSContext *ctx, JSValue this_val,
                                      int argc, JSValue *argv)
 {

--- a/quickjs.h
+++ b/quickjs.h
@@ -705,6 +705,8 @@ JS_EXTERN int JS_SetPrototype(JSContext *ctx, JSValue obj, JSValue proto_val);
 JS_EXTERN JSValue JS_GetPrototype(JSContext *ctx, JSValue val);
 JS_EXTERN int JS_GetLength(JSContext *ctx, JSValue obj, int64_t *pres);
 JS_EXTERN int JS_SetLength(JSContext *ctx, JSValue obj, int64_t len);
+JS_EXTERN int JS_SealObject(JSContext *ctx, JSValue obj);
+JS_EXTERN int JS_FreezeObject(JSContext *ctx, JSValue obj);
 
 #define JS_GPN_STRING_MASK  (1 << 0)
 #define JS_GPN_SYMBOL_MASK  (1 << 1)


### PR DESCRIPTION
For optimisation, we share some huge objects in different scripts and make them "const" to prevent user from accidentally changing them.