### PR TITLE
Handle string slices correctly in JS_ToCString

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -631,6 +631,23 @@ static void global_object_prototype(void)
     }
 }
 
+// https://github.com/quickjs-ng/quickjs/issues/1178
+static void slice_string_tocstring(void)
+{
+    JSRuntime *rt = JS_NewRuntime();
+    JSContext *ctx = JS_NewContext(rt);
+    static const char code[] = "'.'.repeat(16384).slice(1, -1)";
+    JSValue ret = JS_Eval(ctx, code, strlen(code), "*", JS_EVAL_TYPE_GLOBAL);
+    assert(!JS_IsException(ret));
+    assert(JS_IsString(ret));
+    const char *str = JS_ToCString(ctx, ret);
+    assert(strlen(str) == 16382);
+    JS_FreeCString(ctx, str);
+    JS_FreeValue(ctx, ret);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     sync_call();
@@ -645,5 +662,6 @@ int main(void)
     dump_memory_usage();
     new_errors();
     global_object_prototype();
+    slice_string_tocstring();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -4277,7 +4277,7 @@ go:
         for (pos = 0; pos < len; pos++) {
             count += src[pos] >> 7;
         }
-        if (count == 0) {
+        if (count == 0 && str->kind == JS_STRING_KIND_NORMAL) {
             if (plen)
                 *plen = len;
             return (const char *)src;


### PR DESCRIPTION
JS_ToCStringLen2 returns a pointer to a string that is prefixed by a JSString struct. It lets JS_FreeCString free the memory through simple pointer arithmetic.

JS_ToCStringLen2 has an optimization for ASCII-only 8 bit strings where it returns early but that optimization is not valid for slice strings. They reference their string data indirectly and said data is not prefixed by a JSString.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1178