### PR TITLE
Upgrade to ubuntu-22.04 CI image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,6 @@ jobs:
         with:
           submodules: true
 
-      # ASLR with big PIE slides does not work well with [AM]San
-      - name: disable ASLR
-        if: ${{ matrix.config.os == 'ubuntu-latest' && (matrix.config.configType == 'asan+ubsan' || matrix.config.configType == 'msan')}}
-        run: |
-          sudo sysctl -w kernel.randomize_va_space=0
-
       - name: install TCC
         if: ${{ matrix.config.configType == 'tcc' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
           path: build/*-windows-${{matrix.arch}}.exe
 
   wasi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: setup wasi-sdk
@@ -119,7 +119,7 @@ jobs:
 
   upload-to-release:
     needs: [linux, macos, windows, wasi]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: get assets
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The ubuntu-20.04 images will be shut down on April 1st.