### PR TITLE
Handle unprintable objects better in print()

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -3984,12 +3984,20 @@ static JSValue js_print(JSContext *ctx, JSValue this_val,
     DWORD mode;
 #endif
     const char *s;
+    JSValue v;
     DynBuf b;
     int i;
 
     dbuf_init(&b);
     for(i = 0; i < argc; i++) {
-        s = JS_ToCString(ctx, argv[i]);
+        v = argv[i];
+        s = JS_ToCString(ctx, v);
+        if (!s && JS_IsObject(v)) {
+            JS_FreeValue(ctx, JS_GetException(ctx));
+            v = JS_ToObjectString(ctx, v);
+            s = JS_ToCString(ctx, v);
+            JS_FreeValue(ctx, v);
+        }
         if (s) {
             dbuf_printf(&b, "%s%s", &" "[!i], s);
             JS_FreeCString(ctx, s);

--- a/quickjs.c
+++ b/quickjs.c
@@ -37079,6 +37079,11 @@ static JSValue js_object_toString(JSContext *ctx, JSValue this_val,
     return JS_ConcatString3(ctx, "[object ", tag, "]");
 }
 
+JSValue JS_ToObjectString(JSContext *ctx, JSValue val)
+{
+    return js_object_toString(ctx, val, 0, NULL);
+}
+
 static JSValue js_object_toLocaleString(JSContext *ctx, JSValue this_val,
                                         int argc, JSValue *argv)
 {

--- a/quickjs.h
+++ b/quickjs.h
@@ -694,6 +694,7 @@ JS_EXTERN JSValue JS_NewObjectClass(JSContext *ctx, int class_id);
 JS_EXTERN JSValue JS_NewObjectProto(JSContext *ctx, JSValue proto);
 JS_EXTERN JSValue JS_NewObject(JSContext *ctx);
 JS_EXTERN JSValue JS_ToObject(JSContext *ctx, JSValue val);
+JS_EXTERN JSValue JS_ToObjectString(JSContext *ctx, JSValue val);
 
 JS_EXTERN bool JS_IsFunction(JSContext* ctx, JSValue val);
 JS_EXTERN bool JS_IsConstructor(JSContext* ctx, JSValue val);

--- a/tests.conf
+++ b/tests.conf
@@ -4,6 +4,7 @@ verbose=yes
 testdir=tests
 
 [exclude]
+tests/empty.js
 tests/fixture_cyclic_import.js
 tests/microbench.js
 tests/test_worker_module.js

--- a/tests/bug832.js
+++ b/tests/bug832.js
@@ -1,0 +1,2 @@
+const m = await import("./empty.js")
+print(m) // should not throw


### PR DESCRIPTION
Before this commit, such objects were printed as `<exception>` because print() and console.log() had no good way to turn them into strings.

Instead perform the C equivalent of Object.prototype.toString.call(o) and print the result (which can still error but at least we tried.)

Fixes: https://github.com/quickjs-ng/quickjs/issues/832