### PR TITLE
Use suffix .dylib for MacOS native modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,9 +379,10 @@ if(QJS_BUILD_EXAMPLES)
     target_compile_definitions(hello_module PRIVATE ${qjs_defines})
     target_link_libraries(hello_module qjs)
 
-    add_library(fib MODULE examples/fib.c)
+    add_library(fib SHARED examples/fib.c)
     set_target_properties(fib PROPERTIES
         PREFIX ""
+        SUFFIX ".qjs"
         C_VISIBILITY_PRESET default
     )
     target_compile_definitions(fib PRIVATE JS_SHARED_LIBRARY)
@@ -391,8 +392,9 @@ if(QJS_BUILD_EXAMPLES)
         target_link_options(fib PRIVATE -undefined dynamic_lookup)
     endif()
 
-    add_library(point MODULE examples/point.c)
+    add_library(point SHARED examples/point.c)
     set_target_properties(point PROPERTIES
+        OUTPUT_NAME "point.qjs"
         PREFIX ""
         C_VISIBILITY_PRESET default
     )

--- a/examples/test_fib.js
+++ b/examples/test_fib.js
@@ -1,8 +1,6 @@
 /* example of JS module importing a C module */
-import * as os from "qjs:os";
 
-const isWin = os.platform === 'win32';
-const { fib } = await import(`./fib.${isWin ? 'dll' : 'so'}`);
+const { fib } = await import(`./fib.qjs`);
 
 console.log("Hello World");
 console.log("fib(10)=", fib(10));

--- a/examples/test_point.js
+++ b/examples/test_point.js
@@ -1,8 +1,10 @@
 /* example of JS module importing a C module */
-import * as os from "qjs:os";
 
-const isWin = os.platform === 'win32';
-const { Point } = await import(`./point.${isWin ? 'dll' : 'so'}`);
+// This should look for:
+//  - point.qjs.dll on Win32,
+//  - point.qjs.so on Linux,
+//  - point.qjs.dylib on macOS
+const { Point } = await import(`./point.qjs`);
 
 function assert(b, str)
 {

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -99,6 +99,8 @@ extern char **environ;
 #ifndef QJS_NATIVE_MODULE_SUFFIX
 #ifdef _WIN32
 #define QJS_NATIVE_MODULE_SUFFIX ".dll"
+#elif defined(__APPLE__)
+#define QJS_NATIVE_MODULE_SUFFIX ".dylib"
 #else
 #define QJS_NATIVE_MODULE_SUFFIX ".so"
 #endif


### PR DESCRIPTION
- The current implementation only supports `.so` (Unix-like platforms) and `.dll` (Windows) extensions
- macOS requires `.dylib` for native modules
