### PR TITLE
Support for AVX MSVC builds

### DIFF
--- a/xsum.c
+++ b/xsum.c
@@ -67,7 +67,7 @@
 
 /* INCLUDE INTEL INTRINSICS IF USED AND AVAILABLE. */
 
-#if USE_SIMD && __SSE2__
+#if USE_SIMD && (__SSE2__ || __AVX__)
 # include <immintrin.h>
 #endif
 


### PR DESCRIPTION
To have <immintrin.h>, we need to check the __SSE2__ and __AVX__ macros.