### PR TITLE
build: initial support for meson build system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,13 +585,13 @@ jobs:
           make amalgam
       - name: build amalgamation
         run: |
-          unzip -d $RUNNER_TEMP build/quickjs-amalgam.zip
-          cc -Wall -I. -o $RUNNER_TEMP/run-test262.o -c run-test262.c
-          cc -Wall -I/ -DQJS_BUILD_LIBC -o $RUNNER_TEMP/quickjs-amalgam.o -c $RUNNER_TEMP/quickjs-amalgam.c
-          cc -o $RUNNER_TEMP/run-test262 $RUNNER_TEMP/run-test262.o $RUNNER_TEMP/quickjs-amalgam.o -lm
+          unzip -d "$RUNNER_TEMP" build/quickjs-amalgam.zip
+          cc -Wall -I. -o "$RUNNER_TEMP/run-test262.o" -c run-test262.c
+          cc -Wall -I/ -DQJS_BUILD_LIBC -o "$RUNNER_TEMP/quickjs-amalgam.o" -c "$RUNNER_TEMP/quickjs-amalgam.c"
+          cc -o "$RUNNER_TEMP/run-test262" "$RUNNER_TEMP/run-test262.o" "$RUNNER_TEMP/quickjs-amalgam.o" -lm
       - name: test
         run: |
-          make test RUN262=$RUNNER_TEMP/run-test262
+          make test RUN262="$RUNNER_TEMP/run-test262"
 
   jscheck:
     runs-on: ubuntu-latest
@@ -617,6 +617,8 @@ jobs:
             args: -Dlibc=true
           - name: mimalloc
             args: -Dcli_mimalloc=auto
+          - name: jscheck
+            args: -Djscheck=true
         mode:
           - name: default
             args: -Dtests=enabled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           make codegen
       - name: Check if the git repository is clean
-        run: $(exit $(git status --porcelain --untracked-files=no | head -255 | wc -l)) || (echo "Dirty git tree"; git diff; exit 1)
+        run: (exit "$(git status --porcelain --untracked-files=no | head -255 | wc -l)") || (echo "Dirty git tree"; git diff; exit 1)
 
   ci:
     runs-on: ${{ matrix.config.os }}
@@ -418,7 +418,7 @@ jobs:
       - name: build
         run: |
           emcmake cmake -B build -DQJS_BUILD_LIBC=ON
-          emmake make -C build qjs_wasm -j$(getconf _NPROCESSORS_ONLN)
+          emmake make -C build qjs_wasm "-j$(getconf _NPROCESSORS_ONLN)"
       - name: result
         run: ls -lh build
   wasi:
@@ -509,10 +509,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          $ANDROID_HOME/cmake/3.22.1/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/26.0.10792818/build/cmake/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-24 -DQJS_BUILD_LIBC=ON ..
+          "$ANDROID_HOME/cmake/3.22.1/bin/cmake" "-DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/26.0.10792818/build/cmake/android.toolchain.cmake" -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-24 -DQJS_BUILD_LIBC=ON ..
       - name: Build android arm64
         run: |
-          $ANDROID_HOME/cmake/3.22.1/bin/cmake --build build --target qjs
+          "$ANDROID_HOME/cmake/3.22.1/bin/cmake" --build build --target qjs
           ls -lh build
 
   ios:
@@ -600,3 +600,198 @@ jobs:
       - name: jscheck
         run: |
           make jscheck
