### PR TITLE
Fix wrong type for class_id in public api

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -5053,7 +5053,7 @@ static int JS_SetObjectData(JSContext *ctx, JSValueConst obj, JSValue val)
     return -1;
 }
 
-JSValue JS_NewObjectClass(JSContext *ctx, int class_id)
+JSValue JS_NewObjectClass(JSContext *ctx, JSClassID class_id)
 {
     return JS_NewObjectProtoClass(ctx, ctx->class_proto[class_id], class_id);
 }

--- a/quickjs.h
+++ b/quickjs.h
@@ -819,7 +819,7 @@ JS_EXTERN void JS_FreeCString(JSContext *ctx, const char *ptr);
 
 JS_EXTERN JSValue JS_NewObjectProtoClass(JSContext *ctx, JSValueConst proto,
                                          JSClassID class_id);
-JS_EXTERN JSValue JS_NewObjectClass(JSContext *ctx, int class_id);
+JS_EXTERN JSValue JS_NewObjectClass(JSContext *ctx, JSClassID class_id);
 JS_EXTERN JSValue JS_NewObjectProto(JSContext *ctx, JSValueConst proto);
 JS_EXTERN JSValue JS_NewObject(JSContext *ctx);
 // takes ownership of the values


### PR DESCRIPTION
This closes #1153 and only changes one function in the public api. I wasn't sure about changing other functions because they are not public and it requires a lot of changes I'm not sure about.
For example functions that are created with `JS_CFUNC_MAGIC_DEF` and `JS_CGETSET_MAGIC_DEF` sometimes use the field as class_id and sometimes as magic and I think it would be confusing to make the field be `JSClassID`.