### PR TITLE
C++ mode

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -6446,7 +6446,7 @@ void JS_ComputeMemoryUsage(JSRuntime *rt, JSMemoryUsage *s)
 
 void JS_DumpMemoryUsage(FILE *fp, const JSMemoryUsage *s, JSRuntime *rt)
 {
-    fprintf(fp, "QuickJS-ng memory usage -- %s version, %d-bit, %s Endian, malloc limit: %"PRId64"\n\n",
+    fprintf(fp, "QuickJS-ng memory usage -- %s version, %d-bit, %s Endian, malloc limit: %" PRId64 "\n\n",
         JS_GetVersion(), (int)sizeof(void *) * 8, is_be() ? "Big" : "Little", s->malloc_limit);
     if (rt) {
         static const struct {
@@ -6506,63 +6506,63 @@ void JS_DumpMemoryUsage(FILE *fp, const JSMemoryUsage *s, JSRuntime *rt)
     fprintf(fp, "%-20s %8s %8s\n", "NAME", "COUNT", "SIZE");
 
     if (s->malloc_count) {
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per block)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per block)\n",
                 "memory allocated", s->malloc_count, s->malloc_size,
                 (double)s->malloc_size / s->malloc_count);
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%d overhead, %0.1f average slack)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64"   (%d overhead, %0.1f average slack)\n",
                 "memory used", s->memory_used_count, s->memory_used_size,
                 MALLOC_OVERHEAD, ((double)(s->malloc_size - s->memory_used_size) /
                                   s->memory_used_count));
     }
     if (s->atom_count) {
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per atom)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per atom)\n",
                 "atoms", s->atom_count, s->atom_size,
                 (double)s->atom_size / s->atom_count);
     }
     if (s->str_count) {
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per string)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per string)\n",
                 "strings", s->str_count, s->str_size,
                 (double)s->str_size / s->str_count);
     }
     if (s->obj_count) {
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per object)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per object)\n",
                 "objects", s->obj_count, s->obj_size,
                 (double)s->obj_size / s->obj_count);
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per object)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per object)\n",
                 "  properties", s->prop_count, s->prop_size,
                 (double)s->prop_count / s->obj_count);
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per shape)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per shape)\n",
                 "  shapes", s->shape_count, s->shape_size,
                 (double)s->shape_size / s->shape_count);
     }
     if (s->js_func_count) {
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "\n",
                 "bytecode functions", s->js_func_count, s->js_func_size);
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per function)\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per function)\n",
                 "  bytecode", s->js_func_count, s->js_func_code_size,
                 (double)s->js_func_code_size / s->js_func_count);
         if (s->js_func_pc2line_count) {
-            fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per function)\n",
+            fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per function)\n",
                     "  pc2line", s->js_func_pc2line_count,
                     s->js_func_pc2line_size,
                     (double)s->js_func_pc2line_size / s->js_func_pc2line_count);
         }
     }
     if (s->c_func_count) {
-        fprintf(fp, "%-20s %8"PRId64"\n", "C functions", s->c_func_count);
+        fprintf(fp, "%-20s %8" PRId64 "\n", "C functions", s->c_func_count);
     }
     if (s->array_count) {
-        fprintf(fp, "%-20s %8"PRId64"\n", "arrays", s->array_count);
+        fprintf(fp, "%-20s %8" PRId64 "\n", "arrays", s->array_count);
         if (s->fast_array_count) {
-            fprintf(fp, "%-20s %8"PRId64"\n", "  fast arrays", s->fast_array_count);
-            fprintf(fp, "%-20s %8"PRId64" %8"PRId64"  (%0.1f per fast array)\n",
+            fprintf(fp, "%-20s %8" PRId64 "\n", "  fast arrays", s->fast_array_count);
+            fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "  (%0.1f per fast array)\n",
                     "  elements", s->fast_array_elements,
                     s->fast_array_elements * (int)sizeof(JSValue),
                     (double)s->fast_array_elements / s->fast_array_count);
         }
     }
     if (s->binary_object_count) {
-        fprintf(fp, "%-20s %8"PRId64" %8"PRId64"\n",
+        fprintf(fp, "%-20s %8" PRId64 " %8" PRId64 "\n",
                 "binary objects", s->binary_object_count, s->binary_object_size);
     }
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -2887,7 +2887,7 @@ static JSAtomKindEnum JS_AtomGetKind(JSContext *ctx, JSAtom v)
     default:
         abort();
     }
-    return (JSAtomKindEnum){-1}; // pacify compiler
+    return (JSAtomKindEnum)(-1); // pacify compiler
 }
 
 static JSAtom js_get_atom_index(JSRuntime *rt, JSAtomStruct *p)
@@ -5459,7 +5459,7 @@ static JSContext *js_autoinit_get_realm(JSProperty *pr)
 
 static JSAutoInitIDEnum js_autoinit_get_id(JSProperty *pr)
 {
-    return pr->u.init.realm_and_id & 3;
+    return (JSAutoInitIDEnum)(pr->u.init.realm_and_id & 3);
 }
 
 static void js_autoinit_free(JSRuntime *rt, JSProperty *pr)
