### PR TITLE
Handle zero limb when counting leading zeroes

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -10617,6 +10617,8 @@ do {                                                    \
 /* a != 0 */
 static inline js_limb_t js_limb_clz(js_limb_t a)
 {
+    if (!a)
+        return JS_LIMB_BITS;
     return clz32(a);
 }
 

--- a/tests/test_bigint.js
+++ b/tests/test_bigint.js
@@ -63,6 +63,8 @@ function test_bigint1()
 
     r = 1n << 32n;
     assert(r, 4294967296n, "1 << 32n === 4294967296n");
+
+    assert(String(-9223372036854775808n), "-9223372036854775808");
 }
 
 function test_bigint2()


### PR DESCRIPTION
I opted to take a more general approach than bellard/quickjs@638ec8c so this problem hopefully doesn't show up again in the future.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1105