### PR TITLE
Add function name to "not a constructor" errors

### DIFF
--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -259,6 +259,15 @@ function test_delete()
     assert(err, true, "delete");
 }
 
+function test_constructor()
+{
+    function *G() {}
+    let ex
+    try { new G() } catch (ex_) { ex = ex_ }
+    assert(ex instanceof TypeError)
+    assert(ex.message, "G is not a constructor")
+}
+
 function test_prototype()
 {
     var f = function f() { };
@@ -718,6 +727,7 @@ test_eq();
 test_inc_dec();
 test_op2();
 test_delete();
+test_constructor();
 test_prototype();
 test_arguments();
 test_class();


### PR DESCRIPTION
Include the function name (if known) in the error message, to make debugging easier. Not a complete fix but still an improvement.

Refs: https://github.com/quickjs-ng/quickjs/issues/991