### PR TITLE
Fix JS_WriteObject2 to check all malloc failures

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -35856,6 +35856,10 @@ uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValueConst obj,
         goto fail;
     if (JS_WriteObjectAtoms(s))
         goto fail;
+    if (dbuf_error(&s->dbuf)) {
+        JS_ThrowOutOfMemory(ctx);
+        goto fail;
+    }
     js_object_list_end(ctx, &s->object_list);
     js_free(ctx, s->atom_to_idx);
     js_free(ctx, s->idx_to_atom);


### PR DESCRIPTION
Add `dbuf_error()` check at the end of `JS_WriteObject2()` to detect buffer allocation failures during BJSON encoding.

Without this check, if malloc/realloc fails at certain points during encoding, the error flag is set in the `DynBuf` but never checked. `JS_WriteObject2()` returns the incomplete buffer as if encoding succeeded, causing data corruption.

Here we ensure that when `dbuf.error` is set, an `OutOfMemory` exception is thrown and the function returns NULL.
