### PR TITLE
WIP: Port recent bellard/quickjs fixes for module async evaluation logic and lifetime

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -425,6 +425,7 @@ typedef struct JSMallocFunctions {
 #define JS_DUMP_OBJECTS       0x20000  /* dump objects in JS_FreeRuntime */
 #define JS_DUMP_ATOMS         0x40000  /* dump atoms in JS_FreeRuntime */
 #define JS_DUMP_SHAPES        0x80000  /* dump shapes in JS_FreeRuntime */
+#define JS_DUMP_MODULE_EXEC  0x100000
 
 // Finalizers run in LIFO order at the very end of JS_FreeRuntime.
 // Intended for cleanup of associated resources; the runtime itself

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -79,7 +79,6 @@ test262/test/language/expressions/in/private-field-invalid-assignment-target.js:
 test262/test/language/expressions/in/private-field-invalid-assignment-target.js:23: strict mode: unexpected error type: Test262: This statement should not be evaluated.
 test262/test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:31: Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
 test262/test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:31: strict mode: Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
-test262/test/language/module-code/top-level-await/module-graphs-does-not-hang.js:10: TypeError: $DONE() not called
 test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js:40: SyntaxError: invalid property name
 test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js:40: strict mode: SyntaxError: invalid property name
 test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js:40: SyntaxError: invalid property name


### PR DESCRIPTION
Ported:

- [x] [fixed module async evaluation logic - added DUMP_MODULE_EXEC](https://github.com/bellard/quickjs/commit/2fd48bf7df44845cd9c0bf5ba44632a4adc09dce)
  - bellard/quickjs@2fd48bf7df44845cd9c0bf5ba44632a4adc09dce
  - Modified to define `JS_DUMP_MODULE_EXEC` publicly and use the `check_dump_flag` function

TODO port:
- [ ] [fixed GC logic so that a module can live after a JSContext is destroyed - update the reference count for the realm in jobs and FinalizationRegistry](https://github.com/bellard/quickjs/commit/458c34d29d0d262f824ea1c0e01aa0e3790669da)
  - bellard/quickjs@458c34d29d0d262f824ea1c0e01aa0e3790669da
  - see: https://github.com/bellard/quickjs/issues/280