### PR TITLE
fix: Replace `/bin/sh` with `/usr/bin/env sh`

### DIFF
--- a/tests/test_std.js
+++ b/tests/test_std.js
@@ -208,7 +208,7 @@ function test_os_exec()
     ret = os.exec(["true"]);
     assert(ret, 0);
 
-    ret = os.exec(["/bin/sh", "-c", "exit 1"], { usePath: false });
+    ret = os.exec(["/usr/bin/env", "sh", "-c", "exit 1"], { usePath: false });
     assert(ret, 1);
 
     fds = os.pipe();


### PR DESCRIPTION
Instead of hard-coding with `/bin/sh`, use the more portable `/usr/bin/env` to find `sh`