### PR TITLE
Remove unused JSContext argument from JS_IsError

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -73,7 +73,7 @@ static void cfunctions(void)
     ret = eval(ctx, "cfunc()");
     assert(JS_IsException(ret));
     ret = JS_GetException(ctx);
-    assert(JS_IsError(ctx, ret));
+    assert(JS_IsError(ret));
     stack = JS_GetPropertyStr(ctx, ret, "stack");
     assert(JS_IsString(stack));
     s = JS_ToCString(ctx, stack);
@@ -90,7 +90,7 @@ static void cfunctions(void)
     ret = eval(ctx, "cfuncdata()");
     assert(JS_IsException(ret));
     ret = JS_GetException(ctx);
-    assert(JS_IsError(ctx, ret));
+    assert(JS_IsError(ret));
     stack = JS_GetPropertyStr(ctx, ret, "stack");
     assert(JS_IsString(stack));
     s = JS_ToCString(ctx, stack);
@@ -137,7 +137,7 @@ static void sync_call(void)
     JS_FreeValue(ctx, ret);
     assert(JS_HasException(ctx));
     JSValue e = JS_GetException(ctx);
-    assert(JS_IsUncatchableError(ctx, e));
+    assert(JS_IsUncatchableError(e));
     JS_FreeValue(ctx, e);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
@@ -170,7 +170,7 @@ static void async_call(void)
     assert(r == -1);
     assert(JS_HasException(ctx));
     JSValue e = JS_GetException(ctx);
-    assert(JS_IsUncatchableError(ctx, e));
+    assert(JS_IsUncatchableError(e));
     JS_FreeValue(ctx, e);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
@@ -215,7 +215,7 @@ static void async_call_stack_overflow(void)
     }
     assert(r == 1);
     assert(!JS_HasException(ctx));
-    assert(JS_IsError(ctx, value)); // stack overflow should be caught
+    assert(JS_IsError(value)); // stack overflow should be caught
     JS_FreeValue(ctx, value);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
@@ -625,7 +625,7 @@ static void new_errors(void)
         JSValue obj = (*e->func)(ctx, "the %s", "needle");
         assert(!JS_IsException(obj));
         assert(JS_IsObject(obj));
-        assert(JS_IsError(ctx, obj));
+        assert(JS_IsError(obj));
         const char *haystack = JS_ToCString(ctx, obj);
         char needle[256];
         snprintf(needle, sizeof(needle), "%s: the needle", e->name);

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -4424,7 +4424,7 @@ static void js_std_dump_error1(JSContext *ctx, JSValueConst exception_val)
     JSValue val;
     bool is_error;
 
-    is_error = JS_IsError(ctx, exception_val);
+    is_error = JS_IsError(exception_val);
     js_dump_obj(ctx, stderr, exception_val);
     if (is_error) {
         val = JS_GetPropertyStr(ctx, exception_val, "stack");

--- a/quickjs.c
+++ b/quickjs.c
@@ -10400,13 +10400,13 @@ bool JS_IsDataView(JSValueConst val)
     return JS_CLASS_DATAVIEW == JS_GetClassID(val);
 }
 
-bool JS_IsError(JSContext *ctx, JSValueConst val)
+bool JS_IsError(JSValueConst val)
 {
     return JS_CLASS_ERROR == JS_GetClassID(val);
 }
 
 /* used to avoid catching interrupt exceptions */
-bool JS_IsUncatchableError(JSContext *ctx, JSValueConst val)
+bool JS_IsUncatchableError(JSValueConst val)
 {
     JSObject *p;
     if (JS_VALUE_GET_TAG(val) != JS_TAG_OBJECT)
@@ -18669,7 +18669,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
         build_backtrace(ctx, rt->current_exception, JS_UNDEFINED,
                         NULL, 0, 0, 0);
     }
-    if (!JS_IsUncatchableError(ctx, rt->current_exception)) {
+    if (!JS_IsUncatchableError(rt->current_exception)) {
         while (sp > stack_buf) {
             JSValue val = *--sp;
             JS_FreeValue(ctx, val);
@@ -19234,7 +19234,7 @@ static bool js_async_function_resume(JSContext *ctx, JSAsyncFunctionData *s)
     func_ret = async_func_resume(ctx, &s->func_state);
     if (JS_IsException(func_ret)) {
     fail:
-        if (unlikely(JS_IsUncatchableError(ctx, ctx->rt->current_exception))) {
+        if (unlikely(JS_IsUncatchableError(ctx->rt->current_exception))) {
             is_success = false;
         } else {
             JSValue error = JS_GetException(ctx);
@@ -19243,7 +19243,7 @@ static bool js_async_function_resume(JSContext *ctx, JSAsyncFunctionData *s)
             JS_FreeValue(ctx, error);
         resolved:
             if (unlikely(JS_IsException(ret2))) {
-                if (JS_IsUncatchableError(ctx, ctx->rt->current_exception)) {
+                if (JS_IsUncatchableError(ctx->rt->current_exception)) {
                     is_success = false;
                 } else {
                     abort(); /* BUG */
@@ -39363,7 +39363,7 @@ static const JSCFunctionListEntry js_error_proto_funcs[] = {
 static JSValue js_error_isError(JSContext *ctx, JSValueConst this_val,
                                 int argc, JSValueConst *argv)
 {
-    return js_bool(JS_IsError(ctx, argv[0]));
+    return js_bool(JS_IsError(argv[0]));
 }
 
 static JSValue js_error_get_stackTraceLimit(JSContext *ctx, JSValueConst this_val)
@@ -50480,7 +50480,7 @@ static JSValue promise_reaction_job(JSContext *ctx, int argc,
     }
     is_reject = JS_IsException(res);
     if (is_reject) {
-        if (unlikely(JS_IsUncatchableError(ctx, ctx->rt->current_exception)))
+        if (unlikely(JS_IsUncatchableError(ctx->rt->current_exception)))
             return JS_EXCEPTION;
         res = JS_GetException(ctx);
     }

--- a/quickjs.h
+++ b/quickjs.h
@@ -747,8 +747,8 @@ static inline bool JS_IsModule(JSValueConst v)
 JS_EXTERN JSValue JS_Throw(JSContext *ctx, JSValue obj);
 JS_EXTERN JSValue JS_GetException(JSContext *ctx);
 JS_EXTERN bool JS_HasException(JSContext *ctx);
-JS_EXTERN bool JS_IsError(JSContext *ctx, JSValueConst val);
-JS_EXTERN bool JS_IsUncatchableError(JSContext* ctx, JSValueConst val);
+JS_EXTERN bool JS_IsError(JSValueConst val);
+JS_EXTERN bool JS_IsUncatchableError(JSValueConst val);
 JS_EXTERN void JS_SetUncatchableError(JSContext *ctx, JSValueConst val);
 JS_EXTERN void JS_ClearUncatchableError(JSContext *ctx, JSValueConst val);
 // Shorthand for:

--- a/run-test262.c
+++ b/run-test262.c
@@ -1389,7 +1389,7 @@ static int eval_buf(JSContext *ctx, const char *buf, size_t buf_len,
 
     if (JS_IsException(res_val)) {
         exception_val = JS_GetException(ctx);
-        is_error = JS_IsError(ctx, exception_val);
+        is_error = JS_IsError(exception_val);
         js_print_262(ctx, JS_NULL, 1, (JSValueConst *)&exception_val);
         if (is_error) {
             JSValue name, stack;


### PR DESCRIPTION
Also remove it from JS_IsUncatchableError.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1203