+
+  meson:
+    runs-on: ${{ matrix.platform }}
+    name: meson on ${{ matrix.platform }} (${{ matrix.mode.name }} ${{ matrix.flavor }}, ${{ matrix.features.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - debug
+          - release
+        features:
+          - name: default
+            args: ""
+          - name: libc
+            args: -Dlibc=true
+          - name: mimalloc
+            args: -Dcli_mimalloc=auto
+        mode:
+          - name: default
+            args: -Dtests=enabled
+            extra_envs: {}
+
+          # Alternative compiler setups
+          - name: gcc
+            args: -Dtests=enabled
+            extra_envs:
+              CC: gcc
+              CXX: g++
+          - name: clang
+            args: -Dtests=enabled
+            extra_envs:
+              CC: clang
+              CXX: clang++
+
+          - name: sanitize
+            args: >-
+              "-Db_sanitize=address,undefined"
+            extra_envs: {}
+
+          # This is for MSVC, which only supports AddressSanitizer.
+          # https://learn.microsoft.com/en-us/cpp/sanitizers/
+          - name: sanitize+asanonly
+            args: -Db_sanitize=address
+            extra_envs:
+              ASAN_OPTIONS: report_globals=0:halt_on_error=1:abort_on_error=1:print_summary=1
+
+          - name: clang+sanitize
+            args: >-
+              "-Db_sanitize=address,undefined"
+            extra_envs:
+              CC: clang
+              CXX: clang++
+          - name: clang+msan
+            args: -Db_sanitize=memory
+            extra_envs:
+              CC: clang
+              CXX: clang++
+
+          # default clang on GitHub hosted runners is from MSYS2.
+          # Use Visual Studio supplied clang-cl instead.
+          - name: clang-cl+sanitize
+            args: >-
+              "-Db_sanitize=address,undefined"
+            extra_envs:
+              CC: clang-cl
+              CXX: clang-cl
+          - name: clang-cl+msan
+            args: -Db_sanitize=memory
+            extra_envs:
+              CC: clang-cl
+              CXX: clang-cl
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+        exclude:
+          # clang-cl only makes sense on windows.
+          - platform: ubuntu-latest
+            mode:
+              name: clang-cl+sanitize
+          - platform: macos-latest
+            mode:
+              name: clang-cl+sanitize
+          - platform: ubuntu-latest
+            mode:
+              name: clang-cl+msan
+          - platform: macos-latest
+            mode:
+              name: clang-cl+msan
+
+          # Use clang-cl instead of MSYS2 clang.
+          #
+          # we already tested clang+sanitize on linux,
+          # if this doesn't work, it should be an issue for MSYS2 team to consider.
+          - platform: windows-latest
+            mode:
+              name: clang
+          - platform: windows-latest
+            mode:
+              name: clang+sanitize
+          - platform: windows-latest
+            mode:
+              name: clang+msan
+
+          # MSVC-only sanitizers
+          - platform: ubuntu-latest
+            mode:
+              name: sanitize+asanonly
+          - platform: macos-latest
+            mode:
+              name: sanitize+asanonly
+          - platform: windows-latest
+            mode:
+              name: sanitize
+
+          # clang is the default on macos
+          # also gcc is an alias to clang
+          - platform: macos-latest
+            mode:
+              name: clang
+          - platform: macos-latest
+            mode:
+              name: gcc
+
+          # gcc is the default on linux
+          - platform: ubuntu-latest
+            mode:
+              name: gcc
+
+          # only run sanitizer tests on linux
+          #
+          # gcc/clang's codegen shouldn't massively change across platforms,
+          # and linux supports most of the sanitizers.
+          - platform: macos-latest
+            mode:
+              name: clang+sanitize
+          - platform: macos-latest
+            mode:
+              # macos does not support msan
+              name: clang+msan
+          - platform: macos-latest
+            mode:
+              name: sanitize
+
+    steps:
+      - name: Setup meson
+        run: |
+          pipx install meson ninja
+      - name: Install mimalloc
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.features.name == 'mimalloc' }}
+        run: sudo apt update && sudo apt -y install libmimalloc-dev
+      - name: Install mimalloc
+        if: ${{ matrix.platform == 'macos-latest' && matrix.features.name == 'mimalloc' }}
+        run: brew install mimalloc
+      # TODO: Install mimalloc on Windows
+      # You need to:
+      # - checkout mimalloc
+      # - `msbuild mimalloc\ide\vs2022\mimalloc.sln`
+      #   - not cmake, because https://github.com/microsoft/mimalloc/issues/575#issuecomment-1112723975
+      #   - it is possible to integrate vcpkg with meson, but:
+      #     - 1. the above issue
+      #     - 2. the vcpkg port of mimalloc is outdated, and still broken on server 2019
+      #   - or maintain a meson port for mimalloc (and ensure it behaves correctly)
+      # - Make it findable with cmake
+      #   - not the simpler pkg-config. although there was pkg-config in PATH,
+      #     but that was from strawberry perl and thus broken
+      # ... good job, microsoft :))))
+
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Activate MSVC and Configure
+        if: ${{ matrix.platform == 'windows-latest' }}
+        env: ${{ matrix.mode.extra_envs }}
+        run: |
+          meson setup build-${{ matrix.flavor }} --buildtype=${{ matrix.flavor }} ${{ matrix.mode.args }} ${{ matrix.features.args }} --vsenv
+      - name: Configuring
+        if: ${{ matrix.platform != 'windows-latest' }}
+        env: ${{ matrix.mode.extra_envs }}
+        run: |
+          meson setup build-${{ matrix.flavor }} --buildtype=${{ matrix.flavor }} ${{ matrix.mode.args }} ${{ matrix.features.args }} 
+      - name: Building
+        run: |
+          meson compile -C build-${{ matrix.flavor }}
+
+      - name: Running tests
+        env: ${{ matrix.mode.extra_envs }}
+        run: |
+          meson test -C build-${{ matrix.flavor }} --timeout-multiplier 5 --print-errorlogs
+          meson test --benchmark -C build-${{ matrix.flavor }} --timeout-multiplier 5 --print-errorlogs
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: ${{ matrix.platform }}-${{ matrix.mode.name }}-${{ matrix.features.name }}-${{ matrix.flavor }}-logs
+          path: build-${{ matrix.flavor }}/meson-logs

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ BUILD_DIR=build
 BUILD_TYPE?=Release
 INSTALL_PREFIX?=/usr/local
 
+BUILD_BACKEND?=cmake
+
 QJS=$(BUILD_DIR)/qjs
 QJSC=$(BUILD_DIR)/qjsc
 RUN262=$(BUILD_DIR)/run-test262
@@ -41,6 +43,21 @@ JOBS := $(shell nproc)
 endif
 ifeq ($(JOBS),)
 JOBS := 4
+endif
+
+ifeq ($(BUILD_BACKEND),meson)
+ifeq ($(BUILD_TYPE),Release)
+BUILD_TYPE=release
+endif
+ifeq ($(BUILD_TYPE),Debug)
+BUILD_TYPE=debug
+endif
+ifeq ($(BUILD_TYPE),RelWithDebInfo)
+BUILD_TYPE=debugoptimized
+endif
+ifeq ($(BUILD_TYPE),MinSizeRel)
+BUILD_TYPE=minsize
+endif
 endif
 
 all: $(QJS)
@@ -59,19 +76,31 @@ fuzz:
 	./fuzz
 
 $(BUILD_DIR):
+ifeq ($(BUILD_BACKEND),cmake)
 	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX)
