### PR TITLE
Enable workers on windows

### DIFF
--- a/tests/test_worker.js
+++ b/tests/test_worker.js
@@ -40,6 +40,4 @@ function test_worker()
     };
 }
 
-if (os.platform !== 'win32') {
-    test_worker();
-}
+test_worker();


### PR DESCRIPTION
Hello,

I would like to use workers with quickjs on windows,
Currently, this is locked behind USE_WORKER that excludes WIN32 with a comment that reads to me as if its because of lack of pthreads.
Windows C mingw compiler has its own implementation of pthreads,i have limited knowledge in this area, but it seems to run fine. Could something similar to this be added in near future?

Im posting as pull request to show example implementation, with test_worker.js working, sorry for moving js_os_poll around since changes are now less readable, it had to be underneath handle_posted_message