### PR TITLE
Make TypedArray constructor extensible

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -57144,6 +57144,7 @@ void JS_AddIntrinsicTypedArrays(JSContext *ctx)
                                js_typed_array_base_funcs,
                                countof(js_typed_array_base_funcs));
     JS_SetConstructor(ctx, typed_array_base_func, typed_array_base_proto);
+    JS_SetConstructorBit(ctx, typed_array_base_func, true);
 
     /* Used to squelch a -Wcast-function-type warning. */
     JSCFunctionType ft = { .generic_magic = js_typed_array_constructor };

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -569,6 +569,16 @@ function test_typed_array()
     assert(a.buffer, b.buffer);
     assert(a.toString(), "0,0,0,255");
     assert(b.toString(), "0,0,255,255");
+
+    const TypedArray = class extends Object.getPrototypeOf(Uint8Array) {};
+    let caught = false;
+    try {
+        new TypedArray(); // extensible but not instantiable
+    } catch (e) {
+        assert(/cannot be called/.test(e.message));
+        caught = true;
+    }
+    assert(caught);
 }
 
 function test_json()


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/1112