### PR TITLE
Add qjsc -C flag to compile as classic script

### DIFF
--- a/qjs.c
+++ b/qjs.c
@@ -382,8 +382,8 @@ void help(void)
            "-h  --help         list options\n"
            "-e  --eval EXPR    evaluate EXPR\n"
            "-i  --interactive  go to interactive mode\n"
-           "-m  --module       load as ES6 module (default=autodetect)\n"
-           "    --script       load as ES6 script (default=autodetect)\n"
+           "-C  --script       load as JS classic script (default=autodetect)\n"
+           "-m  --module       load as ES module (default=autodetect)\n"
            "-I  --include file include an additional file\n"
            "    --std          make 'std', 'os' and 'bjson' available to script\n"
            "-T  --trace        trace memory allocation\n"
@@ -498,7 +498,7 @@ int main(int argc, char **argv)
                 module = 1;
                 continue;
             }
-            if (!strcmp(longopt, "script")) {
+            if (opt == 'C' || !strcmp(longopt, "script")) {
                 module = 0;
                 continue;
             }

--- a/qjsc.c
+++ b/qjsc.c
@@ -347,7 +347,8 @@ void help(void)
            "-o output   set the output filename\n"
            "-n script_name    set the script name (as used in stack traces)\n"
            "-N cname    set the C name of the generated data\n"
-           "-m          compile as Javascript module (default=autodetect)\n"
+           "-C          compile as JS classic script (default=autodetect)\n"
+           "-m          compile as ES module (default=autodetect)\n"
            "-D module_name         compile a dynamically loaded module or worker\n"
            "-M module_name[,cname] add initialization code for an external C module\n"
            "-p prefix   set the prefix of the generated C names\n"
@@ -390,7 +391,7 @@ int main(int argc, char **argv)
     namelist_add(&cmodule_list, "bjson", "bjson", 0);
 
     for(;;) {
-        c = getopt(argc, argv, "ho:N:mn:bxesvM:p:S:D:");
+        c = getopt(argc, argv, "ho:N:Cmn:bxesvM:p:S:D:");
         if (c == -1)
             break;
         switch(c) {
@@ -410,6 +411,9 @@ int main(int argc, char **argv)
             break;
         case 'N':
             cname = optarg;
+            break;
+        case 'C':
+            module = 0;
             break;
         case 'm':
             module = 1;


### PR DESCRIPTION
Add -C as the complementary to the -m flag to qjsc that compiles the input as an ES module.

Add -C as a shorthand alias for --script to qjs and harmonize the qjs and qjsc help messages.