### PR TITLE
Don't check line in JS_EvalThis2

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -33397,8 +33397,7 @@ JSValue JS_EvalThis2(JSContext *ctx, JSValue this_obj,
             return JS_ThrowInternalError(ctx, "bad JSEvalOptions version");
         if (options->filename)
             filename = options->filename;
-        if (options->line_num != 0)
-            line = options->line_num;
+        line = options->line_num;
         eval_flags = options->eval_flags;
     }
     JSValue ret;


### PR DESCRIPTION
The check was added in a later version of pull request an attempt to be on the safe side of things; but it break one Qbs test. Apparently, 0 is a valid value in Qbs code. Which might be a bug, but currently the code relies on that and when using 1 instead of 0, the line in the stack trace is not correct.
Remove the check for now.