### PR TITLE
Add pre-init ICs

### DIFF
--- a/quickjs-opcode.h
+++ b/quickjs-opcode.h
@@ -366,6 +366,9 @@ DEF(typeof_is_undefined, 1, 1, 1, none)
 DEF( typeof_is_function, 1, 1, 1, none)
 
 // order matters, see non-IC counterparts
+DEF(      get_field_preinit_ic, 5, 1, 1, none)
+DEF(     get_field2_preinit_ic, 5, 1, 2, none)
+DEF(      put_field_preinit_ic, 5, 2, 0, none)
 DEF(      get_field_ic, 5, 1, 1, none)
 DEF(     get_field2_ic, 5, 1, 2, none)
 DEF(      put_field_ic, 5, 2, 0, none)


### PR DESCRIPTION
Defer creating the inline cache once, to avoid unprofitable busywork for JS code that only executes once.

It's at best a qualified success. It succeeds at keeping the memory and CPU footprint of execute-once code down but it slows down the babel benchmark from the web-tooling-benchmark suite by 500% because that benchmark is all about property access on tree structures.

Other benchmarks from the suite are unaffected, neither faster or slower, with the possible exception of the terser benchmark, which is a few percent slower for the same reason as the babel one, only much less pronounced.

Refs: https://github.com/quickjs-ng/quickjs/issues/876

<hr>

Opened as a draft as a discussion starter because it probably shouldn't land as-is.