### PR TITLE
Fix reporting handled promises as unhandled in tracker

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -50210,6 +50210,32 @@ static JSValue promise_reaction_job(JSContext *ctx, int argc,
     return res2;
 }
 
+static JSValue promise_rejection_tracker_job(JSContext *ctx, int argc,
+                                             JSValueConst *argv)
+{
+    JSRuntime *rt;
+    JSPromiseData *s;
+    JSValueConst promise;
+
+    assert(argc == 1);
+
+    rt = ctx->rt;
+    promise = argv[0];
+    s = JS_GetOpaque(promise, JS_CLASS_PROMISE);
+
+    if (!s || s->promise_state != JS_PROMISE_REJECTED)
+        return JS_UNDEFINED; /* should never happen */
+
+    promise_trace(ctx, "promise_rejection_tracker_job\n");
+
+    // Check again in case the hook was removed.
+    if (rt->host_promise_rejection_tracker)
+        rt->host_promise_rejection_tracker(
+            ctx, promise, s->promise_result, s->is_handled, rt->host_promise_rejection_tracker_opaque);
+
+    return JS_UNDEFINED;
+}
+
 void JS_SetPromiseHook(JSRuntime *rt, JSPromiseHook promise_hook, void *opaque)
 {
     rt->promise_hook = promise_hook;
@@ -50247,14 +50273,6 @@ static void fulfill_or_reject_promise(JSContext *ctx, JSValueConst promise,
         }
     }
 
-    if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
-        JSRuntime *rt = ctx->rt;
-        if (rt->host_promise_rejection_tracker) {
-            rt->host_promise_rejection_tracker(ctx, promise, value, false,
-                                               rt->host_promise_rejection_tracker_opaque);
-        }
-    }
-
     list_for_each_safe(el, el1, &s->promise_reactions[is_reject]) {
         rd = list_entry(el, JSPromiseReactionData, link);
         args[0] = rd->resolving_funcs[0];
@@ -50271,6 +50289,12 @@ static void fulfill_or_reject_promise(JSContext *ctx, JSValueConst promise,
         rd = list_entry(el, JSPromiseReactionData, link);
         list_del(&rd->link);
         promise_reaction_data_free(ctx->rt, rd);
+    }
+
+    if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
+        JSRuntime *rt = ctx->rt;
+        if (rt->host_promise_rejection_tracker)
+            JS_EnqueueJob(ctx, promise_rejection_tracker_job, 1, &promise);
     }
 }
 
@@ -51018,10 +51042,8 @@ static __exception int perform_promise_then(JSContext *ctx,
         JSValueConst args[5];
         if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
             JSRuntime *rt = ctx->rt;
-            if (rt->host_promise_rejection_tracker) {
-                rt->host_promise_rejection_tracker(ctx, promise, s->promise_result,
-                                                   true, rt->host_promise_rejection_tracker_opaque);
-            }
+            if (rt->host_promise_rejection_tracker)
+                JS_EnqueueJob(ctx, promise_rejection_tracker_job, 1, &promise);
         }
         i = s->promise_state - JS_PROMISE_FULFILLED;
         rd = rd_array[i];

--- a/tests/bug39.js
+++ b/tests/bug39.js
@@ -1,0 +1,6 @@
+/*---
+flags: [qjs:track-promise-rejections]
+---*/
+
+Promise.reject().catch(() => print('oops'))
+Promise.resolve().then(() => print('ok'))


### PR DESCRIPTION
Enqueue a job which will perform the check after all reactions. Also drop the case in which the tracker gets called with `true`, the handler now only gets called when the promise rejection is unhandled.

Fixes: https://github.com/quickjs-ng/quickjs/issues/39