### PR TITLE
Only look up .stack property on exception objects

### DIFF
--- a/run-test262.c
+++ b/run-test262.c
@@ -1548,7 +1548,7 @@ static int eval_buf(JSContext *ctx, const char *buf, size_t buf_len,
                 }
             }
         }
-        if (is_unexpected_error && verbose > 1) {
+        if (is_unexpected_error && verbose > 1 && JS_IsException(exception_val)) {
             JSValue val = JS_GetPropertyStr(ctx, exception_val, "stack");
             if (!JS_IsException(val) &&
                 !JS_IsUndefined(val) &&


### PR DESCRIPTION
Without this additional check, run-test262 prints "TypeError: cannot read property 'stack' of undefined" when a test throws undefined, obscuring the actual error.