### PR TITLE
Fix unnoticed exception in JS_DetectModule

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -56280,7 +56280,7 @@ bool JS_DetectModule(const char *input, size_t input_len)
         JS_FreeRuntime(rt);
         return false;
     }
-    JS_AddIntrinsicRegExp(ctx); // otherwise regexp literals don't parse
+    JS_AddIntrinsicRegExpCompiler(ctx); // otherwise regexp literals don't parse
     val = __JS_EvalInternal(ctx, JS_UNDEFINED, input, input_len, "<unnamed>", 1,
                             JS_EVAL_TYPE_MODULE|JS_EVAL_FLAG_COMPILE_ONLY, -1);
     if (JS_IsException(val)) {


### PR DESCRIPTION
JS_DetectModule calls JS_AddIntrinsicRegExp but that indirectly uses `ctx->global_obj` when it tries to define `globalThis.RegExp`.

There is no `ctx->global_obj` however because JS_NewContextRaw doesn't create one. It raised an "not an object" TypeError that went unnoticed because there is no error checking in JS_NewGlobalCConstructor2.

Using JS_AddIntrinsicRegExpCompiler is better all around because we only need to parse regexp literals, nothing more.

JS_NewGlobalCConstructor2 should probably be changed to do proper error checking, and __JS_EvalInternal to return JS_EXCEPTION when an exception is pending on entry, but I'll save that for another commit.