### PR TITLE
Fix release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,6 @@ jobs:
       - name: get assets
         uses: actions/download-artifact@v4
         with:
-          pattern: *
           path: build
           merge-multiple: true
       - run: ls -R build


### PR DESCRIPTION
Apparently `pattern: *` is not valid syntax. I think we can do without patterns because we want to publish all artifacts anyway.
<hr>

Gleaned from https://github.com/actions/download-artifact/blob/main/README.md#download-all-artifacts