### PR TITLE
Update copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
 The MIT License (MIT)
  
-Copyright (c) 2017-2021 Fabrice Bellard
-Copyright (c) 2017-2021 Charlie Gordon
-Copyright (c) 2023 Ben Noordhuis
-Copyright (c) 2023 Saúl Ibarra Corretgé
+Copyright (c) 2017-2024 Fabrice Bellard
+Copyright (c) 2017-2024 Charlie Gordon
+Copyright (c) 2023-2025 Ben Noordhuis
+Copyright (c) 2023-2025 Saúl Ibarra Corretgé
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 #
 # QuickJS Javascript Engine
 #
-# Copyright (c) 2017-2021 Fabrice Bellard
-# Copyright (c) 2017-2021 Charlie Gordon
-# Copyright (c) 2023 Ben Noordhuis
-# Copyright (c) 2023 Saúl Ibarra Corretgé
+# Copyright (c) 2017-2024 Fabrice Bellard
+# Copyright (c) 2017-2024 Charlie Gordon
+# Copyright (c) 2023-2025 Ben Noordhuis
+# Copyright (c) 2023-2025 Saúl Ibarra Corretgé
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/qjsc.c
+++ b/qjsc.c
@@ -1,9 +1,9 @@
 /*
  * QuickJS command line compiler
  *
- * Copyright (c) 2018-2021 Fabrice Bellard
- * Copyright (c) 2023 Ben Noordhuis
- * Copyright (c) 2023 Saúl Ibarra Corretgé
+ * Copyright (c) 2018-2024 Fabrice Bellard
+ * Copyright (c) 2023-2025 Ben Noordhuis
+ * Copyright (c) 2023-2025 Saúl Ibarra Corretgé
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/quickjs.c
+++ b/quickjs.c
@@ -1,10 +1,10 @@
 /*
  * QuickJS Javascript Engine
  *
- * Copyright (c) 2017-2021 Fabrice Bellard
- * Copyright (c) 2017-2021 Charlie Gordon
- * Copyright (c) 2023 Ben Noordhuis
- * Copyright (c) 2023 Saúl Ibarra Corretgé
+ * Copyright (c) 2017-2024 Fabrice Bellard
+ * Copyright (c) 2017-2024 Charlie Gordon
+ * Copyright (c) 2023-2025 Ben Noordhuis
+ * Copyright (c) 2023-2025 Saúl Ibarra Corretgé
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/quickjs.h
+++ b/quickjs.h
@@ -1,10 +1,10 @@
 /*
  * QuickJS Javascript Engine
  *
- * Copyright (c) 2017-2021 Fabrice Bellard
- * Copyright (c) 2017-2021 Charlie Gordon
- * Copyright (c) 2023 Ben Noordhuis
- * Copyright (c) 2023 Saúl Ibarra Corretgé
+ * Copyright (c) 2017-2024 Fabrice Bellard
+ * Copyright (c) 2017-2024 Charlie Gordon
+ * Copyright (c) 2023-2025 Ben Noordhuis
+ * Copyright (c) 2023-2025 Saúl Ibarra Corretgé
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Editorial: should we also update the copyright notices for Fabrice and Charlie seeing how we did pick some patches from bellard/quickjs, plus Charlie's contributions here?

Nothing past June 2024 though so... 2017-2024? Honestly, I'm not sure what the standard practice is for that.