### PR TITLE
Fix String.prototype match/split/etc. methods

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -43529,7 +43529,7 @@ static JSValue js_string_match(JSContext *ctx, JSValueConst this_val,
     if (JS_IsUndefined(O) || JS_IsNull(O))
         return JS_ThrowTypeError(ctx, "cannot convert to object");
 
-    if (!JS_IsUndefined(regexp) && !JS_IsNull(regexp)) {
+    if (JS_IsObject(regexp)) {
         matcher = JS_GetProperty(ctx, regexp, atom);
         if (JS_IsException(matcher))
             return JS_EXCEPTION;
@@ -43695,7 +43695,7 @@ static JSValue js_string_replace(JSContext *ctx, JSValueConst this_val,
     replaceValue_str = JS_UNDEFINED;
     repl_str = JS_UNDEFINED;
 
-    if (!JS_IsUndefined(searchValue) && !JS_IsNull(searchValue)) {
+    if (JS_IsObject(searchValue)) {
         JSValue replacer;
         if (is_replaceAll) {
             if (check_regexp_g_flag(ctx, searchValue) < 0)
@@ -43806,7 +43806,7 @@ static JSValue js_string_split(JSContext *ctx, JSValueConst this_val,
     A = JS_UNDEFINED;
     R = JS_UNDEFINED;
 
-    if (!JS_IsUndefined(separator) && !JS_IsNull(separator)) {
+    if (JS_IsObject(separator)) {
         JSValue splitter;
         splitter = JS_GetProperty(ctx, separator, JS_ATOM_Symbol_split);
         if (JS_IsException(splitter))

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -40,62 +40,16 @@ test262/test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js:45:
 test262/test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js:45: strict mode: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
 test262/test/built-ins/RegExp/unicodeSets/generated/rgi-emoji-16.0.js:16: Test262Error: `\p{RGI_Emoji}` should match 🇨🇶 (U+01F1E8 U+01F1F6)
 test262/test/built-ins/RegExp/unicodeSets/generated/rgi-emoji-16.0.js:16: strict mode: Test262Error: `\p{RGI_Emoji}` should match 🇨🇶 (U+01F1E8 U+01F1F6)
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-bigint-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-bigint-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-boolean-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-boolean-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-number-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-number-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-string-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/match/cstm-matcher-on-string-primitive.js:22: strict mode: Test262Error: should not be called
 test262/test/built-ins/String/prototype/match/regexp-prototype-match-v-u-flag.js:10: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
 test262/test/built-ins/String/prototype/match/regexp-prototype-match-v-u-flag.js:10: strict mode: Test262Error: Actual argument shouldn't be nullish. Unicode property escapes with v flag
-test262/test/built-ins/String/prototype/matchAll/cstm-matchall-on-bigint-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/matchAll/cstm-matchall-on-bigint-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/matchAll/cstm-matchall-on-number-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/matchAll/cstm-matchall-on-number-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/matchAll/cstm-matchall-on-string-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/matchAll/cstm-matchall-on-string-primitive.js:22: strict mode: Test262Error: should not be called
 test262/test/built-ins/String/prototype/matchAll/regexp-prototype-matchAll-v-u-flag.js:73: Test262Error: Actual [] and expected [𠮷, 𠮷, 𠮷, 0, 3, 6] should have the same contents. 
 test262/test/built-ins/String/prototype/matchAll/regexp-prototype-matchAll-v-u-flag.js:73: strict mode: Test262Error: Actual [] and expected [𠮷, 𠮷, 𠮷, 0, 3, 6] should have the same contents. 
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-bigint-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-bigint-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-boolean-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-boolean-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-number-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-number-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-string-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replace/cstm-replace-on-string-primitive.js:21: strict mode: Test262Error: should not be called
 test262/test/built-ins/String/prototype/replace/regexp-prototype-replace-v-u-flag.js:9: Test262Error: Unicode property escapes with v flag Expected SameValue(«"𠮷a𠮷b𠮷"», «"XaXbX"») to be true
 test262/test/built-ins/String/prototype/replace/regexp-prototype-replace-v-u-flag.js:9: strict mode: Test262Error: Unicode property escapes with v flag Expected SameValue(«"𠮷a𠮷b𠮷"», «"XaXbX"») to be true
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-bigint-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-bigint-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-boolean-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-boolean-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-number-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-number-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-string-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/replaceAll/cstm-replaceall-on-string-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-bigint-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-bigint-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-boolean-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-boolean-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-number-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-number-primitive.js:21: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-string-primitive.js:21: Test262Error: should not be called
-test262/test/built-ins/String/prototype/search/cstm-search-on-string-primitive.js:21: strict mode: Test262Error: should not be called
 test262/test/built-ins/String/prototype/search/regexp-prototype-search-v-flag.js:9: Test262Error: Unicode property escapes with v flag Expected SameValue(«-1», «0») to be true
 test262/test/built-ins/String/prototype/search/regexp-prototype-search-v-flag.js:9: strict mode: Test262Error: Unicode property escapes with v flag Expected SameValue(«-1», «0») to be true
 test262/test/built-ins/String/prototype/search/regexp-prototype-search-v-u-flag.js:9: Test262Error: Unicode property escapes with v flag Expected SameValue(«-1», «0») to be true
 test262/test/built-ins/String/prototype/search/regexp-prototype-search-v-u-flag.js:9: strict mode: Test262Error: Unicode property escapes with v flag Expected SameValue(«-1», «0») to be true
-test262/test/built-ins/String/prototype/split/cstm-split-on-bigint-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-bigint-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-boolean-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-boolean-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-number-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-number-primitive.js:22: strict mode: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-string-primitive.js:22: Test262Error: should not be called
-test262/test/built-ins/String/prototype/split/cstm-split-on-string-primitive.js:22: strict mode: Test262Error: should not be called
 test262/test/built-ins/TypedArray/prototype/includes/search-undefined-after-shrinking-buffer-index-is-oob.js:23: Test262Error: Expected SameValue(«true», «false») to be true (Testing with Float64Array.)
 test262/test/built-ins/TypedArray/prototype/includes/search-undefined-after-shrinking-buffer-index-is-oob.js:23: strict mode: Test262Error: Expected SameValue(«true», «false») to be true (Testing with Float64Array.)
 test262/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js:35: Test262Error: value should not be coerced Expected SameValue(«22», «0») to be true


### PR DESCRIPTION
test262's expectation is that String methods don't try to look up well-known symbols like Symbol.match and Symbol.split on primitive values, even when those values have prototypes that do contain the symbol. Make it so.