### PR TITLE
JS_GetClass function

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -3609,15 +3609,14 @@ bool JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id)
     return (class_id < rt->class_count &&
             rt->class_array[class_id].class_id != 0);
 }
-JSAtom JS_GetClassName(JSRuntime *rt, JSClassID id)
+JSAtom JS_GetClassName(JSRuntime *rt, JSClassID class_id)
 {
-    if(!JS_IsRegisteredClass(rt, id)) {
+    if (JS_IsRegisteredClass(rt, class_id)) {
+        return JS_DupAtomRT(rt, rt->class_array[class_id].class_id);
+    } else {
         return JS_ATOM_NULL;
     }
-    JSAtom ret = rt->class_array[id].class_name;
-    JS_DupAtomRT(rt, ret);
-    return ret;
-}
+    }
 
 /* create a new object internal class. Return -1 if error, 0 if
    OK. The finalizer can be NULL if none is needed. */

--- a/quickjs.c
+++ b/quickjs.c
@@ -327,16 +327,6 @@ struct JSRuntime {
     JSRuntimeFinalizerState *finalizers;
 };
 
-struct JSClass {
-    uint32_t class_id; /* 0 means free entry */
-    JSAtom class_name;
-    JSClassFinalizer *finalizer;
-    JSClassGCMark *gc_mark;
-    JSClassCall *call;
-    /* pointers for exotic behavior, can be NULL if none are present */
-    const JSClassExoticMethods *exotic;
-};
-
 typedef struct JSStackFrame {
     struct JSStackFrame *prev_frame; /* NULL if first stack frame */
     JSValue cur_func; /* current function, JS_UNDEFINED if the frame is detached */
@@ -3610,6 +3600,13 @@ bool JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id)
             rt->class_array[class_id].class_id != 0);
 }
 
+const JSClass *JS_GetClass(JSRuntime *rt, JSClassID class_id)
+{
+    if(!JS_IsRegisteredClass(rt, class_id)) {
+        return NULL;
+    }
+    return &rt->class_array[class_id];
+}
 /* create a new object internal class. Return -1 if error, 0 if
    OK. The finalizer can be NULL if none is needed. */
 static int JS_NewClass1(JSRuntime *rt, JSClassID class_id,

--- a/quickjs.h
+++ b/quickjs.h
@@ -618,16 +618,6 @@ typedef struct JSClassDef {
     JSClassExoticMethods *exotic;
 } JSClassDef;
 
-struct JSClass {
-    uint32_t class_id; /* 0 means free entry */
-    JSAtom class_name;
-    JSClassFinalizer *finalizer;
-    JSClassGCMark *gc_mark;
-    JSClassCall *call;
-    /* pointers for exotic behavior, can be NULL if none are present */
-    const JSClassExoticMethods *exotic;
-};
-
 #define JS_EVAL_OPTIONS_VERSION 1
 
 typedef struct JSEvalOptions {
@@ -644,8 +634,8 @@ JS_EXTERN JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id);
 JS_EXTERN JSClassID JS_GetClassID(JSValueConst v);
 JS_EXTERN int JS_NewClass(JSRuntime *rt, JSClassID class_id, const JSClassDef *class_def);
 JS_EXTERN bool JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id);
-/* Returns a class definition if `class_id` is a registered class, otherwise returns NULL. */
-const JSClass *JS_GetClass(JSRuntime *rt, JSClassID class_id);
+/* Returns the class name or JS_ATOM_NULL if `id` is not a registered class. Must be freed with JS_FreeAtom. */
+JS_EXTERN JSAtom JS_GetClassName(JSRuntime *rt, JSClassID id);
 
 /* value handling */
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -618,6 +618,16 @@ typedef struct JSClassDef {
     JSClassExoticMethods *exotic;
 } JSClassDef;
 
+struct JSClass {
+    uint32_t class_id; /* 0 means free entry */
+    JSAtom class_name;
+    JSClassFinalizer *finalizer;
+    JSClassGCMark *gc_mark;
+    JSClassCall *call;
+    /* pointers for exotic behavior, can be NULL if none are present */
+    const JSClassExoticMethods *exotic;
+};
+
 #define JS_EVAL_OPTIONS_VERSION 1
 
 typedef struct JSEvalOptions {
@@ -634,6 +644,8 @@ JS_EXTERN JSClassID JS_NewClassID(JSRuntime *rt, JSClassID *pclass_id);
 JS_EXTERN JSClassID JS_GetClassID(JSValueConst v);
 JS_EXTERN int JS_NewClass(JSRuntime *rt, JSClassID class_id, const JSClassDef *class_def);
 JS_EXTERN bool JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id);
+/* Returns a class definition if `class_id` is a registered class, otherwise returns NULL. */
+const JSClass *JS_GetClass(JSRuntime *rt, JSClassID class_id);
 
 /* value handling */
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -635,7 +635,7 @@ JS_EXTERN JSClassID JS_GetClassID(JSValueConst v);
 JS_EXTERN int JS_NewClass(JSRuntime *rt, JSClassID class_id, const JSClassDef *class_def);
 JS_EXTERN bool JS_IsRegisteredClass(JSRuntime *rt, JSClassID class_id);
 /* Returns the class name or JS_ATOM_NULL if `id` is not a registered class. Must be freed with JS_FreeAtom. */
-JS_EXTERN JSAtom JS_GetClassName(JSRuntime *rt, JSClassID id);
+JS_EXTERN JSAtom JS_GetClassName(JSRuntime *rt, JSClassID class_id);
 
 /* value handling */
 


### PR DESCRIPTION
Hi,

Thanks again for this fantastic library!

I would like to add a JS_GetClass function so that the host application can inspect the details of native classes. Useful especially for generation of context-specific error messages that include class names.

Are there any concerns regarding the definition of JSClass being moved to the public header?

I would also like to disclose that I am totally blind. Though I tried to match the style as best I could, your feedback on any stylistic inconsistencies I may have missed would be greatly appreciated.

Thank you.
