### PR TITLE
Optimize {__proto__:null} object literal creation

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -16449,6 +16449,7 @@ typedef enum {
     OP_SPECIAL_OBJECT_HOME_OBJECT,
     OP_SPECIAL_OBJECT_VAR_OBJECT,
     OP_SPECIAL_OBJECT_IMPORT_META,
+    OP_SPECIAL_OBJECT_NULL_PROTO,
 } OPSpecialObjectEnum;
 
 #define FUNC_RET_AWAIT      0
@@ -16745,6 +16746,11 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     break;
                 case OP_SPECIAL_OBJECT_IMPORT_META:
                     *sp++ = js_import_meta(ctx);
+                    if (unlikely(JS_IsException(sp[-1])))
+                        goto exception;
+                    break;
+                case OP_SPECIAL_OBJECT_NULL_PROTO:
+                    *sp++ = JS_NewObjectProtoClass(ctx, JS_NULL, JS_CLASS_OBJECT);
                     if (unlikely(JS_IsException(sp[-1])))
                         goto exception;
                     break;
@@ -33487,6 +33493,18 @@ static __exception int resolve_labels(JSContext *ctx, JSFunctionDef *s)
                         goto has_label;
                     }
                 }
+            }
+            goto no_change;
+
+        case OP_object:
+            if (code_match(&cc, pos_next, OP_null, OP_set_proto, -1)) {
+                if (cc.line_num >= 0) line_num = cc.line_num;
+                if (cc.col_num >= 0) col_num = cc.col_num;
+                add_pc2line_info(s, bc_out.size, line_num, col_num);
+                dbuf_putc(&bc_out, OP_special_object);
+                dbuf_putc(&bc_out, OP_SPECIAL_OBJECT_NULL_PROTO);
+                pos_next = cc.pos;
+                break;
             }
             goto no_change;
 

--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -710,6 +710,15 @@ function math_min(n)
     return n * 1000;
 }
 
+function object_null(n)
+{
+    var j;
+    for(j = 0; j < n; j++) {
+        global_res = {__proto__: null};
+    }
+    return n;
+}
+
 function regexp_ascii(n)
 {
     var i, j, r, s;
@@ -1098,6 +1107,7 @@ function main(argc, argv, g)
         array_for_in,
         array_for_of,
         math_min,
+        object_null,
         regexp_ascii,
         regexp_utf16,
         string_build1,


### PR DESCRIPTION
Speeds up the common pattern of creating prototype-less objects by 40%:

                  TEST          N TIME (ns)  REF (ns) SCORE (%)
           object_null      20000    124.50

                  TEST          N TIME (ns)  REF (ns) SCORE (%)
           object_null      50000     74.30

It's so much faster the benchmarker decides to run it 50,000 times instead of merely 20,000 times. Win.