### PR TITLE
Add pointer cast magic to avoid pedantic warnings with gcc-13

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -3115,7 +3115,7 @@ static js_once_t js_os_exec_once = JS_ONCE_INIT;
 
 static void js_os_exec_once_init(void)
 {
-    js_os_exec_closefrom = dlsym(RTLD_DEFAULT, "closefrom");
+     *(void **) (&js_os_exec_closefrom) = dlsym(RTLD_DEFAULT, "closefrom");
 }
 
 #endif


### PR DESCRIPTION
The same trick is used on line 689, so I'm considering it reasonable to do the same for js_os_exec_once_init.

```c
// ...
// line 689:
    *(void **) (&init) = dlsym(hd, "js_init_module");
// ...
```