### PR TITLE
Cherry-pick bellard/quickjs@1eb05e44fa

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -36250,6 +36250,10 @@ static JSString *JS_ReadString(BCReaderState *s)
         return NULL;
     is_wide_char = len & 1;
     len >>= 1;
+    if (len > JS_STRING_LEN_MAX) {
+        JS_ThrowInternalError(s->ctx, "string too long");
+        return NULL;
+    }
     p = js_alloc_string(s->ctx, len, is_wide_char);
     if (!p) {
         s->error_state = -1;
@@ -36361,8 +36365,7 @@ static JSValue JS_ReadBigInt(BCReaderState *s)
         bc_read_trace(s, "}\n");
         return __JS_NewShortBigInt(s->ctx, 0);
     }
-    p = js_bigint_new(s->ctx,
-                      (len + (JS_LIMB_BITS / 8) - 1) / (JS_LIMB_BITS / 8));
+    p = js_bigint_new(s->ctx, (len - 1) / (JS_LIMB_BITS / 8) + 1);
     if (!p)
         goto fail;
     for(i = 0; i < len / (JS_LIMB_BITS / 8); i++) {

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -285,16 +285,17 @@ function bjson_test_bytecode()
 function bjson_test_fuzz()
 {
     var corpus = [
-        "EBAAAAAABGA=",
-        "EObm5oIt",
-        "EAARABMGBgYGBgYGBgYGBv////8QABEALxH/vy8R/78=",
+        "FBAAAAAABGA=",
+        "FObm5oIt",
+        "FAARABMGBgYGBgYGBgYGBv////8QABEALxH/vy8R/78=",
+        "FAAIfwAK/////3//////////////////////////////3/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAD5+fn5+fn5+fn5+fkAAAAAAAYAqw==",
     ];
     for (var input of corpus) {
         var buf = base64decode(input);
         try {
             bjson.read(buf, 0, buf.byteLength);
         } catch (e) {
-            // okay, ignore
+            if (/invalid version/.test(e.message)) throw e; // corpus needs update
         }
     }
 }


### PR DESCRIPTION
Fix buffer overflows in the string and BigInt deserializer caused by a missing length check and bad size calculation respectively.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1018