### PR TITLE
Make initial shape hash table bigger

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -4430,7 +4430,7 @@ static inline JSShapeProperty *get_shape_prop(JSShape *sh)
 
 static int init_shape_hash(JSRuntime *rt)
 {
-    rt->shape_hash_bits = 4;   /* 16 shapes */
+    rt->shape_hash_bits = 6;   /* 64 shapes */
     rt->shape_hash_size = 1 << rt->shape_hash_bits;
     rt->shape_hash_count = 0;
     rt->shape_hash = js_mallocz_rt(rt, sizeof(rt->shape_hash[0]) *


### PR DESCRIPTION
Even an empty script requires more than 16 entries in the hash table.

Before this commit, executing an empty script caused the hash table to resize two times. Now, it's the proper size from the start and not resized at all.