### PR TITLE
Fix regression in 0.10.x: fix type for is_detached

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -374,7 +374,7 @@ typedef struct JSVarRef {
         struct {
             int __gc_ref_count; /* corresponds to header.ref_count */
             uint8_t __gc_mark; /* corresponds to header.mark/gc_obj_type */
-            bool is_detached;
+            uint8_t is_detached;
         };
     };
     JSValue *pvalue; /* pointer to the value, either on the stack or


### PR DESCRIPTION
This fixes regression in 0.10.0, see: https://github.com/quickjs-ng/quickjs/issues/1122
Subsequent segfault still remains, but it also happens with 0.9.0 and 0.8.0.

@andrjohns @bnoordhuis 