### PR TITLE
MSVC fix: include <intrin.h> for `_AddressOfReturnAddress`

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -33,9 +33,11 @@
 #if !defined(_MSC_VER)
 #include <sys/time.h>
 #if defined(_WIN32)
-#include <intrin.h>
 #include <timezoneapi.h>
 #endif
+#endif
+#if defined(_WIN32)
+#include <intrin.h>
 #endif
 #include <time.h>
 #include <fenv.h>


### PR DESCRIPTION
Fixes: `warning C5250: '_AddressOfReturnAddress': intrinsic function not declared`
(Ref: https://learn.microsoft.com/en-us/cpp/intrinsics/addressofreturnaddress)