### PR TITLE
Enforce R^W in std.popen()

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -1150,7 +1150,7 @@ static JSValue js_std_popen(JSContext *ctx, JSValueConst this_val,
     mode = JS_ToCString(ctx, argv[1]);
     if (!mode)
         goto fail;
-    if (mode[strspn(mode, "rw")] != '\0') {
+    if (strcmp(mode, "r") && strcmp(mode, "w")) {
         JS_ThrowTypeError(ctx, "invalid file mode");
         goto fail;
     }

--- a/tests/test_std.js
+++ b/tests/test_std.js
@@ -104,6 +104,17 @@ function test_popen()
     std.writeFile(fname, content);
     assert(std.loadFile(fname), content);
 
+    // popen pipe is unidirectional so mode should
+    // be either read or write but not both
+    let caught = false;
+    try {
+        std.popen(cmd, "rw");
+    } catch (e) {
+        assert(/invalid file mode/.test(e.message));
+        caught = true;
+    }
+    assert(caught);
+
     /* execute shell command */
     f = std.popen(cmd + " " + fname, "r");
     str = f.readAsString();


### PR DESCRIPTION
Because a popen pipe is unidirectional the mode argument should be "r" or "w" but not "rw".