### PR TITLE
RFC: Custom-handling for gc leaks at FreeRuntime

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -2010,7 +2010,17 @@ void JS_SetRuntimeInfo(JSRuntime *rt, const char *s)
         rt->rt_info = s;
 }
 
+void js_freeruntime_gc_leak_handler_def(const char* msg)
+{
+	assert(false);
+}
+
 void JS_FreeRuntime(JSRuntime *rt)
+{
+	JS_FreeRuntime2(rt, js_freeruntime_gc_leak_handler_def);
+}
+
+void JS_FreeRuntime2(JSRuntime *rt, void (*gc_leak_handler)(const char* msg))
 {
     struct list_head *el, *el1;
     int i;
@@ -2068,7 +2078,11 @@ void JS_FreeRuntime(JSRuntime *rt)
     }
 #endif
 
-    assert(list_empty(&rt->gc_obj_list));
+    if (!list_empty(&rt->gc_obj_list)) {
+        if (gc_leak_handler != NULL) {
+            gc_leak_handler("gc_obj_list is not empty");
+        }
+    }
 
     /* free the classes */
     for(i = 0; i < rt->class_count; i++) {

--- a/quickjs.h
+++ b/quickjs.h
@@ -377,6 +377,7 @@ JS_EXTERN void JS_SetMaxStackSize(JSRuntime *rt, size_t stack_size);
 JS_EXTERN void JS_UpdateStackTop(JSRuntime *rt);
 JS_EXTERN JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque);
 JS_EXTERN void JS_FreeRuntime(JSRuntime *rt);
+JS_EXTERN void JS_FreeRuntime2(JSRuntime *rt, void (*gc_leak_handler)(const char* msg));
 JS_EXTERN void *JS_GetRuntimeOpaque(JSRuntime *rt);
 JS_EXTERN void JS_SetRuntimeOpaque(JSRuntime *rt, void *opaque);
 JS_EXTERN int JS_AddRuntimeFinalizer(JSRuntime *rt,


### PR DESCRIPTION
Allows bypassing the default `assert()` if `rt->gc_obj_list` is not empty (and handling as desired).

I'm not overly attached to this specific implementation, but wanted to open this to discuss.

What we need is some ability to call `JS_FreeRuntime`, bypass the default `assert` behavior when there are leaks, and handle with a custom callback.