### PR TITLE
Add JS_NewArrayFrom

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -728,6 +728,9 @@ JS_EXTERN bool JS_IsRegExp(JSValue val);
 JS_EXTERN bool JS_IsMap(JSValue val);
 
 JS_EXTERN JSValue JS_NewArray(JSContext *ctx);
+// takes ownership of the values
+JS_EXTERN JSValue JS_NewArrayFrom(JSContext *ctx, int count,
+                                  const JSValue *values);
 JS_EXTERN int JS_IsArray(JSContext *ctx, JSValue val);
 
 JS_EXTERN JSValue JS_NewDate(JSContext *ctx, double epoch_ms);


### PR DESCRIPTION
Add a version of JS_NewArray that takes the initial elements as its argument.

Change the OP_array_from bytecode handler to use it, to show that it works.

Refs: https://github.com/quickjs-ng/quickjs/discussions/868