### PR TITLE
Use js_free instead of bare free in api-test.c

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -217,7 +217,7 @@ static void module_serde(void)
     JS_FreeValue(ctx, mod);
     assert(loader_calls == 1);
     mod = JS_ReadObject(ctx, buf, len, JS_READ_OBJ_BYTECODE);
-    free(buf);
+    js_free(ctx, buf);
     assert(loader_calls == 1); // 'b' is returned from cache
     assert(!JS_IsException(mod));
     JSValue ret = JS_EvalFunction(ctx, mod);


### PR DESCRIPTION
Functionally a no-op when not using a custom allocator but it's more correct and ensures quickjs knows how much memory has been allocated.