### PR TITLE
Use poll() instead of select() in js_os_poll

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -61,12 +61,12 @@
 #define chdir _chdir
 #else
 #include <sys/ioctl.h>
+#include <poll.h>
 #if !defined(__wasi__)
 #include <dlfcn.h>
 #include <termios.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
-#include <poll.h>
 #include <grp.h>
 #endif
 


### PR DESCRIPTION
It's not safe to add file descriptors > FD_SETSIZE (usually 1,024) to a fd_set, it writes beyond the buffer. Switch to poll(2).

Fixes: https://github.com/quickjs-ng/quickjs/issues/1096