### PR TITLE
Revert "Add ref-counted string slices (#1175)"

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -631,23 +631,6 @@ static void global_object_prototype(void)
     }
 }
 
-// https://github.com/quickjs-ng/quickjs/issues/1178
-static void slice_string_tocstring(void)
-{
-    JSRuntime *rt = JS_NewRuntime();
-    JSContext *ctx = JS_NewContext(rt);
-    static const char code[] = "'.'.repeat(16384).slice(1, -1)";
-    JSValue ret = JS_Eval(ctx, code, strlen(code), "*", JS_EVAL_TYPE_GLOBAL);
-    assert(!JS_IsException(ret));
-    assert(JS_IsString(ret));
-    const char *str = JS_ToCString(ctx, ret);
-    assert(strlen(str) == 16382);
-    JS_FreeCString(ctx, str);
-    JS_FreeValue(ctx, ret);
-    JS_FreeContext(ctx);
-    JS_FreeRuntime(rt);
-}
-
 int main(void)
 {
     sync_call();
@@ -662,6 +645,5 @@ int main(void)
     dump_memory_usage();
     new_errors();
     global_object_prototype();
-    slice_string_tocstring();
     return 0;
 }

--- a/run-test262.c
+++ b/run-test262.c
@@ -1700,32 +1700,15 @@ void update_stats(JSRuntime *rt, const char *filename) {
     js_mutex_unlock(&stats_mutex);
 }
 
-static JSValue qjs_black_box(JSContext *ctx, JSValueConst this_val,
-                            int argc, JSValueConst argv[], int magic)
-{
-    return JS_NewInt32(ctx, js_std_cmd(magic, ctx, &argv[0]));
-}
-
-static const JSCFunctionListEntry qjs_methods[] = {
-    JS_CFUNC_MAGIC_DEF("getStringKind", 1, qjs_black_box, /*GetStringKind*/3),
-};
-
-static const JSCFunctionListEntry qjs_object =
-    JS_OBJECT_DEF("qjs", qjs_methods, countof(qjs_methods), JS_PROP_C_W_E);
-
 JSContext *JS_NewCustomContext(JSRuntime *rt)
 {
     JSContext *ctx;
-    JSValue obj;
 
     ctx = JS_NewContext(rt);
     if (ctx && local) {
         js_init_module_std(ctx, "qjs:std");
         js_init_module_os(ctx, "qjs:os");
         js_init_module_bjson(ctx, "qjs:bjson");
-        obj = JS_GetGlobalObject(ctx);
-        JS_SetPropertyFunctionList(ctx, obj, &qjs_object, 1);
-        JS_FreeValue(ctx, obj);
     }
     return ctx;
 }

--- a/tests/microbench.js
+++ b/tests/microbench.js
@@ -797,39 +797,6 @@ function string_build4(n)
     return n * 100;
 }
 
-function string_slice1(n)
-{
-    var i, j, s;
-    s = "x".repeat(1<<16);
-    for (i = 0; i < n; i++) {
-        for (j = 0; j < 1000; j++)
-            s.slice(-1); // too short for JSStringSlice
-    }
-    return n * 1000;
-}
-
-function string_slice2(n)
-{
-    var i, j, s;
-    s = "x".repeat(1<<16);
-    for (i = 0; i < n; i++) {
-        for (j = 0; j < 1000; j++)
-            s.slice(-1024);
-    }
-    return n * 1000;
-}
-
-function string_slice3(n)
-{
-    var i, j, s;
-    s = "x".repeat(1<<16);
-    for (i = 0; i < n; i++) {
-        for (j = 0; j < 1000; j++)
-            s.slice(1);
-    }
-    return n * 1000;
-}
-
 /* sort bench */
 
 function sort_bench(text) {
@@ -1147,9 +1114,6 @@ function main(argc, argv, g)
         string_build2,
         //string_build3,
         //string_build4,
-        string_slice1,
-        string_slice2,
-        string_slice3,
         sort_bench,
         int_to_string,
         int_toString,

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -378,11 +378,6 @@ function test_string()
     assert(eval('"\0"'), "\0");
 
     assert("abc".padStart(Infinity, ""), "abc");
-
-    assert(qjs.getStringKind("xyzzy".slice(1)),
-           /*JS_STRING_KIND_NORMAL*/0);
-    assert(qjs.getStringKind("xyzzy".repeat(512).slice(1)),
-           /*JS_STRING_KIND_SLICE*/1);
 }
 
 function test_math()


### PR DESCRIPTION
This change seems to have introduced a seemingly impossible bug in a real-world code base where values flip to JS_NULL for no discernible reason.

My best guess is something manipulating string data directly, without being aware of slice strings, but it's impossible to track down where. The weird thing is that the value flipping to null isn't even a string, it appears to be an array.

This reverts commit 08db51a73a9ce3948e9e7ac8142689fe4c83d46f. This reverts commit 62b4eede257c1ab8f82005e4e2042330a0acb323.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1178