@@ -16313,7 +16313,7 @@ static JSValue js_call_c_function(JSContext *ctx, JSValueConst func_obj,
     JSCFunctionEnum cproto;
 
     p = JS_VALUE_GET_OBJ(func_obj);
-    cproto = p->u.cfunc.cproto;
+    cproto = (JSCFunctionEnum)p->u.cfunc.cproto;
     arg_count = p->u.cfunc.length;
 
     /* better to always check stack overflow */
@@ -23290,7 +23290,7 @@ static __exception int js_parse_object_literal(JSParseState *s)
 
             func_kind = JS_FUNC_NORMAL;
             if (is_getset) {
-                func_type = JS_PARSE_FUNC_GETTER + prop_type - PROP_TYPE_GET;
+                func_type = (JSParseFunctionEnum)(JS_PARSE_FUNC_GETTER + prop_type - PROP_TYPE_GET);
             } else {
                 func_type = JS_PARSE_FUNC_METHOD;
                 if (prop_type == PROP_TYPE_STAR)
@@ -34382,7 +34382,7 @@ static __exception int js_parse_function_decl2(JSParseState *s,
         if (s->token.val == '*') {
             if (next_token(s))
                 return -1;
-            func_kind |= JS_FUNC_GENERATOR;
+            func_kind = (JSFunctionKindEnum)(func_kind | JS_FUNC_GENERATOR);
         }
 
         if (s->token.val == TOK_IDENT) {
@@ -36934,7 +36934,7 @@ static JSValue JS_ReadModule(BCReaderState *s)
             JSExportEntry *me = &m->export_entries[i];
             if (bc_get_u8(s, &v8))
                 goto fail;
-            me->export_type = v8;
+            me->export_type = (JSExportTypeEnum)v8;
             if (me->export_type == JS_EXPORT_TYPE_LOCAL) {
                 if (bc_get_leb128_int(s, &me->u.local.var_idx))
                     goto fail;
@@ -39155,7 +39155,7 @@ static JSValue js_function_proto(JSContext *ctx, JSValueConst this_val,
 static JSValue js_function_constructor(JSContext *ctx, JSValueConst new_target,
                                        int argc, JSValueConst *argv, int magic)
 {
-    JSFunctionKindEnum func_kind = magic;
+    JSFunctionKindEnum func_kind = (JSFunctionKindEnum)magic;
     int i, n, ret;
     JSValue s, proto, obj = JS_UNDEFINED;
     StringBuffer b_s, *b = &b_s;
@@ -41691,7 +41691,7 @@ static JSValue js_create_array_iterator(JSContext *ctx, JSValueConst this_val,
     JSIteratorKindEnum kind;
     int class_id;
 
-    kind = magic & 3;
+    kind = (JSIteratorKindEnum)(magic & 3);
     if (magic & 4) {
         /* string iterator case */
         arr = JS_ToStringCheckObject(ctx, this_val);
@@ -42015,7 +42015,7 @@ static JSValue js_create_iterator_helper(JSContext *ctx, JSValueConst this_val,
         JS_FreeValue(ctx, method);
         goto fail;
     }
-    it->kind = magic;
+    it->kind = (JSIteratorHelperKindEnum)magic;
     it->obj = js_dup(this_val);
     it->func = js_dup(func);
     it->next = method;
@@ -44520,7 +44520,7 @@ static JSValue js_string_normalize(JSContext *ctx, JSValueConst this_val,
             p++;
         }
         if (*p == 'C' || *p == 'D') {
-            n_type = UNICODE_NFC + is_compat * 2 + (*p - 'C');
+            n_type = (UnicodeNormalizationEnum)(UNICODE_NFC + is_compat * 2 + (*p - 'C'));
             if ((p + 1 - form) != form_len)
                 goto bad_form;
         } else {
@@ -49372,7 +49372,7 @@ static JSValue js_create_map_iterator(JSContext *ctx, JSValueConst this_val,
     JSMapIteratorData *it;
     JSValue enum_obj;
 
-    kind = magic >> 2;
+    kind = (JSIteratorKindEnum)(magic >> 2);
     magic &= 3;
     s = (JSMapState *)JS_GetOpaque2(ctx, this_val, JS_CLASS_MAP + magic);
     if (!s)
@@ -50299,7 +50299,7 @@ JSPromiseStateEnum JS_PromiseState(JSContext *ctx, JSValueConst promise)
 {
     JSPromiseData *s = (JSPromiseData *)JS_GetOpaque(promise, JS_CLASS_PROMISE);
     if (!s)
-        return -1;
+        return (JSPromiseStateEnum)-1;
     return s->promise_state;
 }
 
@@ -50409,7 +50409,7 @@ static void fulfill_or_reject_promise(JSContext *ctx, JSValueConst promise,
     if (!s || s->promise_state != JS_PROMISE_PENDING)
         return; /* should never happen */
     set_value(ctx, &s->promise_result, js_dup(value));
-    s->promise_state = JS_PROMISE_FULFILLED + is_reject;
+    s->promise_state = (JSPromiseStateEnum)(JS_PROMISE_FULFILLED + is_reject);
 
     promise_trace(ctx, "fulfill_or_reject_promise: is_reject=%d\n", is_reject);
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -28065,7 +28065,7 @@ static char *js_default_module_normalize_name(JSContext *ctx,
         return js_strdup(ctx, name);
     }
 
-    p = strrchr(base_name, '/');
+    p = (char *)strrchr(base_name, '/');
     if (p)
         len = p - base_name;
     else

--- a/quickjs.c
+++ b/quickjs.c
@@ -3384,7 +3384,7 @@ static JSValue JS_AtomIsNumericIndex1(JSContext *ctx, JSAtom atom)
             c = *r;
             /* -0 case is specific */
             if (c == '0' && len == 2)
-                goto minus_zero;
+                return js_float64(-0.0);
         }
         /* XXX: should test NaN, but the tests do not check it */
         if (!is_num(c)) {
@@ -3405,10 +3405,8 @@ static JSValue JS_AtomIsNumericIndex1(JSContext *ctx, JSAtom atom)
             r++;
             c = *r;
             /* -0 case is specific */
-            if (c == '0' && len == 2) {
-            minus_zero:
+            if (c == '0' && len == 2)
                 return js_float64(-0.0);
-            }
         }
         if (!is_num(c)) {
             if (!(c =='I' && (r_end - r) == 8 &&
@@ -19554,10 +19552,12 @@ static bool js_async_function_resume(JSContext *ctx, JSAsyncFunctionData *s)
         if (unlikely(JS_IsUncatchableError(ctx, ctx->rt->current_exception))) {
             is_success = false;
         } else {
-            JSValue error = JS_GetException(ctx);
-            ret2 = JS_Call(ctx, s->resolving_funcs[1], JS_UNDEFINED,
-                           1, vc(&error));
-            JS_FreeValue(ctx, error);
+            {
+                JSValue error = JS_GetException(ctx);
+                ret2 = JS_Call(ctx, s->resolving_funcs[1], JS_UNDEFINED,
+                               1, vc(&error));
+                JS_FreeValue(ctx, error);
+            }
         resolved:
             if (unlikely(JS_IsException(ret2))) {
                 if (JS_IsUncatchableError(ctx, ctx->rt->current_exception)) {

--- a/quickjs.c
+++ b/quickjs.c
@@ -1370,14 +1370,14 @@ static const JSClassExoticMethods js_arguments_exotic_methods = {
 };
 static const JSClassExoticMethods js_string_exotic_methods = {
     .get_own_property = js_string_get_own_property,
-    .define_own_property = js_string_define_own_property,
     .delete_property = js_string_delete_property,
+    .define_own_property = js_string_define_own_property,
 };
 static const JSClassExoticMethods js_proxy_exotic_methods = {
     .get_own_property = js_proxy_get_own_property,
-    .define_own_property = js_proxy_define_own_property,
-    .delete_property = js_proxy_delete_property,
     .get_own_property_names = js_proxy_get_own_property_names,
+    .delete_property = js_proxy_delete_property,
+    .define_own_property = js_proxy_define_own_property,
     .has_property = js_proxy_has,
     .get_property = js_proxy_get,
     .set_property = js_proxy_set,
@@ -35195,9 +35195,9 @@ JSValue JS_EvalThis(JSContext *ctx, JSValueConst this_obj,
 {
     JSEvalOptions options = {
         .version = JS_EVAL_OPTIONS_VERSION,
+        .eval_flags = eval_flags,
         .filename = filename,
         .line_num = 1,
-        .eval_flags = eval_flags
     };
     return JS_EvalThis2(ctx, this_obj, input, input_len, &options);
 }
@@ -35232,9 +35232,9 @@ JSValue JS_Eval(JSContext *ctx, const char *input, size_t input_len,
 {
     JSEvalOptions options = {
         .version = JS_EVAL_OPTIONS_VERSION,
+        .eval_flags = eval_flags,
         .filename = filename,
         .line_num = 1,
-        .eval_flags = eval_flags
     };
     return JS_EvalThis2(ctx, ctx->global_obj, input, input_len, &options);
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -190,7 +190,11 @@ enum {
 
 /* number of typed array types */
 #define JS_TYPED_ARRAY_COUNT  (JS_CLASS_FLOAT64_ARRAY - JS_CLASS_UINT8C_ARRAY + 1)
-static uint8_t const typed_array_size_log2[JS_TYPED_ARRAY_COUNT];
+static uint8_t const typed_array_size_log2[JS_TYPED_ARRAY_COUNT] = {
+    0, 0, 0, 1, 1, 2, 2,
+    3, 3,                   // BigInt64Array, BigUint64Array
+    1, 2, 3                 // Float16Array, Float32Array, Float64Array
+};
 #define typed_array_size_log2(classid)  (typed_array_size_log2[(classid)- JS_CLASS_UINT8C_ARRAY])
 
 typedef enum JSErrorEnum {
@@ -53593,12 +53597,6 @@ void JS_AddIntrinsicBaseObjects(JSContext *ctx)
 }
 
 /* Typed Arrays */
-
-static uint8_t const typed_array_size_log2[JS_TYPED_ARRAY_COUNT] = {
-    0, 0, 0, 1, 1, 2, 2,
-    3, 3,                   // BigInt64Array, BigUint64Array
-    1, 2, 3                 // Float16Array, Float32Array, Float64Array
-};
 
 static JSValue js_array_buffer_constructor3(JSContext *ctx,
                                             JSValueConst new_target,

--- a/quickjs.c
+++ b/quickjs.c
@@ -13990,7 +13990,7 @@ static __exception int js_post_inc_slow(JSContext *ctx,
     }
     sp[-1] = op1;
     sp[0] = js_dup(op1);
-    return js_unary_arith_slow(ctx, sp + 1, op - OP_post_dec + OP_dec);
+    return js_unary_arith_slow(ctx, sp + 1, (OPCodeEnum)(op - OP_post_dec + OP_dec));
 }
 
 static no_inline int js_not_slow(JSContext *ctx, JSValue *sp)
@@ -14005,7 +14005,7 @@ static no_inline int js_not_slow(JSContext *ctx, JSValue *sp)
         sp[-1] = __JS_NewShortBigInt(ctx, ~JS_VALUE_GET_SHORT_BIG_INT(op1));
     } else if (JS_VALUE_GET_TAG(op1) == JS_TAG_BIG_INT) {
         JSBigInt *r;
-        r = js_bigint_not(ctx, JS_VALUE_GET_PTR(op1));
+        r = js_bigint_not(ctx, (const JSBigInt *)JS_VALUE_GET_PTR(op1));
         JS_FreeValue(ctx, op1);
         if (!r)
             goto exception;
@@ -18436,7 +18436,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
         CASE(OP_pow):
         binary_arith_slow:
             sf->cur_pc = pc;
-            if (js_binary_arith_slow(ctx, sp, opcode))
+            if (js_binary_arith_slow(ctx, sp, (OPCodeEnum)opcode))
                 goto exception;
             sp--;
             BREAK;
@@ -18450,7 +18450,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 if (tag == JS_TAG_INT || JS_TAG_IS_FLOAT64(tag)) {
                 } else {
                     sf->cur_pc = pc;
-                    if (js_unary_arith_slow(ctx, sp, opcode))
+                    if (js_unary_arith_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                 }
             }
@@ -18481,7 +18481,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     sp[-1] = js_float64(d);
                 } else {
                     sf->cur_pc = pc;
-                    if (js_unary_arith_slow(ctx, sp, opcode))
+                    if (js_unary_arith_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                 }
             }
@@ -18499,7 +18499,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 } else {
                 inc_slow:
                     sf->cur_pc = pc;
-                    if (js_unary_arith_slow(ctx, sp, opcode))
+                    if (js_unary_arith_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                 }
             }
@@ -18517,7 +18517,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 } else {
                 dec_slow:
                     sf->cur_pc = pc;
-                    if (js_unary_arith_slow(ctx, sp, opcode))
+                    if (js_unary_arith_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                 }
             }
@@ -18525,7 +18525,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
         CASE(OP_post_inc):
         CASE(OP_post_dec):
             sf->cur_pc = pc;
-            if (js_post_inc_slow(ctx, sp, opcode))
+            if (js_post_inc_slow(ctx, sp, (OPCodeEnum)opcode))
                 goto exception;
             sp++;
             BREAK;
@@ -18608,7 +18608,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     sp--;
                 } else {
                     sf->cur_pc = pc;
-                    if (js_binary_logic_slow(ctx, sp, opcode))
+                    if (js_binary_logic_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                     sp--;
                 }
@@ -18648,7 +18648,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     sp--;
                 } else {
                     sf->cur_pc = pc;
-                    if (js_binary_logic_slow(ctx, sp, opcode))
+                    if (js_binary_logic_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                     sp--;
                 }
@@ -18664,7 +18664,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     sp--;
                 } else {
                     sf->cur_pc = pc;
-                    if (js_binary_logic_slow(ctx, sp, opcode))
+                    if (js_binary_logic_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                     sp--;
                 }
@@ -18680,7 +18680,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     sp--;
                 } else {
                     sf->cur_pc = pc;
-                    if (js_binary_logic_slow(ctx, sp, opcode))
+                    if (js_binary_logic_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                     sp--;
                 }
@@ -18696,7 +18696,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     sp--;
                 } else {
                     sf->cur_pc = pc;
-                    if (js_binary_logic_slow(ctx, sp, opcode))
+                    if (js_binary_logic_slow(ctx, sp, (OPCodeEnum)opcode))
                         goto exception;
                     sp--;
                 }
@@ -18722,10 +18722,10 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 }                                                       \
             BREAK
 
-            OP_CMP(OP_lt, <, js_relational_slow(ctx, sp, opcode));
-            OP_CMP(OP_lte, <=, js_relational_slow(ctx, sp, opcode));
-            OP_CMP(OP_gt, >, js_relational_slow(ctx, sp, opcode));
-            OP_CMP(OP_gte, >=, js_relational_slow(ctx, sp, opcode));
+            OP_CMP(OP_lt, <, js_relational_slow(ctx, sp, (OPCodeEnum)opcode));
+            OP_CMP(OP_lte, <=, js_relational_slow(ctx, sp, (OPCodeEnum)opcode));
+            OP_CMP(OP_gt, >, js_relational_slow(ctx, sp, (OPCodeEnum)opcode));
+            OP_CMP(OP_gte, >=, js_relational_slow(ctx, sp, (OPCodeEnum)opcode));
             OP_CMP(OP_eq, ==, js_eq_slow(ctx, sp, 0));
             OP_CMP(OP_neq, !=, js_eq_slow(ctx, sp, 1));
             OP_CMP(OP_strict_eq, ==, js_strict_eq_slow(ctx, sp, 0));
@@ -22066,7 +22066,7 @@ static int new_label_fd(JSFunctionDef *fd)
     int label;
     LabelSlot *ls;
 
-    if (js_resize_array(fd->ctx, (void *)&fd->label_slots,
+    if (js_resize_array(fd->ctx, (void **)&fd->label_slots,
                             sizeof(fd->label_slots[0]),
                             &fd->label_size, fd->label_count + 1))
         return -1;
@@ -22133,7 +22133,7 @@ static int cpool_add(JSParseState *s, JSValue val)
 {
     JSFunctionDef *fd = s->cur_func;
 
-    if (js_resize_array(s->ctx, (void *)&fd->cpool, sizeof(fd->cpool[0]),
+    if (js_resize_array(s->ctx, (void **)&fd->cpool, sizeof(fd->cpool[0]),
                         &fd->cpool_size, fd->cpool_count + 1))
         return -1;
     fd->cpool[fd->cpool_count++] = val;
@@ -23739,13 +23739,13 @@ static __exception int js_parse_class(JSParseState *s, bool is_class_expr,
                     fd->vars[idx].var_kind = JS_VAR_PRIVATE_GETTER_SETTER;
                 } else {
                     if (add_private_class_field(s, fd, name,
-                                                JS_VAR_PRIVATE_GETTER + is_set, is_static) < 0)
+                                                (JSVarKindEnum)(JS_VAR_PRIVATE_GETTER + is_set), is_static) < 0)
                         goto fail;
                 }
                 class_fields[is_static].need_brand = true;
             }
 
-            if (js_parse_function_decl2(s, JS_PARSE_FUNC_GETTER + is_set,
+            if (js_parse_function_decl2(s, (JSParseFunctionEnum)(JS_PARSE_FUNC_GETTER + is_set),
                                         JS_FUNC_NORMAL, JS_ATOM_NULL,
                                         start_ptr,
                                         s->token.line_num,
@@ -31199,7 +31199,7 @@ static int resolve_scope_var(JSContext *ctx, JSFunctionDef *s,
                                            false,
                                            cv->is_arg, idx1,
                                            cv->var_name, cv->is_const,
-                                           cv->is_lexical, cv->var_kind);
+                                           cv->is_lexical, (JSVarKindEnum)cv->var_kind);
                 } else {
                     idx = idx1;
                 }
@@ -31238,7 +31238,7 @@ static int resolve_scope_var(JSContext *ctx, JSFunctionDef *s,
                                   var_name,
                                   fd->vars[var_idx].is_const,
                                   fd->vars[var_idx].is_lexical,
-                                  fd->vars[var_idx].var_kind);
+                                  (JSVarKindEnum)fd->vars[var_idx].var_kind);
         }
         if (idx >= 0) {
         has_idx:
@@ -31428,7 +31428,7 @@ static int resolve_scope_private_field1(JSContext *ctx,
                                                    cv->is_arg, idx,
                                                    cv->var_name, cv->is_const,
                                                    cv->is_lexical,
-                                                   cv->var_kind);
+                                                   (JSVarKindEnum)cv->var_kind);
                             if (idx < 0)
                                 return -1;
                         }
@@ -31659,7 +31659,7 @@ static void add_eval_variables(JSContext *ctx, JSFunctionDef *s)
             vd = &fd->vars[scope_idx];
             vd->is_captured = 1;
             get_closure_var(ctx, s, fd, false, scope_idx,
-                            vd->var_name, vd->is_const, vd->is_lexical, vd->var_kind);
+                            vd->var_name, vd->is_const, vd->is_lexical, (JSVarKindEnum)vd->var_kind);
             scope_idx = vd->scope_next;
         }
         is_arg_scope = (scope_idx == ARG_SCOPE_END);
@@ -31705,7 +31705,7 @@ static void add_eval_variables(JSContext *ctx, JSFunctionDef *s)
                 get_closure_var2(ctx, s, fd,
                                  false, cv->is_arg,
                                  idx, cv->var_name, cv->is_const,
-                                 cv->is_lexical, cv->var_kind);
+                                 cv->is_lexical, (JSVarKindEnum)cv->var_kind);
             }
         }
     }
@@ -35315,7 +35315,7 @@ static int js_object_list_add(JSContext *ctx, JSObjectList *s, JSObject *obj)
     JSObjectListEntry *e;
     uint32_t h, new_hash_size;
 
-    if (js_resize_array(ctx, (void *)&s->object_tab,
+    if (js_resize_array(ctx, (void **)&s->object_tab,
                         sizeof(s->object_tab[0]),
                         &s->object_size, s->object_count + 1))
         return -1;
@@ -36623,7 +36623,7 @@ static JSValue JS_ReadObjectRec(BCReaderState *s);
 static int BC_add_object_ref1(BCReaderState *s, JSObject *p)
 {
     if (s->allow_reference) {
-        if (js_resize_array(s->ctx, (void *)&s->objects,
+        if (js_resize_array(s->ctx, (void **)&s->objects,
                             sizeof(s->objects[0]),
                             &s->objects_size, s->objects_count + 1))
             return -1;
@@ -37597,7 +37597,7 @@ static JSValue JS_InstantiateFunctionListItem2(JSContext *ctx, JSObject *p,
     switch(e->def_type) {
     case JS_DEF_CFUNC:
         val = JS_NewCFunction2(ctx, e->u.func.cfunc.generic,
-                               e->name, e->u.func.length, e->u.func.cproto, e->magic);
+                               e->name, e->u.func.length, (JSCFunctionEnum)e->u.func.cproto, e->magic);
         break;
     case JS_DEF_PROP_STRING:
         val = JS_NewAtomString(ctx, e->u.str);
@@ -37745,7 +37745,7 @@ int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
         switch(e->def_type) {
         case JS_DEF_CFUNC:
             val = JS_NewCFunction2(ctx, e->u.func.cfunc.generic,
-                                   e->name, e->u.func.length, e->u.func.cproto, e->magic);
+                                   e->name, e->u.func.length, (JSCFunctionEnum)e->u.func.cproto, e->magic);
             break;
         case JS_DEF_PROP_STRING:
             /* `e->u.str` may be pure ASCII or UTF-8 encoded */
@@ -48869,7 +48869,7 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
         goto hash_float64;
     case (uint32_t)JS_TAG_BIG_INT:
         r = (JSBigInt *)JS_VALUE_GET_PTR(key);
-        h = hash_string8((void *)r->tab, r->len * sizeof(*r->tab), 0);
+        h = hash_string8((const uint8_t *)r->tab, r->len * sizeof(*r->tab), 0);
         break;
     case JS_TAG_FLOAT64:
         d = JS_VALUE_GET_FLOAT64(key);

--- a/quickjs.c
+++ b/quickjs.c
@@ -5797,7 +5797,7 @@ static void js_free_value_rt(JSRuntime *rt, JSValue v)
 #endif
 
     switch(tag) {
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         {
             JSString *p = JS_VALUE_GET_STRING(v);
             if (p->atom_type) {
@@ -5810,8 +5810,8 @@ static void js_free_value_rt(JSRuntime *rt, JSValue v)
             }
         }
         break;
-    case JS_TAG_OBJECT:
-    case JS_TAG_FUNCTION_BYTECODE:
+    case (uint32_t)JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_FUNCTION_BYTECODE:
         {
             JSGCObjectHeader *p = (JSGCObjectHeader *)JS_VALUE_GET_PTR(v);
             if (rt->gc_phase != JS_GC_PHASE_REMOVE_CYCLES) {
@@ -5823,16 +5823,16 @@ static void js_free_value_rt(JSRuntime *rt, JSValue v)
             }
         }
         break;
-    case JS_TAG_MODULE:
+    case (uint32_t)JS_TAG_MODULE:
         abort(); /* never freed here */
         break;
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         {
             JSBigInt *p = (JSBigInt *)JS_VALUE_GET_PTR(v);
             js_free_rt(rt, p);
         }
         break;
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_SYMBOL:
         {
             JSAtomStruct *p = (JSAtomStruct *)JS_VALUE_GET_PTR(v);
             JS_FreeAtomStruct(rt, p);
@@ -7608,7 +7608,7 @@ static JSValue JS_GetPropertyInternal(JSContext *ctx, JSValueConst obj,
             return JS_ThrowTypeErrorAtom(ctx, "cannot read property '%s' of undefined", prop);
         case JS_TAG_EXCEPTION:
             return JS_EXCEPTION;
-        case JS_TAG_STRING:
+        case (uint32_t)JS_TAG_STRING:
             {
                 JSString *p1 = JS_VALUE_GET_STRING(obj);
                 if (__JS_AtomIsTaggedInt(prop)) {
@@ -10540,7 +10540,7 @@ static int JS_ToBoolFree(JSContext *ctx, JSValue val)
         return JS_VALUE_GET_INT(val);
     case JS_TAG_EXCEPTION:
         return -1;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         {
             bool ret = JS_VALUE_GET_STRING(val)->len != 0;
             JS_FreeValue(ctx, val);
@@ -10548,7 +10548,7 @@ static int JS_ToBoolFree(JSContext *ctx, JSValue val)
         }
     case JS_TAG_SHORT_BIG_INT:
         return JS_VALUE_GET_SHORT_BIG_INT(val) != 0;
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         {
             JSBigInt *p = (JSBigInt *)JS_VALUE_GET_PTR(val);
             bool ret;
@@ -10567,7 +10567,7 @@ static int JS_ToBoolFree(JSContext *ctx, JSValue val)
             JS_FreeValue(ctx, val);
             return ret;
         }
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         {
             JSObject *p = JS_VALUE_GET_OBJ(val);
             bool ret = !p->is_HTMLDDA;
@@ -12252,7 +12252,7 @@ static JSValue JS_ToNumberHintFree(JSContext *ctx, JSValue val,
  redo:
     tag = JS_VALUE_GET_NORM_TAG(val);
     switch(tag) {
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
     case JS_TAG_SHORT_BIG_INT:
         if (flag != TON_FLAG_NUMERIC) {
             JS_FreeValue(ctx, val);
@@ -12272,12 +12272,12 @@ static JSValue JS_ToNumberHintFree(JSContext *ctx, JSValue val,
     case JS_TAG_UNDEFINED:
         ret = JS_NAN;
         break;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         val = JS_ToPrimitiveFree(ctx, val, HINT_NUMBER);
         if (JS_IsException(val))
             return JS_EXCEPTION;
         goto redo;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         {
             const char *str;
             size_t len;
@@ -12296,7 +12296,7 @@ static JSValue JS_ToNumberHintFree(JSContext *ctx, JSValue val,
             JS_FreeCString(ctx, str);
         }
         break;
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_SYMBOL:
         JS_FreeValue(ctx, val);
         return JS_ThrowTypeError(ctx, "cannot convert symbol to number");
     default:
@@ -12837,7 +12837,7 @@ static bool JS_NumberIsNegativeOrMinusZero(JSContext *ctx, JSValueConst val)
         }
     case JS_TAG_SHORT_BIG_INT:
         return (JS_VALUE_GET_SHORT_BIG_INT(val) < 0);
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         {
             JSBigInt *p = (JSBigInt *)JS_VALUE_GET_PTR(val);
             return js_bigint_sign(p);
@@ -13284,7 +13284,7 @@ JSValue JS_ToStringInternal(JSContext *ctx, JSValueConst val,
 
     tag = JS_VALUE_GET_NORM_TAG(val);
     switch(tag) {
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         return js_dup(val);
     case JS_TAG_INT:
         len = i32toa(buf, JS_VALUE_GET_INT(val));
@@ -13298,7 +13298,7 @@ JSValue JS_ToStringInternal(JSContext *ctx, JSValueConst val,
         return JS_AtomToString(ctx, JS_ATOM_undefined);
     case JS_TAG_EXCEPTION:
         return JS_EXCEPTION;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         {
             JSValue val1, ret;
             val1 = JS_ToPrimitive(ctx, val, HINT_STRING);
@@ -13309,9 +13309,9 @@ JSValue JS_ToStringInternal(JSContext *ctx, JSValueConst val,
             return ret;
         }
         break;
-    case JS_TAG_FUNCTION_BYTECODE:
+    case (uint32_t)JS_TAG_FUNCTION_BYTECODE:
         return js_new_string8(ctx, "[function bytecode]");
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_SYMBOL:
         if (is_ToPropertyKey) {
             return js_dup(val);
         } else {
@@ -13320,7 +13320,7 @@ JSValue JS_ToStringInternal(JSContext *ctx, JSValueConst val,
     case JS_TAG_FLOAT64:
         return js_dtoa(ctx, JS_VALUE_GET_FLOAT64(val), 0, JS_DTOA_TOSTRING);
     case JS_TAG_SHORT_BIG_INT:
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         return js_bigint_to_string(ctx, val);
     case JS_TAG_UNINITIALIZED:
         return js_new_string8(ctx, "[uninitialized]");
@@ -13608,7 +13608,7 @@ static __maybe_unused void JS_DumpValue(JSRuntime *rt, JSValueConst val)
     case JS_TAG_SHORT_BIG_INT:
         printf("%" PRId64 "n", (int64_t)JS_VALUE_GET_SHORT_BIG_INT(val));
         break;
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         {
             JSBigInt *p = (JSBigInt *)JS_VALUE_GET_PTR(val);
             int sgn, i;
@@ -13627,14 +13627,14 @@ static __maybe_unused void JS_DumpValue(JSRuntime *rt, JSValueConst val)
                 printf(")");
         }
         break;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         {
             JSString *p;
             p = JS_VALUE_GET_STRING(val);
             JS_DumpString(rt, p);
         }
         break;
-    case JS_TAG_FUNCTION_BYTECODE:
+    case (uint32_t)JS_TAG_FUNCTION_BYTECODE:
         {
             JSFunctionBytecode *b = (JSFunctionBytecode *)JS_VALUE_GET_PTR(val);
             char buf[ATOM_GET_STR_BUF_SIZE];
@@ -13645,7 +13645,7 @@ static __maybe_unused void JS_DumpValue(JSRuntime *rt, JSValueConst val)
             }
         }
         break;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         {
             JSObject *p = JS_VALUE_GET_OBJ(val);
             JSAtom atom = rt->class_array[p->class_id].class_name;
@@ -13654,7 +13654,7 @@ static __maybe_unused void JS_DumpValue(JSRuntime *rt, JSValueConst val)
                    JS_AtomGetStrRT(rt, atom_buf, sizeof(atom_buf), atom), (void *)p);
         }
         break;
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_SYMBOL:
         {
             JSAtomStruct *p = (JSAtomStruct *)JS_VALUE_GET_PTR(val);
             char atom_buf[ATOM_GET_STR_BUF_SIZE];
@@ -13662,7 +13662,7 @@ static __maybe_unused void JS_DumpValue(JSRuntime *rt, JSValueConst val)
                    JS_AtomGetStrRT(rt, atom_buf, sizeof(atom_buf), js_get_atom_index(rt, p)));
         }
         break;
-    case JS_TAG_MODULE:
+    case (uint32_t)JS_TAG_MODULE:
         printf("[module]");
         break;
     default:
@@ -13769,7 +13769,7 @@ static JSValue JS_ToBigIntFree(JSContext *ctx, JSValue val)
     tag = JS_VALUE_GET_NORM_TAG(val);
     switch(tag) {
     case JS_TAG_SHORT_BIG_INT:
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         break;
     case JS_TAG_INT:
     case JS_TAG_NULL:
@@ -13779,12 +13779,12 @@ static JSValue JS_ToBigIntFree(JSContext *ctx, JSValue val)
     case JS_TAG_BOOL:
         val = __JS_NewShortBigInt(ctx, JS_VALUE_GET_INT(val));
         break;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         val = JS_StringToBigIntErr(ctx, val);
         if (JS_IsException(val))
             return val;
         goto redo;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         val = JS_ToPrimitiveFree(ctx, val, HINT_NUMBER);
         if (JS_IsException(val))
             return val;
@@ -13913,7 +13913,7 @@ static no_inline __exception int js_unary_arith_slow(JSContext *ctx,
             }
         }
         break;
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         {
             JSBigInt *r;
             p1 = (JSBigInt *)JS_VALUE_GET_PTR(op1);
@@ -15128,7 +15128,7 @@ static __exception int js_operator_typeof(JSContext *ctx, JSValue op1)
     tag = JS_VALUE_GET_NORM_TAG(op1);
     switch(tag) {
     case JS_TAG_SHORT_BIG_INT:
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         atom = JS_ATOM_bigint;
         break;
     case JS_TAG_INT:
@@ -15141,10 +15141,10 @@ static __exception int js_operator_typeof(JSContext *ctx, JSValue op1)
     case JS_TAG_BOOL:
         atom = JS_ATOM_boolean;
         break;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         atom = JS_ATOM_string;
         break;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         {
             JSObject *p;
             p = JS_VALUE_GET_OBJ(op1);
@@ -15160,7 +15160,7 @@ static __exception int js_operator_typeof(JSContext *ctx, JSValue op1)
     obj_type:
         atom = JS_ATOM_object;
         break;
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_SYMBOL:
         atom = JS_ATOM_symbol;
         break;
     default:
@@ -36033,26 +36033,26 @@ static int JS_WriteObjectRec(BCWriterState *s, JSValueConst obj)
             bc_put_u64(s, u.u64);
         }
         break;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         {
             JSString *p = JS_VALUE_GET_STRING(obj);
             bc_put_u8(s, BC_TAG_STRING);
             JS_WriteString(s, p);
         }
         break;
-    case JS_TAG_FUNCTION_BYTECODE:
+    case (uint32_t)JS_TAG_FUNCTION_BYTECODE:
         if (!s->allow_bytecode)
             goto invalid_tag;
         if (JS_WriteFunctionTag(s, obj))
             goto fail;
         break;
-    case JS_TAG_MODULE:
+    case (uint32_t)JS_TAG_MODULE:
         if (!s->allow_bytecode)
             goto invalid_tag;
         if (JS_WriteModule(s, obj))
             goto fail;
         break;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         {
             JSObject *p = JS_VALUE_GET_OBJ(obj);
             int ret, idx;
@@ -36127,11 +36127,11 @@ static int JS_WriteObjectRec(BCWriterState *s, JSValueConst obj)
         }
         break;
     case JS_TAG_SHORT_BIG_INT:
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         if (JS_WriteBigInt(s, obj))
             goto fail;
         break;
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_SYMBOL:
         {
             JSAtomStruct *p = (JSAtomStruct *)JS_VALUE_GET_PTR(obj);
             if (p->atom_type != JS_ATOM_TYPE_GLOBAL_SYMBOL && p->atom_type != JS_ATOM_TYPE_SYMBOL) {
@@ -48854,11 +48854,11 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
     case JS_TAG_BOOL:
         h = JS_VALUE_GET_INT(key);
         break;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         h = hash_string(JS_VALUE_GET_STRING(key), 0);
         break;
-    case JS_TAG_OBJECT:
-    case JS_TAG_SYMBOL:
+    case (uint32_t)JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_SYMBOL:
         h = (uintptr_t)JS_VALUE_GET_PTR(key) * 3163;
         break;
     case JS_TAG_INT:
@@ -48867,7 +48867,7 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
     case JS_TAG_SHORT_BIG_INT:
         d = JS_VALUE_GET_SHORT_BIG_INT(key);
         goto hash_float64;
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         r = (JSBigInt *)JS_VALUE_GET_PTR(key);
         h = hash_string8((void *)r->tab, r->len * sizeof(*r->tab), 0);
         break;
@@ -53148,7 +53148,7 @@ static JSValue JS_ToBigIntCtorFree(JSContext *ctx, JSValue val)
         val = JS_NewBigInt64(ctx, JS_VALUE_GET_INT(val));
         break;
     case JS_TAG_SHORT_BIG_INT:
-    case JS_TAG_BIG_INT:
+    case (uint32_t)JS_TAG_BIG_INT:
         break;
     case JS_TAG_FLOAT64:
         {
@@ -53168,10 +53168,10 @@ static JSValue JS_ToBigIntCtorFree(JSContext *ctx, JSValue val)
             }
         }
         break;
-    case JS_TAG_STRING:
+    case (uint32_t)JS_TAG_STRING:
         val = JS_StringToBigIntErr(ctx, val);
         break;
-    case JS_TAG_OBJECT:
+    case (uint32_t)JS_TAG_OBJECT:
         val = JS_ToPrimitiveFree(ctx, val, HINT_NUMBER);
         if (JS_IsException(val))
             break;

--- a/quickjs.c
+++ b/quickjs.c
@@ -54318,7 +54318,7 @@ JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
         return JS_ThrowRangeError(ctx, "invalid typed array type");
 
     return js_typed_array_constructor(ctx, JS_UNDEFINED, argc, argv,
-                                      JS_CLASS_UINT8C_ARRAY + type);
+                                      JS_CLASS_UINT8C_ARRAY + (int)type);
 }
 
 /* Return the buffer associated to the typed array or an exception if

--- a/quickjs.c
+++ b/quickjs.c
@@ -1328,10 +1328,63 @@ static void _JS_AddIntrinsicCallSite(JSContext *ctx);
 
 static void JS_SetOpaqueInternal(JSValueConst obj, void *opaque);
 
-static const JSClassExoticMethods js_arguments_exotic_methods;
-static const JSClassExoticMethods js_string_exotic_methods;
-static const JSClassExoticMethods js_proxy_exotic_methods;
-static const JSClassExoticMethods js_module_ns_exotic_methods;
+static int js_arguments_define_own_property(JSContext *ctx,
+                                            JSValueConst this_obj,
+                                            JSAtom prop, JSValueConst val,
+                                            JSValueConst getter,
+                                            JSValueConst setter, int flags);
+
+static int js_string_get_own_property(JSContext *ctx,
+                                      JSPropertyDescriptor *desc,
+                                      JSValueConst obj, JSAtom prop);
+static int js_string_define_own_property(JSContext *ctx,
+                                         JSValueConst this_obj,
+                                         JSAtom prop, JSValueConst val,
+                                         JSValueConst getter,
+                                         JSValueConst setter, int flags);
+static int js_string_delete_property(JSContext *ctx,
+                                     JSValueConst obj, JSAtom prop);
+
+static int js_proxy_get_own_property(JSContext *ctx, JSPropertyDescriptor *pdesc,
+                                     JSValueConst obj, JSAtom prop);
+static int js_proxy_define_own_property(JSContext *ctx, JSValueConst obj,
+                                        JSAtom prop, JSValueConst val,
+                                        JSValueConst getter,
+                                        JSValueConst setter, int flags);
+static int js_proxy_delete_property(JSContext *ctx, JSValueConst obj,
+                                    JSAtom atom);
+static int js_proxy_get_own_property_names(JSContext *ctx,
+                                           JSPropertyEnum **ptab,
+                                           uint32_t *plen,
+                                           JSValueConst obj);
+static int js_proxy_has(JSContext *ctx, JSValueConst obj, JSAtom atom);
+static JSValue js_proxy_get(JSContext *ctx, JSValueConst obj, JSAtom atom,
+                            JSValueConst receiver);
+static int js_proxy_set(JSContext *ctx, JSValueConst obj, JSAtom atom,
+                        JSValueConst value, JSValueConst receiver, int flags);
+
+static int js_module_ns_has(JSContext *ctx, JSValueConst obj, JSAtom atom);
+
+static const JSClassExoticMethods js_arguments_exotic_methods = {
+    .define_own_property = js_arguments_define_own_property,
+};
+static const JSClassExoticMethods js_string_exotic_methods = {
+    .get_own_property = js_string_get_own_property,
+    .define_own_property = js_string_define_own_property,
+    .delete_property = js_string_delete_property,
+};
+static const JSClassExoticMethods js_proxy_exotic_methods = {
+    .get_own_property = js_proxy_get_own_property,
+    .define_own_property = js_proxy_define_own_property,
+    .delete_property = js_proxy_delete_property,
+    .get_own_property_names = js_proxy_get_own_property_names,
+    .has_property = js_proxy_has,
+    .get_property = js_proxy_get,
+    .set_property = js_proxy_set,
+};
+static const JSClassExoticMethods js_module_ns_exotic_methods = {
+    .has_property = js_module_ns_has,
+};
 
 static inline bool double_is_int32(double d)
 {
@@ -15190,10 +15243,6 @@ static int js_arguments_define_own_property(JSContext *ctx,
                              flags | JS_PROP_NO_EXOTIC);
 }
 
-static const JSClassExoticMethods js_arguments_exotic_methods = {
-    .define_own_property = js_arguments_define_own_property,
-};
-
 static JSValue js_build_arguments(JSContext *ctx, int argc, JSValueConst *argv)
 {
     JSValue val, *tab;
@@ -28412,10 +28461,6 @@ static int js_module_ns_has(JSContext *ctx, JSValueConst obj, JSAtom atom)
 {
     return (find_own_property1(JS_VALUE_GET_OBJ(obj), atom) != NULL);
 }
-
-static const JSClassExoticMethods js_module_ns_exotic_methods = {
-    .has_property = js_module_ns_has,
-};
 
 static int exported_names_cmp(const void *p1, const void *p2, void *opaque)
 {
@@ -43050,12 +43095,6 @@ static int js_string_delete_property(JSContext *ctx,
     return true;
 }
 
-static const JSClassExoticMethods js_string_exotic_methods = {
-    .get_own_property = js_string_get_own_property,
-    .define_own_property = js_string_define_own_property,
-    .delete_property = js_string_delete_property,
-};
-
 static JSValue js_string_constructor(JSContext *ctx, JSValueConst new_target,
                                      int argc, JSValueConst *argv)
 {
@@ -48423,16 +48462,6 @@ static int js_proxy_isArray(JSContext *ctx, JSValueConst obj)
     }
     return js_is_array(ctx, s->target);
 }
-
-static const JSClassExoticMethods js_proxy_exotic_methods = {
-    .get_own_property = js_proxy_get_own_property,
-    .define_own_property = js_proxy_define_own_property,
-    .delete_property = js_proxy_delete_property,
-    .get_own_property_names = js_proxy_get_own_property_names,
-    .has_property = js_proxy_has,
-    .get_property = js_proxy_get,
-    .set_property = js_proxy_set,
-};
 
 static JSValue js_proxy_constructor(JSContext *ctx, JSValueConst this_val,
                                     int argc, JSValueConst *argv)

--- a/quickjs.c
+++ b/quickjs.c
@@ -564,12 +564,12 @@ struct JSString {
 
 static inline uint8_t *str8(JSString *p)
 {
-    return (void *)(p + 1);
+    return (uint8_t *)(p + 1);
 }
 
 static inline uint16_t *str16(JSString *p)
 {
-    return (void *)(p + 1);
+    return (uint16_t *)(p + 1);
 }
 
 typedef struct JSClosureVar {

--- a/quickjs.c
+++ b/quickjs.c
@@ -7940,7 +7940,7 @@ static uint32_t js_string_obj_get_length(JSContext *ctx, JSValueConst obj)
 
 static int num_keys_cmp(const void *p1, const void *p2, void *opaque)
 {
-    JSContext *ctx = opaque;
+    JSContext *ctx = (JSContext *)opaque;
     JSAtom atom1 = ((const JSPropertyEnum *)p1)->atom;
     JSAtom atom2 = ((const JSPropertyEnum *)p2)->atom;
     uint32_t v1, v2;
@@ -19073,7 +19073,7 @@ static JSContext *JS_GetFunctionRealm(JSContext *ctx, JSValueConst func_obj)
         break;
     case JS_CLASS_PROXY:
         {
-            JSProxyData *s = p->u.opaque;
+            JSProxyData *s = (JSProxyData *)p->u.opaque;
             if (!s)
                 return ctx;
             if (s->is_revoked) {
@@ -22171,7 +22171,7 @@ static uint32_t hash_bytes(uint32_t h, const void *b, size_t n)
 {
     const char *p;
 
-    for (p = b; p < (char *)b + n; p++)
+    for (p = (const char *)b; p < (const char *)b + n; p++)
         h = 33*h + *p;
     h += h >> 5;
     return h;
@@ -28464,9 +28464,9 @@ static int js_module_ns_has(JSContext *ctx, JSValueConst obj, JSAtom atom)
 
 static int exported_names_cmp(const void *p1, const void *p2, void *opaque)
 {
-    JSContext *ctx = opaque;
-    const ExportedNameEntry *me1 = p1;
-    const ExportedNameEntry *me2 = p2;
+    JSContext *ctx = (JSContext *)opaque;
+    const ExportedNameEntry *me1 = (const ExportedNameEntry *)p1;
+    const ExportedNameEntry *me2 = (const ExportedNameEntry *)p2;
     JSValue str1, str2;
     int ret;
 
@@ -28488,7 +28488,7 @@ static int exported_names_cmp(const void *p1, const void *p2, void *opaque)
 static JSValue js_module_ns_autoinit(JSContext *ctx, JSObject *p, JSAtom atom,
                                      void *opaque)
 {
-    JSModuleDef *m = opaque;
+    JSModuleDef *m = (JSModuleDef *)opaque;
     return JS_GetModuleNamespace(ctx, m);
 }
 
@@ -34038,7 +34038,7 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
         goto fail;
     b->header.ref_count = 1;
 
-    b->byte_code_buf = (void *)((uint8_t*)b + byte_code_offset);
+    b->byte_code_buf = (uint8_t *)((uint8_t*)b + byte_code_offset);
     b->byte_code_len = fd->byte_code.size;
     memcpy(b->byte_code_buf, fd->byte_code.buf, fd->byte_code.size);
     js_free(ctx, fd->byte_code.buf);
@@ -34046,7 +34046,7 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
 
     b->func_name = fd->func_name;
     if (fd->arg_count + fd->var_count > 0) {
-        b->vardefs = (void *)((uint8_t*)b + vardefs_offset);
+        b->vardefs = (JSVarDef *)((uint8_t*)b + vardefs_offset);
         if (fd->arg_count > 0)
             memcpy(b->vardefs, fd->args, fd->arg_count * sizeof(fd->args[0]));
         if (fd->var_count > 0)
@@ -34060,7 +34060,7 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
     }
     b->cpool_count = fd->cpool_count;
     if (b->cpool_count) {
-        b->cpool = (void *)((uint8_t*)b + cpool_offset);
+        b->cpool = (JSValue *)((uint8_t*)b + cpool_offset);
         memcpy(b->cpool, fd->cpool, b->cpool_count * sizeof(*b->cpool));
     }
     js_free(ctx, fd->cpool);
@@ -34087,7 +34087,7 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
 
     b->closure_var_count = fd->closure_var_count;
     if (b->closure_var_count) {
-        b->closure_var = (void *)((uint8_t*)b + closure_var_offset);
+        b->closure_var = (JSClosureVar *)((uint8_t*)b + closure_var_offset);
         memcpy(b->closure_var, fd->closure_var, b->closure_var_count * sizeof(*b->closure_var));
     }
     js_free(ctx, fd->closure_var);
@@ -36706,13 +36706,13 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
     bc.func_name = JS_ATOM_NULL;
     b->header.ref_count = 1;
     if (local_count != 0) {
-        b->vardefs = (void *)((uint8_t*)b + vardefs_offset);
+        b->vardefs = (JSVarDef *)((uint8_t*)b + vardefs_offset);
     }
     if (b->closure_var_count != 0) {
-        b->closure_var = (void *)((uint8_t*)b + closure_var_offset);
+        b->closure_var = (JSClosureVar *)((uint8_t*)b + closure_var_offset);
     }
     if (b->cpool_count != 0) {
-        b->cpool = (void *)((uint8_t*)b + cpool_offset);
+        b->cpool = (JSValue *)((uint8_t*)b + cpool_offset);
     }
 
     add_gc_object(ctx->rt, &b->header, JS_GC_OBJ_TYPE_FUNCTION_BYTECODE);
@@ -37591,7 +37591,7 @@ static JSAtom find_atom(JSContext *ctx, const char *name)
 static JSValue JS_InstantiateFunctionListItem2(JSContext *ctx, JSObject *p,
                                                JSAtom atom, void *opaque)
 {
-    const JSCFunctionListEntry *e = opaque;
+    const JSCFunctionListEntry *e = (const JSCFunctionListEntry *)opaque;
     JSValue val;
 
     switch(e->def_type) {
@@ -41423,7 +41423,7 @@ struct array_sort_context {
 };
 
 static int js_array_cmp_generic(const void *a, const void *b, void *opaque) {
-    struct array_sort_context *psc = opaque;
+    struct array_sort_context *psc = (struct array_sort_context *)opaque;
     JSContext *ctx = psc->ctx;
     JSValueConst argv[2];
     JSValue res;
@@ -45614,13 +45614,13 @@ fail:
 
 bool lre_check_stack_overflow(void *opaque, size_t alloca_size)
 {
-    JSContext *ctx = opaque;
+    JSContext *ctx = (JSContext *)opaque;
     return js_check_stack_overflow(ctx->rt, alloca_size);
 }
 
 int lre_check_timeout(void *opaque)
 {
-    JSContext *ctx = opaque;
+    JSContext *ctx = (JSContext *)opaque;
     JSRuntime *rt = ctx->rt;
     return (rt->interrupt_handler &&
             rt->interrupt_handler(rt, rt->interrupt_opaque));
@@ -45628,7 +45628,7 @@ int lre_check_timeout(void *opaque)
 
 void *lre_realloc(void *opaque, void *ptr, size_t size)
 {
-    JSContext *ctx = opaque;
+    JSContext *ctx = (JSContext *)opaque;
     /* No JS exception is raised here */
     return js_realloc_rt(ctx->rt, ptr, size);
 }
@@ -55094,7 +55094,7 @@ static JSValue js_typed_array_indexOf(JSContext *ctx, JSValueConst this_val,
             if (inc > 0) {
                 pp = NULL;
                 if (pv)
-                    pp = memchr(pv + k, v, len - k);
+                    pp = (const uint8_t *)memchr(pv + k, v, len - k);
                 if (pp)
                     res = pp - pv;
             } else {
@@ -55660,7 +55660,7 @@ struct TA_sort_context {
 };
 
 static int js_TA_cmp_generic(const void *a, const void *b, void *opaque) {
-    struct TA_sort_context *psc = opaque;
+    struct TA_sort_context *psc = (struct TA_sort_context *)opaque;
     JSContext *ctx = psc->ctx;
     uint32_t a_idx, b_idx;
     JSValue argv[2];
@@ -57009,7 +57009,7 @@ static JSValue js_atomics_wait(JSContext *ctx,
     }
 
     waiter = &waiter_s;
-    waiter->ptr = ptr;
+    waiter->ptr = (int32_t *)ptr;
     js_cond_init(&waiter->cond);
     waiter->linked = true;
     list_add_tail(&waiter->link, &js_atomics_waiter_list);
@@ -57766,7 +57766,7 @@ static JSValue js_callsite_getnumber(JSContext *ctx, JSValueConst this_val, int 
     JSCallSiteData *csd = (JSCallSiteData *)JS_GetOpaque2(ctx, this_val, JS_CLASS_CALL_SITE);
     if (!csd)
         return JS_EXCEPTION;
-    int *field = (void *)((char *)csd + magic);
+    int *field = (int *)((char *)csd + magic);
     return js_int32(*field);
 }
 
@@ -57916,7 +57916,7 @@ static JSValue js_domexception_getfield(JSContext *ctx, JSValueConst this_val,
     s = (JSDOMExceptionData *)JS_GetOpaque2(ctx, this_val, JS_CLASS_DOM_EXCEPTION);
     if (!s)
         return JS_EXCEPTION;
-    valp = (void *)((char *)s + magic);
+    valp = (JSValue *)((char *)s + magic);
     return js_dup(*valp);
 }
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -53670,8 +53670,8 @@ static JSValue js_array_buffer_constructor3(JSContext *ctx,
             // TOOD(bnoordhuis) resizing backing memory for SABs atomically
             // is hard so we cheat and allocate |maxByteLength| bytes upfront
             sab_alloc_len = max_len ? *max_len : len;
-            abuf->data = rt->sab_funcs.sab_alloc(rt->sab_funcs.sab_opaque,
-                                                 max_int(sab_alloc_len, 1));
+            abuf->data = (uint8_t *)rt->sab_funcs.sab_alloc(rt->sab_funcs.sab_opaque,
+                                                            max_int(sab_alloc_len, 1));
             if (!abuf->data)
                 goto fail;
             memset(abuf->data, 0, sab_alloc_len);

--- a/xsum.h
+++ b/xsum.h
@@ -111,9 +111,9 @@ typedef ptrdiff_t xsum_length;
 void xsum_small_init (xsum_small_accumulator *restrict);
 void xsum_small_add1 (xsum_small_accumulator *restrict, xsum_flt);
 void xsum_small_addv (xsum_small_accumulator *restrict,
-                      const xsum_flt *restrict, xsum_length);
+                      const xsum_flt *restrict2, xsum_length);
 void xsum_small_add_sqnorm (xsum_small_accumulator *restrict,
-                            const xsum_flt *restrict, xsum_length);
+                            const xsum_flt *restrict2, xsum_length);
 void xsum_small_add_dot (xsum_small_accumulator *restrict,
                          const xsum_flt *, const xsum_flt *, xsum_length);
 void xsum_small_add_accumulator (xsum_small_accumulator *,


### PR DESCRIPTION
This allows C++ compiler (namely clang++, at least for now) to compile quickjs.

For now I'm done with `quickjs.c` file and you can test it: `clang++ -c quickjs.c`.

There are still some warnings:
```
clang++: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
quickjs.c:16106:5: warning: array designators are a C99 extension [-Wc99-designator]
 16106 |     [JS_FUNC_NORMAL] = JS_CLASS_BYTECODE_FUNCTION,
       |     ^~~~~~~~~~~~~~~~
quickjs.c:16530:9: warning: array designators are a C99 extension [-Wc99-designator]
 16530 |         [ OP_COUNT ... 255 ] = &&case_default
       |         ^~~~~~~~~~~~~~~~~~~~
quickjs.c:16530:9: warning: mixture of designated and non-designated initializers in the same initializer list is a C99 extension [-Wc99-designator]
 16530 |         [ OP_COUNT ... 255 ] = &&case_default
       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./quickjs-opcode.h:66:1: note: first non-designated initializer is here
   66 | DEF(invalid, 1, 0, 0, none) /* never emitted */
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
quickjs.c:16527:41: note: expanded from macro 'DEF'
 16527 | #define DEF(id, size, n_pop, n_push, f) && case_OP_ ## id,
       |                                         ^~~~~~~~~~~~~~~~~
quickjs.c:52155:14: warning: use of result of assignment to object of volatile-qualified type 'volatile double' is deprecated [-Wdeprecated-volatile]
 52155 |     time += (temp = m * 60000);
       |              ^
quickjs.c:52156:14: warning: use of result of assignment to object of volatile-qualified type 'volatile double' is deprecated [-Wdeprecated-volatile]
 52156 |     time += (temp = s * 1000);
       |              ^
quickjs.c:52160:11: warning: use of result of assignment to object of volatile-qualified type 'volatile double' is deprecated [-Wdeprecated-volatile]
 52160 |     tv = (temp = day * 86400000) + time;   /* prevent generation of FMA */
       |           ^
6 warnings generated.
```

That I do not intend to address right now.

My goal is to be able to compile quickjs either explicitly as c++ by renaming the file or by including the C source from a C++ file, because in a project consuming quickjs (openrct2) I don't want to set up all the compiler flags for C - we are exclusively C++.

I can split this PR to smaller chunks if necessary, but I tried to keep individual commits digestable.