+else
+ifeq ($(BUILD_BACKEND),meson)
+	meson setup $(BUILD_DIR) --buildtype=$(BUILD_TYPE) --prefix=$(INSTALL_PREFIX)
+else
+	false
+endif
+endif
 
 $(QJS): $(BUILD_DIR)
-	cmake --build $(BUILD_DIR) -j $(JOBS)
+	test -f $(BUILD_DIR)/meson-private/coredata.dat || cmake --build $(BUILD_DIR) -j $(JOBS)
+	test -f $(BUILD_DIR)/CMakeCache.txt || meson compile -C $(BUILD_DIR) -j $(JOBS)
 
 $(QJSC): $(BUILD_DIR)
-	cmake --build $(BUILD_DIR) --target qjsc -j $(JOBS)
+	test -f $(BUILD_DIR)/meson-private/coredata.dat || cmake --build $(BUILD_DIR) --target qjsc -j $(JOBS)
+	test -f $(BUILD_DIR)/CMakeCache.txt || meson compile -C $(BUILD_DIR) -j $(JOBS) qjsc
 
 install: $(QJS) $(QJSC)
-	cmake --build $(BUILD_DIR) --target install
+	test -f $(BUILD_DIR)/meson-private/coredata.dat || cmake --build $(BUILD_DIR) --target install
+	test -f $(BUILD_DIR)/CMakeCache.txt || meson install -C $(BUILD_DIR)
 
 clean:
