### PR TITLE
Fix Object.freeze on RAB-backed typed arrays

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -37126,6 +37126,8 @@ static JSValue js_object_seal(JSContext *ctx, JSValue this_val,
 {
     JSValue obj = argv[0];
     JSObject *p;
+    JSTypedArray *ta;
+    JSArrayBuffer *abuf;
     JSPropertyEnum *props;
     uint32_t len, i;
     int flags, desc_flags, res;
@@ -37144,6 +37146,13 @@ static JSValue js_object_seal(JSContext *ctx, JSValue this_val,
         return JS_EXCEPTION;
     if (!res) {
         return JS_ThrowTypeError(ctx, "proxy preventExtensions handler returned false");
+    }
+
+    if (freeze_flag && is_typed_array(p->class_id)) {
+        ta = p->u.typed_array;
+        abuf = ta->buffer->u.array_buffer;
+        if (array_buffer_is_resizable(abuf) || typed_array_is_oob(p))
+            return JS_ThrowTypeError(ctx, "cannot freeze resizable typed array");
     }
 
     flags = JS_GPN_STRING_MASK | JS_GPN_SYMBOL_MASK;

--- a/test262.conf
+++ b/test262.conf
@@ -68,6 +68,7 @@ Atomics.pause=!tcc
 Atomics.waitAsync=skip
 BigInt
 caller
+canonical-tz=skip
 change-array-by-copy
 class
 class-fields-private
@@ -114,6 +115,7 @@ hashbang
 host-gc-required=skip
 import-assertions=skip
 import-attributes=skip
+import-defer=skip
 import.meta
 Int16Array
 Int32Array
@@ -137,6 +139,7 @@ Intl.RelativeTimeFormat=skip
 Intl.Segmenter=skip
 IsHTMLDDA
 iterator-helpers
+iterator-sequencing=skip
 json-modules=skip
 json-parse-with-source=skip
 json-superset
@@ -384,6 +387,9 @@ test262/test/built-ins/RegExp/unicodeSets/generated/string-literal-union-charact
 test262/test/built-ins/RegExp/unicodeSets/generated/string-literal-union-character.js
 test262/test/built-ins/RegExp/unicodeSets/generated/string-literal-union-property-of-strings-escape.js
 test262/test/built-ins/RegExp/unicodeSets/generated/string-literal-union-string-literal.js
+
+# frequently broken, sometimes contain engine-dependent tests
+test262/test/staging/
 
 [tests]
 # list test files or use config.testdir

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -30,8 +30,6 @@ test262/test/built-ins/Object/defineProperty/coerced-P-shrink.js:16: Test262Erro
 test262/test/built-ins/Object/defineProperty/coerced-P-shrink.js:16: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/Object/defineProperty/typedarray-backed-by-resizable-buffer.js:18: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/Object/defineProperty/typedarray-backed-by-resizable-buffer.js:18: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
-test262/test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js:14: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
-test262/test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js:14: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js:45: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
 test262/test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js:45: strict mode: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
 test262/test/built-ins/RegExp/unicodeSets/generated/rgi-emoji-16.0.js:16: Test262Error: `\p{RGI_Emoji}` should match 🇨🇶 (U+01F1E8 U+01F1F6)

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -30,6 +30,8 @@ test262/test/built-ins/Object/defineProperty/coerced-P-shrink.js:16: Test262Erro
 test262/test/built-ins/Object/defineProperty/coerced-P-shrink.js:16: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/Object/defineProperty/typedarray-backed-by-resizable-buffer.js:18: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/Object/defineProperty/typedarray-backed-by-resizable-buffer.js:18: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+test262/test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js:14: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+test262/test/built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js:14: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js:45: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
 test262/test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js:45: strict mode: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
 test262/test/built-ins/RegExp/unicodeSets/generated/rgi-emoji-16.0.js:16: Test262Error: `\p{RGI_Emoji}` should match 🇨🇶 (U+01F1E8 U+01F1F6)


### PR DESCRIPTION
First two commits are #854 and #855 respectively.