### PR TITLE
Fix Valgrind warning

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -41499,6 +41499,11 @@ next:
     // not done, construct { done: false, value: xxx } object
     // copy .value verbatim from source object, spec doesn't
     // allow dereferencing getters here
+    d = (JSPropertyDescriptor){
+        .value = JS_UNDEFINED,
+        .getter = JS_UNDEFINED,
+        .setter = JS_UNDEFINED,
+    };
     ret = JS_GetOwnProperty(ctx, &d, item, JS_ATOM_value);
     JS_FreeValue(ctx, item);
     if (ret < 0)


### PR DESCRIPTION
Initialize the JSPropertyDescriptor before calling JS_GetOwnProperty because the latter doesn't fill in the former if the property isn't found.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1160