-	cmake --build $(BUILD_DIR) --target clean
+	test -f $(BUILD_DIR)/meson-private/coredata.dat || cmake --build $(BUILD_DIR) --target clean
+	test -f $(BUILD_DIR)/CMakeCache.txt || meson compile -C $(BUILD_DIR) --clean
 
 codegen: $(QJSC)
 	$(QJSC) -ss -o gen/repl.c -m repl.js
@@ -138,7 +167,8 @@ microbench: $(QJS)
 	$(QJS) tests/microbench.js
 
 unicode_gen: $(BUILD_DIR)
-	cmake --build $(BUILD_DIR) --target unicode_gen
+	test -f $(BUILD_DIR)/meson-private/coredata.dat || cmake --build $(BUILD_DIR) --target unicode_gen -j $(JOBS) 
+	test -f $(BUILD_DIR)/CMakeCache.txt || meson compile -C $(BUILD_DIR) -j $(JOBS) unicode_gen
 
 libunicode-table.h: unicode_gen
 	$(BUILD_DIR)/unicode_gen unicode $@

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,19 @@
+shared_module(
+  'fib',
+  'fib.c',
+
+  name_prefix: '',
+  gnu_symbol_visibility: 'default',
+  c_args: ['-DJS_SHARED_LIBRARY'],
+  dependencies: host_system == 'windows' ? qjs_dep : [],
+)
+
+shared_module(
+  'point',
+  'point.c',
+
+  name_prefix: '',
+  gnu_symbol_visibility: 'default',
+  c_args: ['-DJS_SHARED_LIBRARY'],
+  dependencies: host_system == 'windows' ? qjs_dep : [],
+)

--- a/meson.build
+++ b/meson.build
@@ -497,5 +497,6 @@ if examples.allowed()
 
     c_args: qjs_c_args,
     dependencies: qjs_dep,
+    export_dynamic: true,
   )
 endif

--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,19 @@ else
   )
 endif
 
