### PR TITLE
fix memory leak in WeakMap

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -57263,6 +57263,7 @@ static void reset_weak_ref(JSRuntime *rt, JSWeakRefRecord **first_weak_ref)
             assert(!mr->empty); /* no iterator on WeakMap/WeakSet */
             list_del(&mr->hash_link);
             list_del(&mr->link);
+            s->record_count--;
             break;
         case JS_WEAK_REF_KIND_WEAK_REF:
             wrd = wr->u.weak_ref_data;


### PR DESCRIPTION
`JSMapState.record_count`  did not subtract 1 after a record is removed from WeakMap. It causes the hash table size to be incorrect when a new record is added.