### PR TITLE
Remove obsolete test262 feature

### DIFF
--- a/test262.conf
+++ b/test262.conf
@@ -103,7 +103,6 @@ explicit-resource-management=skip
 exponentiation
 export-star-as-namespace-from-module
 FinalizationRegistry
-FinalizationRegistry.prototype.cleanupSome=skip
 Float16Array
 Float32Array
 Float64Array


### PR DESCRIPTION
The FinalizationRegistry.prototype.cleanupSome proposal was withdrawn. There are no test262 tests left with that feature.