### PR TITLE
Fix calling build_backtrace too often

### DIFF
--- a/tests/bug904.js
+++ b/tests/bug904.js
@@ -1,0 +1,6 @@
+import {assert, assertThrows} from "./assert.js"
+let calls = 0
+Error.prepareStackTrace = function() { calls++ }
+function f() { f() }
+assertThrows(RangeError, f)
+assert(calls, 0)


### PR DESCRIPTION
Bug introduced in commit 4c32c53 from late last month.

When unwinding the stack, call build_backtrace only when the exception object doesn't already have a .stack property, like how it was before commit 4c32c53.

Fixes: https://github.com/quickjs-ng/quickjs/issues/904