### PR TITLE
Improve computed property lookup error messages

### DIFF
--- a/tests/null_or_undefined.js
+++ b/tests/null_or_undefined.js
@@ -1,0 +1,38 @@
+import {assert} from "./assert.js"
+
+let ex
+try {
+    null.x
+} catch (e) {
+    ex = e
+}
+assert(ex instanceof TypeError)
+assert(ex.message, "cannot read property 'x' of null")
+ex = undefined
+
+try {
+    null["x"]
+} catch (e) {
+    ex = e
+}
+assert(ex instanceof TypeError)
+assert(ex.message, "cannot read property 'x' of null")
+ex = undefined
+
+try {
+    undefined.x
+} catch (e) {
+    ex = e
+}
+assert(ex instanceof TypeError)
+assert(ex.message, "cannot read property 'x' of undefined")
+ex = undefined
+
+try {
+    undefined["x"]
+} catch (e) {
+    ex = e
+}
+assert(ex instanceof TypeError)
+assert(ex.message, "cannot read property 'x' of undefined")
+ex = undefined


### PR DESCRIPTION
QuickJS reported "cannot read property of null" for computed property lookups (`a[k]` where `a === null`), which is markedly less helpful than "cannot read property 'foo' of null".