### PR TITLE
Throw exception on out of memory in dynamic buffer

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1539,12 +1539,6 @@ void *js_realloc_rt(JSRuntime *rt, void *ptr, size_t size)
     return ptr;
 }
 
-static void *js_dbuf_realloc(void *opaque, void *ptr, size_t size)
-{
-    JSRuntime *rt = opaque;
-    return js_realloc_rt(rt, ptr, size);
-}
-
 size_t js_malloc_usable_size_rt(JSRuntime *rt, const void *ptr)
 {
     return rt->mf.js_malloc_usable_size(ptr);
@@ -1687,9 +1681,14 @@ static inline int js_resize_array(JSContext *ctx, void **parray, int elem_size,
         return 0;
 }
 
+static void *js_dbuf_realloc(void *ctx, void *ptr, size_t size)
+{
+    return js_realloc(ctx, ptr, size);
+}
+
 static inline void js_dbuf_init(JSContext *ctx, DynBuf *s)
 {
-    dbuf_init2(s, ctx->rt, js_dbuf_realloc);
+    dbuf_init2(s, ctx, js_dbuf_realloc);
 }
 
 static inline int is_digit(int c) {


### PR DESCRIPTION
js_dbuf_init users that check the return value of functions like dbuf_put should be able to assume that an OOM exception is pending when the function returns an error. No callers currently do so but I am going to start doing that in the not too distant future.

js_dbuf_init takes a JSContext pointer, strongly suggesting it calls js_realloc, but in fact it called js_realloc_rt, which does *not* raise OOM exceptions.

Call js_realloc and move js_dbuf_realloc closer to js_dbuf_init for legibility reasons.