### PR TITLE
Fix ES module deserialization

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -662,6 +662,11 @@ static inline bool JS_IsObject(JSValue v)
     return JS_VALUE_GET_TAG(v) == JS_TAG_OBJECT;
 }
 
+static inline bool JS_IsModule(JSValue v)
+{
+    return JS_VALUE_GET_TAG(v) == JS_TAG_MODULE;
+}
+
 JS_EXTERN JSValue JS_Throw(JSContext *ctx, JSValue obj);
 JS_EXTERN JSValue JS_GetException(JSContext *ctx);
 JS_EXTERN bool JS_HasException(JSContext *ctx);


### PR DESCRIPTION
A module's imports are not serialized along with the module itself and that left the deserialized module with dangling references. Fix that by checking the module cache first, the module loader second.

A glaring problem with cache checking is that the cached module doesn't have to be the module it was at the time of serialization.

Why not call out to the module loader right away? Because then a module can get loaded twice and that's arguably even worse.

The alternative of serializing modules transitively doesn't work for C modules and is also prone to loading the same module twice.

Fixes: https://github.com/quickjs-ng/quickjs/issues/913

<hr>

As you can probably tell, I don't think it's a great fix, merely the least terrible.