### PR TITLE
Add JS_IsPlainObject function

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -12095,6 +12095,15 @@ bool JS_IsArray(JSValueConst val)
     return false;
 }
 
+bool JS_IsActualObject(JSValueConst val)
+{
+    if (JS_VALUE_GET_TAG(val) == JS_TAG_OBJECT) {
+        JSObject *p = JS_VALUE_GET_OBJ(val);
+        return p->class_id == JS_CLASS_OBJECT;
+    }
+    return false;
+}
+
 /* return -1 if exception (proxy case) or true/false */
 static int js_is_array(JSContext *ctx, JSValueConst val)
 {

--- a/quickjs.c
+++ b/quickjs.c
@@ -12095,7 +12095,7 @@ bool JS_IsArray(JSValueConst val)
     return false;
 }
 
-bool JS_IsActualObject(JSValueConst val)
+bool JS_IsPlainObject(JSValueConst val)
 {
     if (JS_VALUE_GET_TAG(val) == JS_TAG_OBJECT) {
         JSObject *p = JS_VALUE_GET_OBJ(val);

--- a/quickjs.h
+++ b/quickjs.h
@@ -807,7 +807,7 @@ JS_EXTERN JSValue JS_NewArrayFrom(JSContext *ctx, int count,
 // and JS_GetProxyTarget instead, and remember that the target itself can
 // also be a proxy, ad infinitum
 JS_EXTERN bool JS_IsArray(JSValueConst val);
-JS_EXTERN bool JS_IsActualObject(JSValueConst val);
+JS_EXTERN bool JS_IsPlainObject(JSValueConst val);
 
 JS_EXTERN bool JS_IsProxy(JSValueConst val);
 JS_EXTERN JSValue JS_GetProxyTarget(JSContext *ctx, JSValueConst proxy);

--- a/quickjs.h
+++ b/quickjs.h
@@ -807,6 +807,7 @@ JS_EXTERN JSValue JS_NewArrayFrom(JSContext *ctx, int count,
 // and JS_GetProxyTarget instead, and remember that the target itself can
 // also be a proxy, ad infinitum
 JS_EXTERN bool JS_IsArray(JSValueConst val);
+JS_EXTERN bool JS_IsActualObject(JSValueConst val);
 
 JS_EXTERN bool JS_IsProxy(JSValueConst val);
 JS_EXTERN JSValue JS_GetProxyTarget(JSContext *ctx, JSValueConst proxy);


### PR DESCRIPTION
Used to check if an object is actually a JS object, since JS_IsObject only checked if the tag of a JSValue is JS_TAG_OBJECT.