### PR TITLE
Fix compilation error with GCC 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,7 @@ jobs:
     - name: Setup MSYS2
       uses: msys2/setup-msys2@v2
       with:
+        update: true
         msystem: ${{matrix.sys}}
         install: >-
           git

--- a/quickjs.c
+++ b/quickjs.c
@@ -11724,7 +11724,12 @@ static JSBigInt *js_bigint_from_string(JSContext *ctx,
 }
 
 /* 2 <= base <= 36 */
-static char const digits[36] = "0123456789abcdefghijklmnopqrstuvwxyz";
+static char const digits[36] = {
+    '0','1','2','3','4','5','6','7','8','9',
+    'a','b','c','d','e','f','g','h','i','j',
+    'k','l','m','n','o','p','q','r','s','t',
+    'u','v','w','x','y','z'
+};
 
 /* special version going backwards */
 /* XXX: use dtoa.c */


### PR DESCRIPTION
```
quickjs.c:11727:32: error: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (37 chars into 36 available) [-Werror=unterminated-string-initialization]
11727 | static char const digits[36] = "0123456789abcdefghijklmnopqrstuvwxyz";
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```