### PR TITLE
Fix global property access crash in raw context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,9 @@ jobs:
           ./build/qjs -c examples/hello.js -o hello
           ./hello
       
-      - name: test interrupt
+      - name: test api
         run: |
-          ./build/interrupt-test
+          ./build/api-test
 
   windows-msvc:
     runs-on: windows-latest
@@ -197,9 +197,9 @@ jobs:
         run: |
           build\${{matrix.buildType}}\qjs.exe -c examples\hello.js -o hello.exe
           .\hello.exe
-      - name: test interrupt
+      - name: test api
         run: |
-          build\${{matrix.buildType}}\interrupt-test.exe
+          build\${{matrix.buildType}}\api-test.exe
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
@@ -262,9 +262,9 @@ jobs:
           build\${{matrix.buildType}}\qjs.exe examples\test_point.js
           build\${{matrix.buildType}}\run-test262.exe -c tests.conf
           build\${{matrix.buildType}}\function_source.exe
-      - name: test interrupt
+      - name: test api
         run: |
-          build\${{matrix.buildType}}\interrupt-test.exe
+          build\${{matrix.buildType}}\api-test.exe
 
   windows-ninja:
     runs-on: windows-latest
@@ -294,9 +294,9 @@ jobs:
           build\qjs.exe examples\test_point.js
           build\run-test262.exe -c tests.conf
           build\function_source.exe
-      - name: test interrupt
+      - name: test api
         run: |
-          build\interrupt-test.exe
+          build\api-test.exe
 
   windows-sdk:
     runs-on: windows-latest
@@ -327,9 +327,9 @@ jobs:
           build\${{matrix.buildType}}\qjs.exe examples\test_point.js
           build\${{matrix.buildType}}\run-test262.exe -c tests.conf
           build\${{matrix.buildType}}\function_source.exe
-      - name: test interrupt
+      - name: test api
         run: |
-          build\${{matrix.buildType}}\interrupt-test.exe
+          build\${{matrix.buildType}}\api-test.exe
 
   windows-mingw:
     runs-on: windows-latest
@@ -380,9 +380,9 @@ jobs:
       run: |
         ./build/qjs -c examples/hello.js -o hello.exe
         ./hello
-    - name: test interrupt
+    - name: test api
       run: |
-        ./build/interrupt-test
+        ./build/api-test
   windows-mingw-shared:
     runs-on: windows-latest
     defaults:
@@ -467,9 +467,9 @@ jobs:
       - name: test
         run: make test
 
-      - name: test interrupt
+      - name: test api
         run: |
-          ./build/interrupt-test
+          ./build/api-test
 
   openbsd:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,11 @@ endif()
 # Interrupt test
 #
 
