### PR TITLE
Fix naming conflict on MSVC Debug mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,18 +184,18 @@ jobs:
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
         run: |
-          build\${{matrix.buildType}}\qjs.exe -qd
+          build\${{matrix.buildType}}\qjs_exe.exe -qd
       - name: test
         run: |
           cp build\${{matrix.buildType}}\fib.dll examples\
           cp build\${{matrix.buildType}}\point.dll examples\
-          build\${{matrix.buildType}}\qjs.exe examples\test_fib.js
-          build\${{matrix.buildType}}\qjs.exe examples\test_point.js
+          build\${{matrix.buildType}}\qjs_exe.exe examples\test_fib.js
+          build\${{matrix.buildType}}\qjs_exe.exe examples\test_point.js
           build\${{matrix.buildType}}\run-test262.exe -c tests.conf
           build\${{matrix.buildType}}\function_source.exe
       - name: test standalone
         run: |
-          build\${{matrix.buildType}}\qjs.exe -c examples\hello.js -o hello.exe
+          build\${{matrix.buildType}}\qjs_exe.exe -c examples\hello.js -o hello.exe
           .\hello.exe
       - name: test api
         run: |
@@ -224,7 +224,7 @@ jobs:
           cmake --build build --config ${{matrix.buildType}} --target qjs_exe
       - name: stats
         run: |
-          build\${{matrix.buildType}}\qjs.exe -qd
+          build\${{matrix.buildType}}\qjs_exe.exe -qd
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
@@ -249,7 +249,7 @@ jobs:
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
         run: |
-          build\${{matrix.buildType}}\qjs.exe -qd
+          build\${{matrix.buildType}}\qjs_exe.exe -qd
       - name: cxxtest
         run: |
           clang-cl.exe /DJS_NAN_BOXING=0 /Zs cxxtest.cc
@@ -258,8 +258,8 @@ jobs:
         run: |
           cp build\${{matrix.buildType}}\fib.dll examples\
           cp build\${{matrix.buildType}}\point.dll examples\
-          build\${{matrix.buildType}}\qjs.exe examples\test_fib.js
-          build\${{matrix.buildType}}\qjs.exe examples\test_point.js
+          build\${{matrix.buildType}}\qjs_exe.exe examples\test_fib.js
+          build\${{matrix.buildType}}\qjs_exe.exe examples\test_point.js
           build\${{matrix.buildType}}\run-test262.exe -c tests.conf
           build\${{matrix.buildType}}\function_source.exe
       - name: test api
@@ -285,13 +285,13 @@ jobs:
           cmake --build build
       - name: stats
         run: |
-          build\qjs.exe -qd
+          build\qjs_exe.exe -qd
       - name: test
         run: |
           cp build\fib.dll examples\
           cp build\point.dll examples\
-          build\qjs.exe examples\test_fib.js
-          build\qjs.exe examples\test_point.js
+          build\qjs_exe.exe examples\test_fib.js
+          build\qjs_exe.exe examples\test_point.js
           build\run-test262.exe -c tests.conf
           build\function_source.exe
       - name: test api
@@ -318,13 +318,13 @@ jobs:
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
         run: |
-          build\${{matrix.buildType}}\qjs.exe -qd
+          build\${{matrix.buildType}}\qjs_exe.exe -qd
       - name: test
         run: |
           cp build\${{matrix.buildType}}\fib.dll examples\
           cp build\${{matrix.buildType}}\point.dll examples\
-          build\${{matrix.buildType}}\qjs.exe examples\test_fib.js
-          build\${{matrix.buildType}}\qjs.exe examples\test_point.js
+          build\${{matrix.buildType}}\qjs_exe.exe examples\test_fib.js
+          build\${{matrix.buildType}}\qjs_exe.exe examples\test_point.js
           build\${{matrix.buildType}}\run-test262.exe -c tests.conf
           build\${{matrix.buildType}}\function_source.exe
       - name: test api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: build
         run: |
           make
-          mv build/qjs.exe build/qjs-windows-${{matrix.arch}}.exe
+          mv build/qjs_exe.exe build/qjs-windows-${{matrix.arch}}.exe
           mv build/qjsc.exe build/qjsc-windows-${{matrix.arch}}.exe
       - name: check
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,9 +275,6 @@ add_executable(qjs_exe
 )
 add_qjs_libc_if_needed(qjs_exe)
 add_static_if_needed(qjs_exe)
-set_target_properties(qjs_exe PROPERTIES
-    OUTPUT_NAME "qjs"
-)
 target_compile_definitions(qjs_exe PRIVATE ${qjs_defines})
 target_link_libraries(qjs_exe qjs)
 if(NOT WIN32)


### PR DESCRIPTION
There is naming conflict between qjs exe and lib. When building on MSVC Debug mode, qjs.exe will link qjs.lib and generate qjs.pdb, which is conflict with qjs lib pdb file and Error like:
`
D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\HostX64\x64\link.exe /ERRORREPORT:Q 
         UEUE /OUT:"E:\codes\SCGF\build\external\quickjs\Debug\qjs.exe" /INCREMENTAL /ILK:"qjs_exe.dir\Debug\qjs.ilk" /NOLOGO Debu 
         g\qjs.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi3 
         2.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /DEBUG /SUBSYSTEM:CONSOLE /TLBID:1 /DYN 
         AMICBASE /NXCOMPAT /IMPLIB:"E:/codes/SCGF/build/external/quickjs/Debug/qjs.lib" /MACHINE:X64  /machine:x64 qjs_exe.dir\De 
         bug\repl.obj
         qjs_exe.dir\Debug\standalone.obj
         qjs_exe.dir\Debug\qjs.obj
         "qjs_exe.dir\Debug\quickjs-libc.obj"
     8>LINK : fatal error LNK1201: error writing to program database 'E:\codes\SCGF\build\external\quickjs\Debug\qjs.pdb'; check f
       or insufficient disk space, invalid path, or insufficient privilege [E:\codes\SCGF\build\external\quickjs\qjs_exe.vcxproj]  
`