### PR TITLE
Refactor Error.stackTraceLimit

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -6688,9 +6688,9 @@ static void build_backtrace(JSContext *ctx, JSValue error_val, JSValue filter_fu
 
     // Extract stack trace limit.
     JS_ToFloat64(ctx, &d, ctx->error_stack_trace_limit);
-    if (isnan(d) || d < 0.0 || (isinf(d) && d < 0.0))
+    if (isnan(d) || d < 0.0)
         stack_trace_limit = 0;
-    else if (isinf(d) || d > (double)INT32_MAX)
+    else if (d > INT32_MAX)
         stack_trace_limit = INT32_MAX;
     else
         stack_trace_limit = fabs(d);

--- a/tests/bug858.js
+++ b/tests/bug858.js
@@ -12,6 +12,10 @@ Error.stackTraceLimit = NaN;
 assert(Number.isNaN(Error.stackTraceLimit));
 assert(!new Error("error").stack.includes("bug858.js")); // stack should be empty
 
+Error.stackTraceLimit = -0;
+assert(Object.is(Error.stackTraceLimit, -0));
+assert(!new Error("error").stack.includes("bug858.js")); // stack should be empty
+
 const obj = { valueOf() { throw "evil" } };
 Error.stackTraceLimit = obj;
 assert(Error.stackTraceLimit === obj);

--- a/tests/bug858.js
+++ b/tests/bug858.js
@@ -1,10 +1,22 @@
 import {assert} from "./assert.js";
 
 Error.stackTraceLimit = Infinity;
+assert(Error.stackTraceLimit === Infinity);
 assert(new Error("error").stack.includes("bug858.js")); // stack should not be empty
 
 Error.stackTraceLimit = -Infinity;
+assert(Error.stackTraceLimit === -Infinity);
 assert(!new Error("error").stack.includes("bug858.js")); // stack should be empty
 
 Error.stackTraceLimit = NaN;
+assert(Number.isNaN(Error.stackTraceLimit));
 assert(!new Error("error").stack.includes("bug858.js")); // stack should be empty
+
+const obj = { valueOf() { throw "evil" } };
+Error.stackTraceLimit = obj;
+assert(Error.stackTraceLimit === obj);
+try {
+  throw new Error("fail")
+} catch (e) {
+  assert(e.message.includes("fail"));
+}


### PR DESCRIPTION
- Store the JS value, so the conversion happens when the backtrace is needed
- Prevent recursion in build_backtrace
- Simplify code for saving / restoring exception in build_backtrace