### PR TITLE
Make quickjs-libc symbols visible at link time

### DIFF
--- a/quickjs-libc.h
+++ b/quickjs-libc.h
@@ -34,26 +34,40 @@
 extern "C" {
 #endif
 
-JSModuleDef *js_init_module_std(JSContext *ctx, const char *module_name);
-JSModuleDef *js_init_module_os(JSContext *ctx, const char *module_name);
-JSModuleDef *js_init_module_bjson(JSContext *ctx, const char *module_name);
-void js_std_add_helpers(JSContext *ctx, int argc, char **argv);
-int js_std_loop(JSContext *ctx);
-JSValue js_std_await(JSContext *ctx, JSValue obj);
-void js_std_init_handlers(JSRuntime *rt);
-void js_std_free_handlers(JSRuntime *rt);
-void js_std_dump_error(JSContext *ctx);
-uint8_t *js_load_file(JSContext *ctx, size_t *pbuf_len, const char *filename);
-int js_module_set_import_meta(JSContext *ctx, JSValueConst func_val,
-                              bool use_realpath, bool is_main);
-JSModuleDef *js_module_loader(JSContext *ctx,
-                              const char *module_name, void *opaque);
-void js_std_eval_binary(JSContext *ctx, const uint8_t *buf, size_t buf_len,
-                        int flags);
-void js_std_promise_rejection_tracker(JSContext *ctx, JSValueConst promise,
-                                      JSValueConst reason,
-                                      bool is_handled, void *opaque);
-void js_std_set_worker_new_context_func(JSContext *(*func)(JSRuntime *rt));
+#if defined(__GNUC__) || defined(__clang__)
+#define JS_EXTERN __attribute__((visibility("default")))
+#else
+#define JS_EXTERN /* nothing */
+#endif
+
+JS_EXTERN JSModuleDef *js_init_module_std(JSContext *ctx,
+                                          const char *module_name);
+JS_EXTERN JSModuleDef *js_init_module_os(JSContext *ctx,
+                                         const char *module_name);
+JS_EXTERN JSModuleDef *js_init_module_bjson(JSContext *ctx,
+                                            const char *module_name);
+JS_EXTERN void js_std_add_helpers(JSContext *ctx, int argc, char **argv);
+JS_EXTERN int js_std_loop(JSContext *ctx);
+JS_EXTERN JSValue js_std_await(JSContext *ctx, JSValue obj);
+JS_EXTERN void js_std_init_handlers(JSRuntime *rt);
+JS_EXTERN void js_std_free_handlers(JSRuntime *rt);
+JS_EXTERN void js_std_dump_error(JSContext *ctx);
+JS_EXTERN uint8_t *js_load_file(JSContext *ctx, size_t *pbuf_len,
+                                const char *filename);
+JS_EXTERN int js_module_set_import_meta(JSContext *ctx, JSValueConst func_val,
+                                        bool use_realpath, bool is_main);
+JS_EXTERN JSModuleDef *js_module_loader(JSContext *ctx,
+                                        const char *module_name, void *opaque);
+JS_EXTERN void js_std_eval_binary(JSContext *ctx, const uint8_t *buf,
+                                  size_t buf_len, int flags);
+JS_EXTERN void js_std_promise_rejection_tracker(JSContext *ctx,
+                                                JSValueConst promise,
+                                                JSValueConst reason,
+                                                bool is_handled,
+                                                void *opaque);
+JS_EXTERN void js_std_set_worker_new_context_func(JSContext *(*func)(JSRuntime *rt));
+
+#undef JS_EXTERN
 
 #ifdef __cplusplus
 } /* extern "C" { */


### PR DESCRIPTION
Annotate functions in quickjs-libc.h with the proper visibility like we do in quickjs.h, otherwise they are hidden (and produce missing symbol errors) when trying to link against the shared library.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1152

<hr>

I considered adding a CI buildbot but we're already kind of top-heavy and I couldn't find a suitable existing one to repurpose.