### PR TITLE
Relax overly restrictive DataView bounds check

### DIFF
--- a/tests/bug988.js
+++ b/tests/bug988.js
@@ -1,0 +1,7 @@
+import {assert} from  "./assert.js"
+const expected = [97,98,99]
+const ab = new ArrayBuffer(0, {maxByteLength:3})
+const dv = new DataView(ab)
+ab.resize(3)
+for (const [i,v] of Object.entries(expected)) dv.setUint8(i, v)
+for (const [i,v] of Object.entries(expected)) assert(v, dv.getUint8(i))


### PR DESCRIPTION
Relax the bounds checks for DataViews that auto-track resizable ArrayBuffers.

Fixes: https://github.com/quickjs-ng/quickjs/issues/988