### PR TITLE
Fixes to format preprocessing for Clang on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
       - name: build
         run: |
           git submodule update --init --checkout --depth 1
-          cmake -B build -DBUILD_EXAMPLES=ON -G "Ninja" -T Clang
+          cmake -B build -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -DCMAKE_C_COMPILER=clang.exe -DCMAKE_CXX_COMPILER=clang++.exe -G "Ninja"
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,43 @@ jobs:
           cl.exe /DJS_NAN_BOXING=0 /Zs cxxtest.cc
           cl.exe /DJS_NAN_BOXING=1 /Zs cxxtest.cc
 
-  windows-clang:
+  windows-ninja-clang:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        buildType: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: install ninja
+        run: |
+          choco install ninja
+          ninja.exe --version
+      - name: build
+        run: |
+          git submodule update --init --checkout --depth 1
+          cmake -B build -DBUILD_EXAMPLES=ON -G "Ninja" -T Clang
+          cmake --build build --config ${{matrix.buildType}}
+      - name: stats
+        run: |
+          build\${{matrix.buildType}}\qjs.exe -qd
+      - name: cxxtest
+        run: |
+          clang.exe /DJS_NAN_BOXING=0 /Zs cxxtest.cc
+          clang.exe /DJS_NAN_BOXING=1 /Zs cxxtest.cc
+      - name: test
+        run: |
+          cp build\${{matrix.buildType}}\fib.dll examples\
+          cp build\${{matrix.buildType}}\point.dll examples\
+          build\${{matrix.buildType}}\qjs.exe examples\test_fib.js
+          build\${{matrix.buildType}}\qjs.exe examples\test_point.js
+          build\${{matrix.buildType}}\run-test262.exe -c tests.conf
+          build\${{matrix.buildType}}\function_source.exe
+      - name: test interrupt
+        run: |
+          build\${{matrix.buildType}}\interrupt-test.exe
+
+  windows-clang-cl:
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/cutils.h
+++ b/cutils.h
@@ -102,7 +102,8 @@ extern "C" {
 
 /* Borrowed from Folly */
 #ifndef JS_PRINTF_FORMAT
-#ifdef _MSC_VER
+/* Clang on Windows doesn't seem to support _Printf_format_string_ */
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <sal.h>
 #define JS_PRINTF_FORMAT _Printf_format_string_
 #define JS_PRINTF_FORMAT_ATTR(format_param, dots_param)

--- a/getopt_compat.h
+++ b/getopt_compat.h
@@ -68,6 +68,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <windows.h>
+/* Required for JS_PRINTF_FORMAT */
+#include "cutils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -145,7 +147,7 @@ static const char illoptchar[] = "unknown option -- %c";
 static const char illoptstring[] = "unknown option -- %s";
 
 static void
-_vwarnx(const char *fmt,va_list ap)
+JS_PRINTF_FORMAT_ATTR(1, 0) _vwarnx(JS_PRINTF_FORMAT const char *fmt,va_list ap)
 {
   (void)fprintf(stderr,"%s: ",__progname);
   if (fmt != NULL)

--- a/getopt_compat.h
+++ b/getopt_compat.h
@@ -156,7 +156,7 @@ JS_PRINTF_FORMAT_ATTR(1, 0) _vwarnx(JS_PRINTF_FORMAT const char *fmt,va_list ap)
 }
 
 static void
-warnx(const char *fmt,...)
+JS_PRINTF_FORMAT_ATTR(1, 2) warnx(JS_PRINTF_FORMAT const char *fmt,...)
 {
   va_list ap;
   va_start(ap,fmt);

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -190,10 +190,10 @@ static void js_set_thread_state(JSRuntime *rt, JSThreadState *ts)
     js_std_cmd(/*SetOpaque*/1, rt, ts);
 }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#endif // __GNUC__
+#endif // __GNUC__ || __clang__
 static JSValue js_printf_internal(JSContext *ctx,
                                   int argc, JSValue *argv, FILE *fp)
 {
@@ -409,9 +409,9 @@ fail:
     dbuf_free(&dbuf);
     return JS_EXCEPTION;
 }
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop // ignored "-Wformat-nonliteral"
-#endif // __GNUC__
+#endif // __GNUC__ || __clang__
 
 uint8_t *js_load_file(JSContext *ctx, size_t *pbuf_len, const char *filename)
 {

--- a/quickjs.c
+++ b/quickjs.c
@@ -7048,7 +7048,7 @@ static int JS_PRINTF_FORMAT_ATTR(3, 4) JS_ThrowTypeErrorOrFalse(JSContext *ctx, 
     }
 }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif // __GNUC__
@@ -7065,7 +7065,7 @@ static JSValue JS_ThrowSyntaxErrorAtom(JSContext *ctx, const char *fmt, JSAtom a
     JS_AtomGetStr(ctx, buf, sizeof(buf), atom);
     return JS_ThrowSyntaxError(ctx, fmt, buf);
 }
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop // ignored "-Wformat-nonliteral"
 #endif // __GNUC__
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -49,7 +49,7 @@ extern "C" {
 
 /* Borrowed from Folly */
 #ifndef JS_PRINTF_FORMAT
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <sal.h>
 #define JS_PRINTF_FORMAT _Printf_format_string_
 #define JS_PRINTF_FORMAT_ATTR(format_param, dots_param)


### PR DESCRIPTION
Clang on Windows defines `_MSC_VER`, but it doesn't seem to understand `_Printf_format_string_`, leading to errors code using format string parameters as it fails to understand that the parameters are format strings. However, the `__attribute__((format))` syntax seems to work just fine, and so this PR enables that for Clang on Windows.

For context, I am using clang (19.1.0) instead of clang-cl (because the latter doesn't work for some unknown reasons). I've checked that this still works on MSVC, though I don't know about the rest of the platforms because I didn't realize GitHub wouldn't run CI when I made the commit. Oh well, I'll see when CI runs for the PR, and push new commits to fix it if something goes wrong.