-add_executable(interrupt-test
-    interrupt-test.c
+add_executable(api-test
+    api-test.c
 )
-target_compile_definitions(interrupt-test PRIVATE ${qjs_defines})
-target_link_libraries(interrupt-test qjs)
+target_compile_definitions(api-test PRIVATE ${qjs_defines})
+target_link_libraries(api-test qjs)
 
 # Unicode generator
 #

--- a/api-test.c
+++ b/api-test.c
@@ -125,10 +125,24 @@ static void raw_context_global_var(void)
     JSRuntime *rt = JS_NewRuntime();
     JSContext *ctx = JS_NewContextRaw(rt);
     JS_AddIntrinsicEval(ctx);
-    JSValue ret = JS_Eval(ctx, "globalThis", strlen("globalThis"), "<input>",
-                          JS_EVAL_TYPE_GLOBAL);
-    assert(JS_IsException(ret));
-    JS_FreeValue(ctx, ret);
+    {
+        static const char code[] = "globalThis";
+        JSValue ret = JS_Eval(ctx, code, strlen(code), "*", JS_EVAL_TYPE_GLOBAL);
+        assert(JS_IsException(ret));
+        JS_FreeValue(ctx, ret);
+    }
+    {
+        static const char code[] = "var x = 42";
+        JSValue ret = JS_Eval(ctx, code, strlen(code), "*", JS_EVAL_TYPE_GLOBAL);
+        assert(JS_IsUndefined(ret));
+        JS_FreeValue(ctx, ret);
+    }
+    {
+        static const char code[] = "function f() {}";
+        JSValue ret = JS_Eval(ctx, code, strlen(code), "*", JS_EVAL_TYPE_GLOBAL);
+        assert(JS_IsUndefined(ret));
+        JS_FreeValue(ctx, ret);
+    }
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -2232,6 +2232,7 @@ JSContext *JS_NewContextRaw(JSRuntime *rt)
     ctx->bf_ctx = &rt->bf_ctx;
     for(i = 0; i < rt->class_count; i++)
         ctx->class_proto[i] = JS_NULL;
+    ctx->global_obj = JS_NULL;
     ctx->array_ctor = JS_NULL;
     ctx->iterator_ctor = JS_NULL;
     ctx->regexp_ctor = JS_NULL;
@@ -51399,6 +51400,7 @@ static void JS_AddIntrinsicBasicObjects(JSContext *ctx)
     int i;
 
     ctx->class_proto[JS_CLASS_OBJECT] = JS_NewObjectProto(ctx, JS_NULL);
+    ctx->global_var_obj = JS_NewObjectProto(ctx, JS_NULL);
     ctx->function_proto = JS_NewCFunction3(ctx, js_function_proto, "", 0,
                                            JS_CFUNC_generic, 0,
                                            ctx->class_proto[JS_CLASS_OBJECT]);
@@ -51459,7 +51461,6 @@ void JS_AddIntrinsicBaseObjects(JSContext *ctx)
     JS_FreeValue(ctx, js_object_seal(ctx, JS_UNDEFINED, 1, &ctx->throw_type_error, 1));
 
     ctx->global_obj = JS_NewObject(ctx);
-    ctx->global_var_obj = JS_NewObjectProto(ctx, JS_NULL);
 
     /* Object */
     obj = JS_NewGlobalCConstructor(ctx, "Object", js_object_constructor, 1,

--- a/quickjs.c
+++ b/quickjs.c
@@ -2232,7 +2232,6 @@ JSContext *JS_NewContextRaw(JSRuntime *rt)
     ctx->bf_ctx = &rt->bf_ctx;
     for(i = 0; i < rt->class_count; i++)
         ctx->class_proto[i] = JS_NULL;
-    ctx->global_obj = JS_NULL;
     ctx->array_ctor = JS_NULL;
     ctx->iterator_ctor = JS_NULL;
     ctx->regexp_ctor = JS_NULL;
@@ -51400,6 +51399,7 @@ static void JS_AddIntrinsicBasicObjects(JSContext *ctx)
     int i;
 
     ctx->class_proto[JS_CLASS_OBJECT] = JS_NewObjectProto(ctx, JS_NULL);
+    ctx->global_obj = JS_NewObject(ctx);
     ctx->global_var_obj = JS_NewObjectProto(ctx, JS_NULL);
     ctx->function_proto = JS_NewCFunction3(ctx, js_function_proto, "", 0,
                                            JS_CFUNC_generic, 0,
@@ -51459,8 +51459,6 @@ void JS_AddIntrinsicBaseObjects(JSContext *ctx)
                       JS_PROP_HAS_CONFIGURABLE | JS_PROP_CONFIGURABLE);
     JS_FreeValue(ctx, obj1);
     JS_FreeValue(ctx, js_object_seal(ctx, JS_UNDEFINED, 1, &ctx->throw_type_error, 1));
-
-    ctx->global_obj = JS_NewObject(ctx);
 
     /* Object */
     obj = JS_NewGlobalCConstructor(ctx, "Object", js_object_constructor, 1,


### PR DESCRIPTION
A raw context doesn't contain anything but that doesn't mean property access is allowed to crash.

Rename interrupt-test.c to the more general api-test.c and add a test.

Fixes: https://github.com/quickjs-ng/quickjs/issues/914