### PR TITLE
Rework JS_SetUncatchableError

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -616,8 +616,13 @@ JS_EXTERN JSValue JS_Throw(JSContext *ctx, JSValue obj);
 JS_EXTERN JSValue JS_GetException(JSContext *ctx);
 JS_EXTERN JS_BOOL JS_HasException(JSContext *ctx);
 JS_EXTERN JS_BOOL JS_IsError(JSContext *ctx, JSValue val);
-JS_EXTERN void JS_SetUncatchableError(JSContext *ctx, JSValue val, JS_BOOL flag);
 JS_EXTERN JS_BOOL JS_IsUncatchableError(JSContext* ctx, JSValue val);
+JS_EXTERN void JS_SetUncatchableError(JSContext *ctx, JSValue val);
+JS_EXTERN void JS_ClearUncatchableError(JSContext *ctx, JSValue val);
+// Shorthand for:
+//  JSValue exc = JS_GetException(ctx);
+//  JS_ClearUncatchableError(ctx, exc);
+//  JS_Throw(ctx, exc);
 JS_EXTERN void JS_ResetUncatchableError(JSContext *ctx);
 JS_EXTERN JSValue JS_NewError(JSContext *ctx);
 JS_EXTERN JSValue __js_printf_like(2, 3) JS_ThrowPlainError(JSContext *ctx, const char *fmt, ...);


### PR DESCRIPTION
Remove the (cryptic!) `flag` argument and add JS_ClearUncatchableError.

Fixes: https://github.com/quickjs-ng/quickjs/issues/826