### PR TITLE
Make os.exec support supplementary groups

### DIFF
--- a/docs/docs/stdlib.md
+++ b/docs/docs/stdlib.md
@@ -253,6 +253,8 @@ object containing optional parameters:
   process.
 - `uid` - Integer. If present, the process uid with `setuid`.
 - `gid` - Integer. If present, the process gid with `setgid`.
+- `groups` - Array of integer. If present, the supplementary
+   group IDs with `setgroup`.
 
 ### `waitpid(pid, options)`
 

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -31,7 +31,6 @@
 #include <assert.h>
 #if !defined(_MSC_VER)
 #include <unistd.h>
-#include <grp.h>
 #endif
 #include <errno.h>
 #include <fcntl.h>
@@ -67,6 +66,7 @@
 #include <termios.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
+#include <grp.h>
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Add a .groups property that is an array of group ids for setgroups.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1055

<hr>

No test because it cannot be tested without elevated privileges but `strace -fe setgroups` shows it works with both empty and non-empty lists:
```
$ strace -fe q=attach,exit -fe signal=kill -fe setgroups build/debug/qjs --std -e 'os.exec(["true"], {groups:[]})'
[pid 87228] setgroups(0, [])            = 0

$ strace -fe q=attach,exit -fe signal=kill -fe setgroups build/debug/qjs --std -e 'os.exec(["true"], {groups:[1,2,3]})'
[pid 87252] setgroups(3, [1, 2, 3])     = 0
```