### PR TITLE
Fix Iterator.prototype.constructor

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -53304,7 +53304,7 @@ void JS_AddIntrinsicBaseObjects(JSContext *ctx)
     // first creates a .constructor value property that we then replace with
     // an accessor
     ctx->iterator_ctor_getset = JS_NewCFunctionData(ctx, js_iterator_constructor_getset,
-                                                    0, 0, 1, &obj);
+                                                    0, 0, 1, vc(&obj));
     JS_DefineProperty(ctx, ctx->class_proto[JS_CLASS_ITERATOR],
                       JS_ATOM_constructor, JS_UNDEFINED,
                       ctx->iterator_ctor_getset, ctx->iterator_ctor_getset,

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -24,10 +24,6 @@ test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-retu
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js:72: strict mode: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js:66: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js:66: strict mode: TypeError: $DONE() not called
-test262/test/built-ins/Iterator/prototype/constructor/prop-desc.js:10: Test262Error: Expected SameValue(«"undefined"», «"function"») to be true
-test262/test/built-ins/Iterator/prototype/constructor/prop-desc.js:10: strict mode: Test262Error: Expected SameValue(«"undefined"», «"function"») to be true
-test262/test/built-ins/Iterator/prototype/constructor/weird-setter.js:23: TypeError: cannot read property 'call' of undefined
-test262/test/built-ins/Iterator/prototype/constructor/weird-setter.js:23: strict mode: TypeError: cannot read property 'call' of undefined
 test262/test/built-ins/Object/defineProperties/typedarray-backed-by-resizable-buffer.js:20: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/Object/defineProperties/typedarray-backed-by-resizable-buffer.js:20: strict mode: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 test262/test/built-ins/Object/defineProperty/coerced-P-grow.js:45: TypeError: out-of-bound index in typed array


### PR DESCRIPTION
TC39 in its wisdom decided the property should be an accessor with a setter that enforces certain properties on the set value. Make it so.