### PR TITLE
Fix qjsc static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,14 @@ macro(add_qjs_libc_if_needed target)
         target_sources(${target} PRIVATE quickjs-libc.c)
     endif()
 endmacro()
+macro(add_static_if_needed target)
+    if(BUILD_STATIC_QJS_EXE OR MINGW)
+        target_link_options(${target} PRIVATE -static)
+        if(MINGW)
+            target_link_options(${target} PRIVATE -static-libgcc)
+        endif()
+    endif()
+endmacro()
 
 set(qjs_sources
     cutils.c
@@ -249,6 +257,7 @@ add_executable(qjsc
     qjsc.c
 )
 add_qjs_libc_if_needed(qjsc)
+add_static_if_needed(qjsc)
 target_compile_definitions(qjsc PRIVATE ${qjs_defines})
 target_link_libraries(qjsc qjs)
 
@@ -262,17 +271,12 @@ add_executable(qjs_exe
     qjs.c
 )
 add_qjs_libc_if_needed(qjs_exe)
+add_static_if_needed(qjs_exe)
 set_target_properties(qjs_exe PROPERTIES
     OUTPUT_NAME "qjs"
 )
 target_compile_definitions(qjs_exe PRIVATE ${qjs_defines})
 target_link_libraries(qjs_exe qjs)
-if(BUILD_STATIC_QJS_EXE OR MINGW)
-    target_link_options(qjs_exe PRIVATE -static)
-    if(MINGW)
-        target_link_options(qjs_exe PRIVATE -static-libgcc)
-    endif()
-endif()
 if(NOT WIN32)
     set_target_properties(qjs_exe PROPERTIES ENABLE_EXPORTS TRUE)
 endif()


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/875

<hr>

We don't distribute run-test262, unicode_gen, function_source, etc. so I didn't add the flags to those targets, just makes them slower to build, but LMK if you think that's a good idea after all.