+if host_system == 'windows'
+  # Set a 8MB default stack size on Windows.
+  # It defaults to 1MB on MSVC, which is the same as our current JS stack size,
+  # so it will overflow and crash otherwise.
+  # On MinGW it defaults to 2MB.
+  stack_size = 8 * 1024 * 1024
+  if cc.get_argument_syntax() == 'msvc'
+    add_project_link_arguments(f'/STACK:@stack_size@', language: 'c')
+  else
+    add_project_link_arguments(f'-Wl,--stack,@stack_size@', language: 'c')
+  endif
+endif
+
 if meson.is_cross_build()
   native_cc = meson.get_compiler('c', native: true)
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,501 @@
+project(
+  'quickjs-ng',
+  'c',
+  version: '0.8.0',
+  default_options: [
+    'c_std=gnu11,c11',
+    'warning_level=3',
+    'default_library=static',
+  ],
+  license: 'MIT',
+  license_files: 'LICENSE',
+  meson_version: '>=1.3.0',
+)
+
+host_system = host_machine.system()
+cc = meson.get_compiler('c')
+
+qjs_gcc_warning_args = [
+  '-Wno-unsafe-buffer-usage',
+  '-Wno-sign-conversion',
+  '-Wno-nonportable-system-include-path',
+  '-Wno-implicit-int-conversion',
+  '-Wno-shorten-64-to-32',
+  '-Wno-reserved-macro-identifier',
+  '-Wno-reserved-identifier',
+  '-Wdeprecated-declarations',
+
+  '-Wno-implicit-fallthrough',
+  '-Wno-sign-compare',
+  '-Wno-missing-field-initializers',
+  '-Wno-unused-parameter',
+  '-Wno-unused-but-set-variable',
+  '-Wno-array-bounds',
+  '-Wno-format-truncation',
+]
+qjs_gcc_args = [
+  '-funsigned-char',
+]
+
+if host_system == 'darwin'
+  # https://github.com/quickjs-ng/quickjs/issues/453
+  qjs_gcc_warning_args += '-Wno-maybe-uninitialized'
+endif
+
+# https://github.com/microsoft/cpp-docs/tree/main/docs/error-messages/compiler-warnings
+qjs_msvc_warning_args = [
+  '/wd4018', # -Wno-sign-conversion
+  '/wd4061', # -Wno-implicit-fallthrough
+  '/wd4100', # -Wno-unused-parameter
+  '/wd4200', # -Wno-zero-length-array
+  '/wd4242', # -Wno-shorten-64-to-32
+  '/wd4244', # -Wno-shorten-64-to-32
+  '/wd4245', # -Wno-sign-compare
+  '/wd4267', # -Wno-shorten-64-to-32
+  '/wd4388', # -Wno-sign-compare
+  '/wd4389', # -Wno-sign-compare
+  '/wd4710', # Function not inlined
+  '/wd4711', # Function was inlined
+  '/wd4820', # Padding added after construct
+  '/wd4996', # -Wdeprecated-declarations
+  '/wd5045', # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+]
+qjs_msvc_args = [
+  '/experimental:c11atomics',
+  '/J', # -funsigned-char
+]
+
+if cc.get_argument_syntax() == 'msvc'
+  add_project_arguments(
+    cc.get_supported_arguments(qjs_msvc_warning_args),
+    cc.get_id().contains('clang') ? cc.get_supported_arguments(qjs_gcc_warning_args) : [],
+    qjs_msvc_args,
+    language: 'c',
+  )
+else
+  add_project_arguments(
+    cc.get_supported_arguments(qjs_gcc_warning_args),
+    qjs_gcc_args,
+    language: 'c',
+  )
+endif
+
+if meson.is_cross_build()
+  native_cc = meson.get_compiler('c', native: true)
+
+  if native_cc.get_argument_syntax() == 'msvc'
+    # https://github.com/microsoft/cpp-docs/tree/main/docs/error-messages/compiler-warnings
+    add_project_arguments(
+      native_cc.get_supported_arguments(qjs_msvc_warning_args),
+      native_cc.get_id().contains('clang') ? native_cc.get_supported_arguments(qjs_gcc_warning_args) : [],
+      qjs_msvc_args,
+
+      language: 'c',
+      native: true,
+    )
+  else
+    add_project_arguments(
+      native_cc.get_supported_arguments(qjs_gcc_warning_args),
+      qjs_gcc_args,
+
+      language: 'c',
+      native: true,
+    )
+  endif
+endif
+if get_option('debug')
+  add_project_arguments(
+    cc.get_supported_arguments('-fno-omit-frame-pointer'),
+    language: 'c',
+  )
+endif
+
+qjs_sys_deps = []
+
+m_dep = cc.find_library('m', required: false)
+qjs_sys_deps += m_dep
+qjs_sys_deps += dependency('threads', required: false)
+qjs_sys_deps += dependency('dl', required: false)
+
+qjs_srcs = files(
+  'cutils.c',
+  'libbf.c',
+  'libregexp.c',
+  'libunicode.c',
+  'quickjs.c',
+)
+qjs_hdrs = files(
+  'quickjs.h',
+)
+
+qjs_libc = get_option('libc')
+qjs_libc_srcs = files('quickjs-libc.c')
+qjs_libc_hdrs = files('quickjs-libc.h')
+
+if qjs_libc
+  qjs_hdrs += qjs_libc_hdrs
+endif
+
+qjs_c_args = ['-D_GNU_SOURCE']
+
+if host_system == 'windows'
+  qjs_c_args += ['-DWIN32_LEAN_AND_MEAN', '-D_WIN32_WINNT=0x0602']
+endif
+
+qjs_libc_lib = static_library(
+  'quickjs-libc',
+  qjs_libc_srcs,
+
+  dependencies: qjs_sys_deps,
+  c_args: qjs_c_args,
+  gnu_symbol_visibility: 'hidden',
+)
+
+qjs_lib = library(
+  'qjs',
+  qjs_srcs,
+
+  # export public headers
+  generator(
+    find_program('cp', 'xcopy'),
+    output: ['@PLAINNAME@'],
+    arguments: ['@INPUT@', '@OUTPUT@'],
+  ).process(qjs_hdrs),
+
+  dependencies: qjs_sys_deps,
+  link_whole: qjs_libc ? qjs_libc_lib : [],
+  c_args: qjs_c_args,
+  gnu_symbol_visibility: 'hidden',
+
+  install: true,
+  version: meson.project_version(),
+)
+
+qjs_dep = declare_dependency(
+  link_with: qjs_lib,
+  dependencies: qjs_sys_deps,
+  include_directories: qjs_lib.private_dir_include(),
+)
+
+if host_system == 'emscripten'
+  qjs_wasm_export_name = 'getQuickJs'
+  executable(
+    'qjs_wasm',
+    qjs_srcs,
+    link_args: cc.get_supported_link_arguments(
+      # in emscripten 3.x, this will be set to 16k which is too small for quickjs.
+      '-sSTACK_SIZE=@0@'.format(2 * 1024 * 1024), # let it be 2m = 2 * 1024 * 1024, otherwise, stack overflow may be occured at bootstrap
+      '-sNO_INVOKE_RUN',
+      '-sNO_EXIT_RUNTIME',
+      '-sMODULARIZE', # do not mess the global
+      '-sEXPORT_ES6', # export js file to morden es module
+      '-sEXPORT_NAME=@0@'.format(qjs_wasm_export_name), # give a name
+      '-sTEXTDECODER=1', # it will be 2 if we use -Oz, and that will cause js -> c string convertion fail
+      '-sNO_DEFAULT_TO_CXX', # this project is pure c project, no need for c plus plus handle
+      '-sEXPORTED_RUNTIME_METHODS=ccall,cwrap',
+    ),
+    dependencies: m_dep,
+    c_args: qjs_c_args,
+  )
+endif
+
+install_headers(qjs_hdrs, subdir: 'quickjs-ng')
+
+if not meson.is_subproject()
+  docdir = get_option('docdir')
+  datadir = get_option('datadir')
+
+  if docdir == ''
+    docdir = datadir / 'doc' / meson.project_name()
+  endif
+  install_data(
+    'LICENSE',
+    install_dir: docdir,
+
+    install_tag: 'doc',
+  )
+  install_subdir(
+    'examples',
+    install_dir: docdir,
+
+    strip_directory: false,
+    install_tag: 'doc',
+  )
+endif
+
+meson.override_dependency('quickjs-ng', qjs_dep)
+
+import('pkgconfig').generate(
+  qjs_lib,
+  subdirs: 'quickjs-ng',
+  name: 'quickjs-ng',
+  description: 'QuickJS, the Next Generation: a mighty JavaScript engine',
+  url: 'https://github.com/quickjs-ng/quickjs',
+  version: meson.project_version(),
+)
+
+# QuickJS bytecode compiler
+qjsc_srcs = files(
+  'qjsc.c',
+)
+qjsc_exe = executable(
+  'qjsc',
+  qjsc_srcs,
+
+  c_args: qjs_c_args,
+  link_with: qjs_libc ? [] : qjs_libc_lib,
+  dependencies: qjs_dep,
+
+  install: true,
+)
+
+mimalloc_dep = []
+mimalloc_sys_dep = dependency('mimalloc', required: get_option('cli_mimalloc'))
+if mimalloc_sys_dep.found()
+  mimalloc_dep = declare_dependency(
+    dependencies: mimalloc_sys_dep,
+    compile_args: '-DQJS_USE_MIMALLOC',
+  )
+endif
+
+# QuickJS CLI
+qjs_exe_srcs = files(
+  'gen/repl.c',
+  'gen/standalone.c',
+  'qjs.c',
+)
+qjs_exe = executable(
+  'qjs',
+  qjs_exe_srcs,
+
+  c_args: qjs_c_args,
+  link_with: qjs_libc ? [] : qjs_libc_lib,
+  dependencies: [qjs_dep, mimalloc_dep],
+
+  install: true,
+)
+
+if meson.is_cross_build()
+  mimalloc_native_dep = []
+  mimalloc_sys_native_dep = dependency('mimalloc', required: get_option('cli_mimalloc'), native: true)
+  if mimalloc_sys_dep.found()
+    mimalloc_native_dep = declare_dependency(
+      dependencies: mimalloc_sys_native_dep,
+      compile_args: '-DQJS_USE_MIMALLOC',
+    )
+  endif
+
+  qjs_sys_native_deps = [
+    native_cc.find_library('m', required: false),
+    dependency('threads', required: false, native: true),
+    dependency('dl', required: false, native: true),
+  ]
+  qjs_native_lib = static_library(
+    'qjs_native',
+    qjs_srcs,
+    qjs_libc_srcs,
+
+    dependencies: qjs_sys_native_deps,
+    c_args: qjs_c_args,
+    gnu_symbol_visibility: 'hidden',
+
+    build_by_default: false,
+    native: true,
+    install: false,
+  )
+
+  meson.override_find_program(
+    'qjsc',
+    executable(
+      'qjsc_native',
+      qjsc_srcs,
+
+      c_args: qjs_c_args,
+      link_with: qjs_native_lib,
+      dependencies: qjs_sys_native_deps,
+
+      build_by_default: false,
+      native: true,
+      install: false,
+    ),
+  )
+  meson.override_find_program(
+    'qjs',
+    executable(
+      'qjs_native',
+      qjs_exe_srcs,
+
+      c_args: qjs_c_args,
+      link_with: qjs_native_lib,
+      dependencies: [qjs_sys_native_deps, mimalloc_native_dep],
+
+      build_by_default: false,
+      native: true,
+      install: false,
+    ),
+  )
+else
+  meson.override_find_program('qjsc', qjsc_exe)
+  meson.override_find_program('qjs', qjs_exe)
+endif
+
+tests = get_option('tests').disable_auto_if(meson.is_subproject())
+examples = get_option('examples').disable_auto_if(meson.is_subproject())
+
+if tests.allowed()
+  if host_system != 'emscripten'
+    # Test262 runner
+    run262_exe = executable(
+      'run-test262',
+      'run-test262.c',
+      qjs_libc_srcs,
+
+      c_args: qjs_c_args,
+      dependencies: qjs_dep,
+    )
+
+    test(
+      'test',
+      run262_exe,
+      args: ['-c', files('tests.conf')],
+      workdir: meson.current_source_dir(),
+    )
+
+    foreach bench : [
+      'empty_loop',
+
+      'date_now',
+
+      'prop_read',
+      'prop_write',
+      'prop_create',
+      'prop_delete',
+
+      'array_read',
+      'array_write',
+      'array_prop_create',
+      'array_length_decr',
+      'array_hole_length_decr',
+      'array_push',
+      'array_pop',
+
+      'typed_array_read',
+      'typed_array_write',
+
+      'global_read',
+      'global_write',
+      'global_write_strict',
+
+      'local_destruct',
+      'global_destruct',
+      'global_destruct_strict',
+
+      'func_call',
+      'closure_var',
+
+      'int_arith',
+      'float_arith',
+
+      'set_collection_add',
+
+      'array_for',
+      'array_for_in',
+      'array_for_of',
+
+      'math_min',
+
+      'regexp_ascii',
+      'regexp_utf16',
+
+      'string_build1',
+      'string_build2',
+
+      'sort_bench',
+
+      'int_to_string',
+      'int_toString',
+
+      'float_to_string',
+      'float_toString',
+      'float_toFixed',
+      'float_toPrecision',
+      'float_toExponential',
+
+      'string_to_int',
+      'string_to_float',
+
+      'bigint64_arith',
+      'bigint256_arith',
+    ]
+      benchmark(
+        bench,
+        qjs_exe,
+        args: [files('tests/microbench.js'), bench],
+      )
+    endforeach
+  endif
+
+  # API test
+  test(
+    'api',
+    executable(
+      'api-test',
+      'api-test.c',
+
+      c_args: qjs_c_args,
+      dependencies: qjs_dep,
+    ),
+  )
+endif
+
+# Unicode generator
+executable(
+  'unicode_gen',
+  'cutils.c',
+  'libunicode.c',
+  'unicode_gen.c',
+
+  c_args: qjs_c_args,
+  build_by_default: false,
+)
+
+executable(
+  'function_source',
+  'gen/function_source.c',
+  qjs_libc_srcs,
+
+  c_args: qjs_c_args,
+  dependencies: qjs_dep,
+)
+
+if examples.allowed()
+  executable(
+    'hello',
+    'gen/hello.c',
+    qjs_libc_srcs,
+
+    c_args: qjs_c_args,
+    dependencies: qjs_dep,
+  )
+
+  executable(
+    'hello_module',
+    'gen/hello_module.c',
+    qjs_libc_srcs,
+
+    c_args: qjs_c_args,
+    dependencies: qjs_dep,
+  )
+
+  subdir('examples')
+
+  executable(
+    'test_fib',
+    'examples/fib.c',
+    'gen/test_fib.c',
+    qjs_libc_srcs,
+
+    c_args: qjs_c_args,
+    dependencies: qjs_dep,
+  )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('tests', type: 'feature', description: 'build tests')
+option('examples', type: 'feature', description: 'build examples')
+option('libc', type: 'boolean', value: false, description: 'build qjs standard library modules as part of the library')
+option('cli_mimalloc', type: 'feature', value: 'disabled', description: 'build qjs cli with mimalloc')
+option('docdir', type: 'string', description: 'documentation directory')

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -172,9 +172,15 @@ typedef struct JSThreadState {
 
 static uint64_t os_pending_signals;
 
+static void *js_std_dbuf_realloc(void *opaque, void *ptr, size_t size)
+{
+    JSRuntime *rt = opaque;
+    return js_realloc_rt(rt, ptr, size);
+}
+
 static void js_std_dbuf_init(JSContext *ctx, DynBuf *s)
 {
-    dbuf_init2(s, JS_GetRuntime(ctx), (DynBufReallocFunc *)js_realloc_rt);
+    dbuf_init2(s, JS_GetRuntime(ctx), js_std_dbuf_realloc);
 }
 
 static bool my_isdigit(int c)


### PR DESCRIPTION
Initial support for meson build system.
I plan to maintain this port continuously alongside cmake.

## suppoted features

- ~~`make BUILD_BACKEND=meson`~~ removed per request on <https://github.com/quickjs-ng/quickjs/pull/902#issuecomment-2645955264>
- all current cmake options (except wasi builds)
- tests integration
- benchmarks integration

## xrefs

https://github.com/mesonbuild/wrapdb/pull/1865
#761

## tested

- [x] linux gcc
- [x] mingw gcc (cross)
- [ ] mingw gcc (msys2)
- [ ] mingw clang (msys2)
- [x] msvc (cross)
- [ ] clang-cl
- [ ] apple clang