### PR TITLE
feat: add support for RegExp.leftContext RegExp.rightContext

### DIFF
--- a/test262.conf
+++ b/test262.conf
@@ -143,7 +143,7 @@ iterator-sequencing=skip
 json-modules=skip
 json-parse-with-source=skip
 json-superset
-legacy-regexp=skip
+legacy-regexp
 let
 logical-assignment-operators
 Map

--- a/tests/legacy_regexp.js
+++ b/tests/legacy_regexp.js
@@ -1,0 +1,8 @@
+import { assert } from "./assert.js";
+
+const testString = "Hello, world!";
+const regex = /world/;
+regex.exec(testString);
+
+assert(RegExp.leftContext === "Hello, ", true);
+assert(RegExp.rightContext === "!", true);


### PR DESCRIPTION
This pull request to `quickjs.c` introduces several changes to enhance the handling of regular expression contexts within the `JSContext` structure. The most important changes include adding new fields to store RegExp context information, initializing these fields in context creation, freeing them in context destruction, and implementing new functions to manage these contexts.

Enhancements to RegExp context handling:

* [`quickjs.c`](diffhunk://#diff-45f1ae674139f993bf8a99c382c1ba4863272a6fec2f492d76d7ff1b2cfcfbe2R412-R417): Added new fields `regexp_left_ctx`, `regexp_right_ctx`, `regexp_last_match_str`, `regexp_last_match_start`, and `regexp_last_match_end` to the `JSContext` structure to store RegExp context information.
* [`quickjs.c`](diffhunk://#diff-45f1ae674139f993bf8a99c382c1ba4863272a6fec2f492d76d7ff1b2cfcfbe2R2249-R2253): Initialized the new RegExp context fields in the `JS_NewContextRaw` function.
* [`quickjs.c`](diffhunk://#diff-45f1ae674139f993bf8a99c382c1ba4863272a6fec2f492d76d7ff1b2cfcfbe2R2454-R2456): Freed the new RegExp context fields in the `JS_FreeContext` function to prevent memory leaks.
* [`quickjs.c`](diffhunk://#diff-45f1ae674139f993bf8a99c382c1ba4863272a6fec2f492d76d7ff1b2cfcfbe2R43838-R43855): Implemented new functions `js_regexp_get_leftContext` and `js_regexp_get_rightContext` to retrieve and manage the left and right context of the last RegExp match.
* [`quickjs.c`](diffhunk://#diff-45f1ae674139f993bf8a99c382c1ba4863272a6fec2f492d76d7ff1b2cfcfbe2R44042-R44046): Updated the `js_regexp_exec` function to store the last match string and its start and end positions in the new context fields.


```ts
// Define a string to test
const testString = "Hello, world!";

// Create a regular expression to match the word "world"
const regex = /world/;

// Execute the regular expression on the test string
const result = regex.exec(testString);

// Check if the match was successful
if (result) {
    // Print the matched result
    console.log("Matched:", result[0]);

    // Print the left context
    console.log("Left Context:", RegExp.leftContext);

    // Print the right context
    console.log("Right Context:", RegExp.rightContext);
} else {
    console.log("No match found.");
}
```

Closes #921
