### PR TITLE
Support reading script source from stdin in qjs

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -120,7 +120,9 @@ static int eval_buf(JSContext *ctx, const void *buf, int buf_len,
         val = JS_Eval(ctx, buf, buf_len, filename,
                       eval_flags | JS_EVAL_FLAG_COMPILE_ONLY);
         if (!JS_IsException(val)) {
-            use_realpath = (*filename != '<'); // ex. "<cmdline>"
+            // ex. "<cmdline>" pr "/dev/stdin"
+            use_realpath =
+                !(*filename == '<' || !strncmp(filename, "/dev/", 5));
             if (js_module_set_import_meta(ctx, val, use_realpath, true) < 0) {
                 js_std_dump_error(ctx);
                 ret = -1;

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -418,45 +418,37 @@ fail:
 uint8_t *js_load_file(JSContext *ctx, size_t *pbuf_len, const char *filename)
 {
     FILE *f;
-    uint8_t *buf;
-    size_t buf_len;
-    long lret;
+    size_t n, len;
+    uint8_t *p, *buf, tmp[8192];
 
     f = fopen(filename, "rb");
     if (!f)
         return NULL;
-    if (fseek(f, 0, SEEK_END) < 0)
-        goto fail;
-    lret = ftell(f);
-    if (lret < 0)
-        goto fail;
-    /* XXX: on Linux, ftell() return LONG_MAX for directories */
-    if (lret == LONG_MAX) {
-        errno = EISDIR;
-        goto fail;
-    }
-    buf_len = lret;
-    if (fseek(f, 0, SEEK_SET) < 0)
-        goto fail;
-    if (ctx)
-        buf = js_malloc(ctx, buf_len + 1);
-    else
-        buf = malloc(buf_len + 1);
-    if (!buf)
-        goto fail;
-    if (fread(buf, 1, buf_len, f) != buf_len) {
-        errno = EIO;
-        if (ctx)
-            js_free(ctx, buf);
-        else
-            free(buf);
-    fail:
-        fclose(f);
-        return NULL;
-    }
-    buf[buf_len] = '\0';
+    buf = NULL;
+    len = 0;
+    do {
+        n = fread(tmp, 1, sizeof(tmp), f);
+        if (ctx) {
+            p = js_realloc(ctx, buf, len + n + 1);
+        } else {
+            p = realloc(buf, len + n + 1);
+        }
+        if (!p) {
+            if (ctx) {
+                js_free(ctx, buf);
+            } else {
+                free(buf);
+            }
+            fclose(f);
+            return NULL;
+        }
+        memcpy(&p[len], tmp, n);
+        buf = p;
+        len += n;
+        buf[len] = '\0';
+    } while (n == sizeof(tmp));
     fclose(f);
-    *pbuf_len = buf_len;
+    *pbuf_len = len;
     return buf;
 }
 


### PR DESCRIPTION
Replace js_load_file with something that doesn't choke on special files and don't call realpath(3) on /dev files because that doesn't work.

Now `echo 'print("hello")' | qjs /dev/stdin` works.

Fixes: https://github.com/quickjs-ng/quickjs/issues/945