### PR TITLE
Disable flaky arm64 buildbots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-24.04-arm, configType: Debug }
-          - { os: ubuntu-24.04-arm, configType: Release, runTest262: true }
+          # see https://github.com/quickjs-ng/quickjs/issues/879 - tl;dr flaky
+          #- { os: ubuntu-24.04-arm, configType: Debug }
+          #- { os: ubuntu-24.04-arm, configType: Release, runTest262: true }
           - { os: ubuntu-latest, configType: Debug }
           - { os: ubuntu-latest, configType: Release, runTest262: true }
           - { os: ubuntu-latest, configType: examples }


### PR DESCRIPTION
The "ubuntu-24.04-arm (Release)" buildbot intermittently fails at the "Run actions/checkout@v4" step for no apparent reason.

ARM runners are in preview mode so disable them until GitHub fixes it.

Fixes: https://github.com/quickjs-ng/quickjs/issues/879