### PR TITLE
feat: improve error report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
       - '!examples/**'
       - '.github/workflows/ci.yml'
   push:
-    branches:
-      - master
     paths:
       - '**'
       - '!.gitignore'

--- a/quickjs.c
+++ b/quickjs.c
@@ -8887,7 +8887,8 @@ retry:
             if (JS_IsFunction(ctx, val)) {
                 JSObject *vf = JS_VALUE_GET_OBJ(val);
                 if (vf->class_id == JS_CLASS_BYTECODE_FUNCTION) {
-                   const char* name = get_func_name(ctx, val);
+                   const char *name = get_func_name(ctx, val);
+                   if(name != NULL) {
                     if (strcmp(name, "") == 0) {
                         JSValue js_value = JS_AtomToValue(ctx, prop);
                         JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
@@ -8895,6 +8896,7 @@ retry:
                     }
 
                     JS_FreeCString(ctx, name);
+                   }
                }
             }
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -8888,22 +8888,14 @@ retry:
                 JSObject *vf = JS_VALUE_GET_OBJ(val);
                 if (vf->class_id == JS_CLASS_BYTECODE_FUNCTION &&
                     vf->u.func.var_refs == NULL) {
-                    JSValue name_val = JS_GetProperty(ctx, val, JS_ATOM_name);
-
-                    if (JS_IsString(name_val)) {
-                        const char *name = JS_ToCString(ctx, name_val);
-                        if (name != NULL) {
-                            if (strcmp(name, "") == 0) {
-                                JSValue js_value = JS_AtomToValue(ctx, prop);
-                                JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
-                                JS_FreeValue(ctx, js_value);
-                            }
-
-                            JS_FreeCString(ctx, name);
-                        }
-
+                   const char* name = get_func_name(ctx, val);
+                    if (strcmp(name, "") == 0) {
+                        JSValue js_value = JS_AtomToValue(ctx, prop);
+                        JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
+                        JS_FreeValue(ctx, js_value);
                     }
-                    JS_FreeValue(ctx, name_val);
+
+                    JS_FreeCString(ctx, name);
                }
             }
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -8890,7 +8890,7 @@ retry:
                    const char *name = get_func_name(ctx, val);
                    if(name && *name == '\0') {
                     JSValue js_value = JS_AtomToValue(ctx, prop);
-                    JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
+                    JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE);
 
                     JS_FreeCString(ctx, name);
                    }

--- a/quickjs.c
+++ b/quickjs.c
@@ -8886,8 +8886,7 @@ retry:
             // try give function name in every possible way
             if (JS_IsFunction(ctx, val)) {
                 JSObject *vf = JS_VALUE_GET_OBJ(val);
-                if (vf->class_id == JS_CLASS_BYTECODE_FUNCTION &&
-                    vf->u.func.var_refs == NULL) {
+                if (vf->class_id == JS_CLASS_BYTECODE_FUNCTION) {
                    const char* name = get_func_name(ctx, val);
                     if (strcmp(name, "") == 0) {
                         JSValue js_value = JS_AtomToValue(ctx, prop);

--- a/quickjs.c
+++ b/quickjs.c
@@ -8888,12 +8888,9 @@ retry:
                 JSObject *vf = JS_VALUE_GET_OBJ(val);
                 if (vf->class_id == JS_CLASS_BYTECODE_FUNCTION) {
                    const char *name = get_func_name(ctx, val);
-                   if(name != NULL) {
-                    if (strcmp(name, "") == 0) {
-                        JSValue js_value = JS_AtomToValue(ctx, prop);
-                        JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
-                        JS_FreeValue(ctx, js_value);
-                    }
+                   if(name && *name == '\0') {
+                    JSValue js_value = JS_AtomToValue(ctx, prop);
+                    JS_DefinePropertyValue(ctx, val, JS_ATOM_name, js_value, JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
 
                     JS_FreeCString(ctx, name);
                    }


### PR DESCRIPTION
fix: https://github.com/bellard/quickjs/issues/93

currently for input
```js
var dog = {};
dog.bark = function() {
  throw new Error('woof woof');
};
function makeStack() {
  try {
    dog.bark();
  } catch (error) {
    print(error.stack)
  }
}
makeStack();
```
Engine behaviour
```console 
v8:
Error: woof woof
    at dog.bark (/tmp/3df242e:3:9)
    at makeStack (/tmp/3df242e:7:9)
    at /tmp/3df242e:12:1

quickjs-ng:
    at <anonymous> (/tmp/59832ce:3:13)
    at makeStack (/tmp/59832ce:7:5)
    at <eval> (/tmp/59832ce:12:1)
```
this PR:
```
quickjs-ng:
    at bark (/tmp/59832ce:3:13)
    at makeStack (/tmp/59832ce:7:5)
    at <eval> (/tmp/59832ce:12:1)
```