### PR TITLE
Expose JS_NewCFunction3

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -5242,10 +5242,10 @@ static int js_method_set_properties(JSContext *ctx, JSValue func_obj,
 
 /* Note: at least 'length' arguments will be readable in 'argv' */
 /* `name` may be NULL, pure ASCII or UTF-8 encoded */
-static JSValue JS_NewCFunction3(JSContext *ctx, JSCFunction *func,
-                                const char *name,
-                                int length, JSCFunctionEnum cproto, int magic,
-                                JSValue proto_val)
+JSValue JS_NewCFunction3(JSContext *ctx, JSCFunction *func,
+                         const char *name,
+                         int length, JSCFunctionEnum cproto, int magic,
+                         JSValue proto_val)
 {
     JSValue func_obj;
     JSObject *p;

--- a/quickjs.h
+++ b/quickjs.h
@@ -1006,6 +1006,10 @@ typedef union JSCFunctionType {
 JS_EXTERN JSValue JS_NewCFunction2(JSContext *ctx, JSCFunction *func,
                                    const char *name,
                                    int length, JSCFunctionEnum cproto, int magic);
+JS_EXTERN JSValue JS_NewCFunction3(JSContext *ctx, JSCFunction *func,
+                                   const char *name,
+                                   int length, JSCFunctionEnum cproto, int magic,
+                                   JSValue proto_val);
 JS_EXTERN JSValue JS_NewCFunctionData(JSContext *ctx, JSCFunctionData *func,
                                       int length, int magic, int data_len,
                                       JSValue *data);


### PR DESCRIPTION
Useful if you want to set the prototype of a constructor to its parent constructor when creating a custom type hierarchy.

(e.g. in browsers, `Text.__proto__` == `CharacterData`, and to implement this you can pass the `CharacterData` constructor as `proto_val`.)