### PR TITLE
Port bellard/quickjs CVE fixes - batch 1

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -11697,6 +11697,7 @@ static JSBigInt *js_bigint_from_string(JSContext *ctx,
                                        const char *str, int radix)
 {
     const char *p = str;
+    size_t n_digits1;
     int is_neg, n_digits, n_limbs, len, log2_radix, n_bits, i;
     JSBigInt *r;
     js_limb_t v, c, h;
@@ -11708,10 +11709,16 @@ static JSBigInt *js_bigint_from_string(JSContext *ctx,
     }
     while (*p == '0')
         p++;
-    n_digits = strlen(p);
+    n_digits1 = strlen(p);
+    /* the real check for overflox is done js_bigint_new(). Here
+       we just avoid integer overflow */
+    if (n_digits1 > JS_BIGINT_MAX_SIZE * JS_LIMB_BITS) {
+        JS_ThrowRangeError(ctx, "BigInt is too large to allocate");
+        return NULL;
+    }
+    n_digits = n_digits1;
     log2_radix = 32 - clz32(radix - 1); /* ceil(log2(radix)) */
     /* compute the maximum number of limbs */
-    /* XXX: overflow */
     if (radix == 10) {
         n_bits = (n_digits * 27 + 7) / 8; /* >= ceil(n_digits * log2(10)) */
     } else {

--- a/quickjs.c
+++ b/quickjs.c
@@ -11938,11 +11938,10 @@ static JSValue js_bigint_to_string1(JSContext *ctx, JSValueConst val, int radix)
                 bit_pos = i * log2_radix;
                 pos = bit_pos / JS_LIMB_BITS;
                 shift = bit_pos % JS_LIMB_BITS;
-                if (likely((shift + log2_radix) <= JS_LIMB_BITS)) {
-                    c = r->tab[pos] >> shift;
-                } else {
-                    c = (r->tab[pos] >> shift) |
-                        (r->tab[pos + 1] << (JS_LIMB_BITS - shift));
+                c = r->tab[pos] >> shift;
+                if ((shift + log2_radix) > JS_LIMB_BITS &&
+                    (pos + 1) < r->len) {
+                    c |= r->tab[pos + 1] << (JS_LIMB_BITS - shift);
                 }
                 c &= (radix - 1);
                 *--q = digits[c];

--- a/quickjs.c
+++ b/quickjs.c
@@ -54802,22 +54802,12 @@ static JSValue js_typed_array_indexOf(JSContext *ctx, JSValueConst this_val,
     if (special == special_lastIndexOf) {
         k = len - 1;
         if (argc > 1) {
-            if (JS_ToFloat64(ctx, &d, argv[1]))
+            int64_t k1;
+            if (JS_ToInt64Clamp(ctx, &k1, argv[1], -1, len - 1, len))
                 goto exception;
-            if (isnan(d)) {
-                k = 0;
-            } else {
-                if (d >= 0) {
-                    if (d < k) {
-                        k = d;
-                    }
-                } else {
-                    d += len;
-                    if (d < 0)
-                        goto done;
-                    k = d;
-                }
-            }
+            k = k1;
+            if (k < 0)
+                goto done;
         }
         stop = -1;
         inc = -1;


### PR DESCRIPTION
Ports the following easy-to-apply CVE fixes from bellard/quickjs:

- [x] [fixed buffer overflow in js_bigint_from_string()](https://github.com/bellard/quickjs/commit/e1c18befb8ef661d9ee8a34ebc54e545a0214df9)
  - bellard/quickjs@e1c18befb8ef661d9ee8a34ebc54e545a0214df9
- [x] [fixed buffer overflow in js_bigint_to_string1()](https://github.com/bellard/quickjs/commit/9ce544289fe86acdb8fb33e6a425da151438be05)
  - bellard/quickjs@9ce544289fe86acdb8fb33e6a425da151438be05
- [x] [fixed buffer overflow in TypedArray.prototype.lastIndexOf()](https://github.com/bellard/quickjs/commit/c927eca49a326326181a5db12627ffb48f191fe2)
  - bellard/quickjs@c927eca49a326326181a5db12627ffb48f191fe2