### PR TITLE
Unbreak tcc build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           pushd /tmp
           git clone https://repo.or.cz/tinycc.git
           cd tinycc
-          git checkout 9d2068c6309dc50dfdbbc30a5d6757683d3f884c
+          git checkout c21576f8a32715ab439690d18184b0e02022bbbd
           ./configure
           make
           sudo make install

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -190,8 +190,10 @@ static void js_set_thread_state(JSRuntime *rt, JSThreadState *ts)
     js_std_cmd(/*SetOpaque*/1, rt, ts);
 }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif // __GNUC__
 static JSValue js_printf_internal(JSContext *ctx,
                                   int argc, JSValue *argv, FILE *fp)
 {
@@ -407,7 +409,9 @@ fail:
     dbuf_free(&dbuf);
     return JS_EXCEPTION;
 }
+#ifdef __GNUC__
 #pragma GCC diagnostic pop // ignored "-Wformat-nonliteral"
+#endif // __GNUC__
 
 uint8_t *js_load_file(JSContext *ctx, size_t *pbuf_len, const char *filename)
 {

--- a/quickjs.c
+++ b/quickjs.c
@@ -6927,8 +6927,10 @@ static int JS_PRINTF_FORMAT_ATTR(3, 4) JS_ThrowTypeErrorOrFalse(JSContext *ctx, 
     }
 }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif // __GNUC__
 static JSValue JS_ThrowTypeErrorAtom(JSContext *ctx, const char *fmt, JSAtom atom)
 {
     char buf[ATOM_GET_STR_BUF_SIZE];
@@ -6942,7 +6944,9 @@ static JSValue JS_ThrowSyntaxErrorAtom(JSContext *ctx, const char *fmt, JSAtom a
     JS_AtomGetStr(ctx, buf, sizeof(buf), atom);
     return JS_ThrowSyntaxError(ctx, fmt, buf);
 }
+#ifdef __GNUC__
 #pragma GCC diagnostic pop // ignored "-Wformat-nonliteral"
+#endif // __GNUC__
 
 static int JS_ThrowTypeErrorReadOnly(JSContext *ctx, int flags, JSAtom atom)
 {


### PR DESCRIPTION
The version of tcc in CI merely warned on unrecognized pragmas but newer versions treat them as fatal errors.

Upgrade tcc to prevent that from happening again.