### PR TITLE
Add ref-counted string slices

### DIFF
--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -797,6 +797,39 @@ function string_build4(n)
     return n * 100;
 }
 
+function string_slice1(n)
+{
+    var i, j, s;
+    s = "x".repeat(1<<16);
+    for (i = 0; i < n; i++) {
+        for (j = 0; j < 1000; j++)
+            s.slice(-1); // too short for JSStringSlice
+    }
+    return n * 1000;
+}
+
+function string_slice2(n)
+{
+    var i, j, s;
+    s = "x".repeat(1<<16);
+    for (i = 0; i < n; i++) {
+        for (j = 0; j < 1000; j++)
+            s.slice(-1024);
+    }
+    return n * 1000;
+}
+
+function string_slice3(n)
+{
+    var i, j, s;
+    s = "x".repeat(1<<16);
+    for (i = 0; i < n; i++) {
+        for (j = 0; j < 1000; j++)
+            s.slice(1);
+    }
+    return n * 1000;
+}
+
 /* sort bench */
 
 function sort_bench(text) {
@@ -1114,6 +1147,9 @@ function main(argc, argv, g)
         string_build2,
         //string_build3,
         //string_build4,
+        string_slice1,
+        string_slice2,
+        string_slice3,
         sort_bench,
         int_to_string,
         int_toString,

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -378,6 +378,11 @@ function test_string()
     assert(eval('"\0"'), "\0");
 
     assert("abc".padStart(Infinity, ""), "abc");
+
+    assert(qjs.getStringKind("xyzzy".slice(1)),
+           /*JS_STRING_KIND_NORMAL*/0);
+    assert(qjs.getStringKind("xyzzy".repeat(512).slice(1)),
+           /*JS_STRING_KIND_SLICE*/1);
 }
 
 function test_math()


### PR DESCRIPTION
Instead of copying long substring slices, store a reference to and offset into the parent string.

Gets more profitable as strings get longer. For 64k string slices, it's about 6.5x faster than copying.

The downside of ref-counted string slices is that they can keep the parent string alive for longer than it otherwise would have been, leading to memory usage that is higher than without string slices. That's why this optimization is only applied to long-ish slices, currently slices > 1,024 bytes.

Possible future enhancements are slicing only when the substring is > x% of the parent string, or copying lazily when the slice string is the only thing referencing the parent string.

<hr>

edit: forgot to mention, the next step is adding cons/rope strings