### PR TITLE
Fix printf warnings on Windows

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1436,8 +1436,7 @@ static void js_trigger_gc(JSRuntime *rt, size_t size)
     if (force_gc) {
 #ifdef DUMP_GC
         if (check_dump_flag(rt, DUMP_GC)) {
-            printf("GC: size=%" PRIu64 "\n",
-                   (uint64_t)rt->malloc_state.malloc_size);
+            printf("GC: size=%zd\n", rt->malloc_state.malloc_size);
         }
 #endif
         JS_RunGC(rt);
@@ -2277,9 +2276,9 @@ void JS_FreeRuntime(JSRuntime *rt)
         if (s->malloc_count > 1) {
             if (rt->rt_info)
                 printf("%s:1: ", rt->rt_info);
-            printf("Memory leak: %"PRIu64" bytes lost in %"PRIu64" block%s\n",
-                   (uint64_t)(s->malloc_size - sizeof(JSRuntime)),
-                   (uint64_t)(s->malloc_count - 1), &"s"[s->malloc_count == 2]);
+            printf("Memory leak: %zd bytes lost in %zd block%s\n",
+                   s->malloc_size - sizeof(JSRuntime),
+                   s->malloc_count - 1, &"s"[s->malloc_count == 2]);
         }
     }
 #endif


### PR DESCRIPTION
~~~
D:\a\quickjs\quickjs\quickjs.c(1439,20): warning C4777: 'printf' : format string '%llu' requires an argument of type 'unsigned __int64', but variadic argument 1 has type 'size_t' [D:\a\quickjs\quickjs\build\qjs.vcxproj]
      D:\a\quickjs\quickjs\quickjs.c(1439,20):
      the sizes of types 'size_t' and 'unsigned __int64' might differ on other platforms
      D:\a\quickjs\quickjs\quickjs.c(1439,20):
      consider using '%zu' in the format string
~~~