### PR TITLE
Add JS_NewObjectFrom and JS_NewObjectFromStr

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -5041,17 +5041,22 @@ JSValue JS_NewObjectProto(JSContext *ctx, JSValue proto)
 JSValue JS_NewObjectFrom(JSContext *ctx, int count, const JSAtom *props,
                          const JSValue *values)
 {
+    JSProperty *pr;
+    JSObject *p;
     JSValue obj;
     int i;
 
     obj = JS_NewObject(ctx);
     if (JS_IsException(obj))
         return JS_EXCEPTION;
+    p = JS_VALUE_GET_OBJ(obj);
     for (i = 0; i < count; i++) {
-        if (JS_SetProperty(ctx, obj, props[i], values[i]) < 0) {
+        pr = add_property(ctx, p, props[i], JS_PROP_C_W_E);
+        if (!pr) {
             JS_FreeValue(ctx, obj);
             return JS_EXCEPTION;
         }
+        pr->u.value = values[i];
     }
     return obj;
 }

--- a/quickjs.h
+++ b/quickjs.h
@@ -717,6 +717,12 @@ JS_EXTERN JSValue JS_NewObjectProtoClass(JSContext *ctx, JSValue proto, JSClassI
 JS_EXTERN JSValue JS_NewObjectClass(JSContext *ctx, int class_id);
 JS_EXTERN JSValue JS_NewObjectProto(JSContext *ctx, JSValue proto);
 JS_EXTERN JSValue JS_NewObject(JSContext *ctx);
+JS_EXTERN JSValue JS_NewObjectFrom(JSContext *ctx, int count,
+                                   const JSAtom *props,
+                                   const JSValue *values);
+JS_EXTERN JSValue JS_NewObjectFromStr(JSContext *ctx, int count,
+                                      const char **props,
+                                      const JSValue *values);
 JS_EXTERN JSValue JS_ToObject(JSContext *ctx, JSValue val);
 JS_EXTERN JSValue JS_ToObjectString(JSContext *ctx, JSValue val);
 

--- a/run-test262.c
+++ b/run-test262.c
@@ -931,36 +931,33 @@ static JSValue js_IsHTMLDDA(JSContext *ctx, JSValue this_val,
 static JSValue add_helpers1(JSContext *ctx)
 {
     JSValue global_obj;
-    JSValue obj262, obj;
+    JSValue obj262, is_html_dda;
 
     global_obj = JS_GetGlobalObject(ctx);
 
     JS_SetPropertyStr(ctx, global_obj, "print",
                       JS_NewCFunction(ctx, js_print_262, "print", 1));
 
+    is_html_dda = JS_NewCFunction(ctx, js_IsHTMLDDA, "IsHTMLDDA", 0);
+    JS_SetIsHTMLDDA(ctx, is_html_dda);
+#define N 7
+    static const char *props[N] = {
+        "detachArrayBuffer", "evalScript", "codePointRange",
+        "agent", "global", "createRealm", "IsHTMLDDA",
+    };
+    JSValue values[N] = {
+        JS_NewCFunction(ctx, js_detachArrayBuffer, "detachArrayBuffer", 1),
+        JS_NewCFunction(ctx, js_evalScript_262, "evalScript", 1),
+        JS_NewCFunction(ctx, js_string_codePointRange, "codePointRange", 2),
+        js_new_agent(ctx),
+        JS_DupValue(ctx, global_obj),
+        JS_NewCFunction(ctx, js_createRealm, "createRealm", 0),
+        is_html_dda,
+    };
     /* $262 special object used by the tests */
-    obj262 = JS_NewObject(ctx);
-    JS_SetPropertyStr(ctx, obj262, "detachArrayBuffer",
-                      JS_NewCFunction(ctx, js_detachArrayBuffer,
-                                      "detachArrayBuffer", 1));
-    JS_SetPropertyStr(ctx, obj262, "evalScript",
-                      JS_NewCFunction(ctx, js_evalScript_262,
-                                      "evalScript", 1));
-    JS_SetPropertyStr(ctx, obj262, "codePointRange",
-                      JS_NewCFunction(ctx, js_string_codePointRange,
-                                      "codePointRange", 2));
-    JS_SetPropertyStr(ctx, obj262, "agent", js_new_agent(ctx));
-
-    JS_SetPropertyStr(ctx, obj262, "global",
-                      JS_DupValue(ctx, global_obj));
-    JS_SetPropertyStr(ctx, obj262, "createRealm",
-                      JS_NewCFunction(ctx, js_createRealm,
-                                      "createRealm", 0));
-    obj = JS_NewCFunction(ctx, js_IsHTMLDDA, "IsHTMLDDA", 0);
-    JS_SetIsHTMLDDA(ctx, obj);
-    JS_SetPropertyStr(ctx, obj262, "IsHTMLDDA", obj);
-
+    obj262 = JS_NewObjectFromStr(ctx, N, props, values);
     JS_SetPropertyStr(ctx, global_obj, "$262", JS_DupValue(ctx, obj262));
+#undef N
 
     JS_FreeValue(ctx, global_obj);
     return obj262;


### PR DESCRIPTION
I did it as a sequence of commits that iteratively refine the logic so you can see how it builds up from the naive version to the final version.

The final version is definitely quite a bit faster vs. JS_NewObject + JS_SetProperty because we can make some assumptions about the object shape and skip a lot of repeated busywork.

I do wonder though how often I, as a quickjs user, would actually use these functions. I couldn't find many places in qjs.c or run-test262.c where it made sense. The change I made to the latter is admittedly somewhat contrived, so... WDYT?