### PR TITLE
Implement `typeof` operator specializations

### DIFF
--- a/quickjs-opcode.h
+++ b/quickjs-opcode.h
@@ -362,8 +362,15 @@ DEF(          call3, 1, 1, 1, npopx)
 
 DEF(   is_undefined, 1, 1, 1, none)
 DEF(        is_null, 1, 1, 1, none)
+
 DEF(typeof_is_undefined, 1, 1, 1, none)
 DEF( typeof_is_function, 1, 1, 1, none)
+DEF(   typeof_is_number, 1, 1, 1, none)
+DEF(  typeof_is_boolean, 1, 1, 1, none)
+DEF(   typeof_is_string, 1, 1, 1, none)
+DEF(   typeof_is_object, 1, 1, 1, none)
+DEF(   typeof_is_symbol, 1, 1, 1, none)
+DEF(   typeof_is_bigint, 1, 1, 1, none)
 
 #undef DEF
 #undef def

--- a/quickjs.c
+++ b/quickjs.c
@@ -17296,6 +17296,42 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValue func_obj,
             } else {
                 goto free_and_set_false;
             }
+        CASE(OP_typeof_is_number):
+            if (js_operator_typeof(ctx, sp[-1]) == JS_ATOM_number) {
+                goto free_and_set_true;
+            } else {
+                goto free_and_set_false;
+            }
+        CASE(OP_typeof_is_boolean):
+            if (js_operator_typeof(ctx, sp[-1]) == JS_ATOM_boolean) {
+                goto free_and_set_true;
+            } else {
+                goto free_and_set_false;
+            }
+        CASE(OP_typeof_is_string):
+            if (js_operator_typeof(ctx, sp[-1]) == JS_ATOM_string) {
+                goto free_and_set_true;
+            } else {
+                goto free_and_set_false;
+            }
+        CASE(OP_typeof_is_object):
+            if (js_operator_typeof(ctx, sp[-1]) == JS_ATOM_object) {
+                goto free_and_set_true;
+            } else {
+                goto free_and_set_false;
+            }
+        CASE(OP_typeof_is_symbol):
+            if (js_operator_typeof(ctx, sp[-1]) == JS_ATOM_symbol) {
+                goto free_and_set_true;
+            } else {
+                goto free_and_set_false;
+            }
+        CASE(OP_typeof_is_bigint):
+            if (js_operator_typeof(ctx, sp[-1]) == JS_ATOM_bigint) {
+                goto free_and_set_true;
+            } else {
+                goto free_and_set_false;
+            }
         free_and_set_true:
             JS_FreeValue(ctx, sp[-1]);
         set_true:
@@ -31711,6 +31747,24 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
                     break;
                 case JS_ATOM_function:
                     op2 = OP_typeof_is_function;
+                    break;
+                case JS_ATOM_number:
+                    op2 = OP_typeof_is_number;
+                    break;
+                case JS_ATOM_boolean:
+                    op2 = OP_typeof_is_boolean;
+                    break;
+                case JS_ATOM_string:
+                    op2 = OP_typeof_is_string;
+                    break;
+                case JS_ATOM_object:
+                    op2 = OP_typeof_is_object;
+                    break;
+                case JS_ATOM_symbol:
+                    op2 = OP_typeof_is_symbol;
+                    break;
+                case JS_ATOM_bigint:
+                    op2 = OP_typeof_is_bigint;
                     break;
                 }
                 if (op2 >= 0) {


### PR DESCRIPTION
As mentioned in https://github.com/quickjs-ng/quickjs/issues/750 the specialized versions of the typeof operator are a little faster.
Haven't yet benchmarked the impact, that's why I am marking it as a draft for now.

This should handle all typeof operator usages except those which check for `null`, as those will need a different implementation of which I have no idea on how to implement.