### PR TITLE
Fix realloc with size == 0 in dbuf_default_realloc()

### DIFF
--- a/cutils.c
+++ b/cutils.c
@@ -102,6 +102,10 @@ int js__has_suffix(const char *str, const char *suffix)
 
 static void *dbuf_default_realloc(void *opaque, void *ptr, size_t size)
 {
+    if (unlikely(size == 0)) {
+        free(ptr);
+        return NULL;
+    }
     return realloc(ptr, size);
 }
 


### PR DESCRIPTION
If the new_size argument to realloc is zero, the behavior is undefined since C23. The error was detected by valgrind.