### PR TITLE
Fix updating DataView length when backing buffer is resized

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -52309,8 +52309,12 @@ static JSValue js_array_buffer_resize(JSContext *ctx, JSValueConst this_val,
     list_for_each(el, &abuf->array_list) {
         ta = list_entry(el, JSTypedArray, link);
         p = ta->obj;
-        if (p->class_id == JS_CLASS_DATAVIEW)
+        if (p->class_id == JS_CLASS_DATAVIEW) {
+            if (ta->track_rab && ta->offset < len)
+                ta->length = len - ta->offset;
+
             continue;
+        }
         p->u.array.count = 0;
         p->u.array.u.ptr = NULL;
         size_log2 = typed_array_size_log2(p->class_id);
@@ -54699,8 +54703,7 @@ static JSValue js_dataview_setValue(JSContext *ctx,
     if (class_id <= JS_CLASS_UINT32_ARRAY) {
         if (JS_ToUint32(ctx, &v, val))
             return JS_EXCEPTION;
-    } else
-    if (class_id <= JS_CLASS_BIG_UINT64_ARRAY) {
+    } else if (class_id <= JS_CLASS_BIG_UINT64_ARRAY) {
         if (JS_ToBigInt64(ctx, (int64_t *)&v64, val))
             return JS_EXCEPTION;
     } else {

--- a/tests/bug988.js
+++ b/tests/bug988.js
@@ -5,4 +5,3 @@ const dv = new DataView(ab)
 ab.resize(3)
 for (const [i,v] of Object.entries(expected)) dv.setUint8(i, v)
 for (const [i,v] of Object.entries(expected)) assert(v, dv.getUint8(i))
-

--- a/tests/bug988.js
+++ b/tests/bug988.js
@@ -1,0 +1,8 @@
+import {assert} from  "./assert.js"
+const expected = [97,98,99]
+const ab = new ArrayBuffer(0, {maxByteLength:3})
+const dv = new DataView(ab)
+ab.resize(3)
+for (const [i,v] of Object.entries(expected)) dv.setUint8(i, v)
+for (const [i,v] of Object.entries(expected)) assert(v, dv.getUint8(i))
+


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/988