### PR TITLE
Add Ubuntu ARM64 runners to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - { os: ubuntu-24.04-arm, configType: Debug }
+          - { os: ubuntu-24.04-arm, configType: Release, runTest262: true }
           - { os: ubuntu-latest, configType: Debug }
           - { os: ubuntu-latest, configType: Release, runTest262: true }
           - { os: ubuntu-latest, configType: examples }
@@ -101,6 +103,9 @@ jobs:
         with:
           arch: ${{ matrix.config.arch }}
           packages: "build-base make cmake"
+
+      - name: uname
+        run: uname -a
 
       - name: Set build ENV vars
         run: |


### PR DESCRIPTION
Link: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/