### PR TITLE
Add C Closures

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -25,6 +25,20 @@ static JSValue cfuncdata_callback(JSContext *ctx, JSValueConst this_val,
     return JS_ThrowTypeError(ctx, "from cfuncdata");
 }
 
+static JSValue cclosure_callback(JSContext *ctx, JSValueConst this_val,
+                                 int argc, JSValueConst *argv,
+                                 int magic, void *func_data)
+{
+  return JS_ThrowTypeError(ctx, "from cclosure");
+}
+
+static bool closure_finalized = false;
+static void cclosure_opaque_finalize(void* opaque)
+{
+    if ((intptr_t)opaque == 12)
+        closure_finalized = true;
+}
+
 static void cfunctions(void)
 {
     uint32_t length;
@@ -37,9 +51,13 @@ static void cfunctions(void)
     JSValue cfuncdata =
         JS_NewCFunctionData2(ctx, cfuncdata_callback, "cfuncdata",
                              /*length*/1337, /*magic*/0, /*data_len*/0, NULL);
+    JSValue cclosure =
+        JS_NewCClosure(ctx, cclosure_callback, "cclosure", cclosure_opaque_finalize,
+                       /*length*/0xC0DE, /*magic*/11, /*opaque*/(void*)12);
     JSValue global = JS_GetGlobalObject(ctx);
     JS_SetPropertyStr(ctx, global, "cfunc", cfunc);
     JS_SetPropertyStr(ctx, global, "cfuncdata", cfuncdata);
+    JS_SetPropertyStr(ctx, global, "cclosure", cclosure);
     JS_FreeValue(ctx, global);
 
     ret = eval(ctx, "cfunc.name");
@@ -69,6 +87,20 @@ static void cfunctions(void)
     assert(JS_IsNumber(ret));
     assert(0 == JS_ToUint32(ctx, &length, ret));
     assert(length == 1337);
+
+    ret = eval(ctx, "cclosure.name");
+    assert(!JS_IsException(ret));
+    assert(JS_IsString(ret));
+    s = JS_ToCString(ctx, ret);
+    JS_FreeValue(ctx, ret);
+    assert(s);
+    assert(!strcmp(s, "cclosure"));
+    JS_FreeCString(ctx, s);
+    ret = eval(ctx, "cclosure.length");
+    assert(!JS_IsException(ret));
+    assert(JS_IsNumber(ret));
+    assert(0 == JS_ToUint32(ctx, &length, ret));
+    assert(length == 0xC0DE);
 
     ret = eval(ctx, "cfunc()");
     assert(JS_IsException(ret));
@@ -104,8 +136,27 @@ static void cfunctions(void)
     assert(!strcmp(s, "TypeError: from cfuncdata"));
     JS_FreeCString(ctx, s);
 
+    ret = eval(ctx, "cclosure()");
+    assert(JS_IsException(ret));
+    ret = JS_GetException(ctx);
+    assert(JS_IsError(ret));
+    stack = JS_GetPropertyStr(ctx, ret, "stack");
+    assert(JS_IsString(stack));
+    s = JS_ToCString(ctx, stack);
+    JS_FreeValue(ctx, stack);
+    assert(s);
+    assert(!strcmp(s, "    at cclosure (native)\n    at <eval> (<input>:1:1)\n"));
+    JS_FreeCString(ctx, s);
+    s = JS_ToCString(ctx, ret);
+    JS_FreeValue(ctx, ret);
+    assert(s);
+    assert(!strcmp(s, "TypeError: from cclosure"));
+    JS_FreeCString(ctx, s);
+
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
+
+    assert(closure_finalized);
 }
 
 #define MAX_TIME 10

--- a/api-test.c
+++ b/api-test.c
@@ -33,7 +33,8 @@ static JSValue cclosure_callback(JSContext *ctx, JSValueConst this_val,
 }
 
 static bool closure_finalized = false;
-static void cclosure_opaque_finalize(void* opaque)
+
+static void cclosure_opaque_finalize(void *opaque)
 {
     if ((intptr_t)opaque == 12)
         closure_finalized = true;

--- a/quickjs.c
+++ b/quickjs.c
@@ -138,6 +138,7 @@ enum {
     JS_CLASS_BYTECODE_FUNCTION, /* u.func */
     JS_CLASS_BOUND_FUNCTION,    /* u.bound_function */
     JS_CLASS_C_FUNCTION_DATA,   /* u.c_function_data_record */
+    JS_CLASS_C_CLOSURE,         /* u.c_closure_record */
     JS_CLASS_GENERATOR_FUNCTION, /* u.func */
     JS_CLASS_FOR_IN_ITERATOR,   /* u.for_in_iterator */
     JS_CLASS_REGEXP,            /* u.regexp */
@@ -980,6 +981,7 @@ struct JSObject {
         void *opaque;
         struct JSBoundFunction *bound_function; /* JS_CLASS_BOUND_FUNCTION */
         struct JSCFunctionDataRecord *c_function_data_record; /* JS_CLASS_C_FUNCTION_DATA */
+        struct JSCClosureRecord *c_closure_record; /* JS_CLASS_C_CLOSURE */
         struct JSForInIterator *for_in_iterator; /* JS_CLASS_FOR_IN_ITERATOR */
         struct JSArrayBuffer *array_buffer; /* JS_CLASS_ARRAY_BUFFER, JS_CLASS_SHARED_ARRAY_BUFFER */
         struct JSTypedArray *typed_array; /* JS_CLASS_UINT8C_ARRAY..JS_CLASS_DATAVIEW */
@@ -1343,6 +1345,10 @@ static void js_c_function_data_mark(JSRuntime *rt, JSValueConst val,
 static JSValue js_call_c_function_data(JSContext *ctx, JSValueConst func_obj,
                                        JSValueConst this_val,
                                        int argc, JSValueConst *argv, int flags);
+static void js_c_closure_finalizer(JSRuntime *rt, JSValue val);
+static JSValue js_call_c_closure(JSContext *ctx, JSValueConst func_obj,
+                                 JSValueConst this_val,
+                                 int argc, JSValueConst *argv, int flags);
 static JSAtom js_symbol_to_atom(JSContext *ctx, JSValueConst val);
 static void add_gc_object(JSRuntime *rt, JSGCObjectHeader *h,
                           JSGCObjectTypeEnum type);
@@ -1746,6 +1752,7 @@ static JSClassShortDef const js_std_class_def[] = {
     { JS_ATOM_Function, js_bytecode_function_finalizer, js_bytecode_function_mark }, /* JS_CLASS_BYTECODE_FUNCTION */
     { JS_ATOM_Function, js_bound_function_finalizer, js_bound_function_mark }, /* JS_CLASS_BOUND_FUNCTION */
     { JS_ATOM_Function, js_c_function_data_finalizer, js_c_function_data_mark }, /* JS_CLASS_C_FUNCTION_DATA */
+    { JS_ATOM_Function, js_c_closure_finalizer, NULL},                           /* JS_CLASS_C_CLOSURE */
     { JS_ATOM_GeneratorFunction, js_bytecode_function_finalizer, js_bytecode_function_mark },  /* JS_CLASS_GENERATOR_FUNCTION */
     { JS_ATOM_ForInIterator, js_for_in_iterator_finalizer, js_for_in_iterator_mark },      /* JS_CLASS_FOR_IN_ITERATOR */
     { JS_ATOM_RegExp, js_regexp_finalizer, NULL },                              /* JS_CLASS_REGEXP */
@@ -1870,6 +1877,7 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
 
     rt->class_array[JS_CLASS_C_FUNCTION].call = js_call_c_function;
     rt->class_array[JS_CLASS_C_FUNCTION_DATA].call = js_call_c_function_data;
+    rt->class_array[JS_CLASS_C_CLOSURE].call = js_call_c_closure;
     rt->class_array[JS_CLASS_BOUND_FUNCTION].call = js_call_bound_function;
     rt->class_array[JS_CLASS_GENERATOR_FUNCTION].call = js_call_generator_function;
     if (init_shape_hash(rt))
@@ -5547,6 +5555,75 @@ static void js_autoinit_mark(JSRuntime *rt, JSProperty *pr,
     mark_func(rt, &js_autoinit_get_realm(pr)->header);
 }
 
+typedef struct JSCClosureRecord {
+    JSCClosure *func;
+    uint16_t length;
+    uint16_t magic;
+    void *opaque;
+    void (*opaque_finalize)(void*);
+} JSCClosureRecord;
+
+static void js_c_closure_finalizer(JSRuntime *rt, JSValue val)
+{
+    JSCClosureRecord *s = JS_GetOpaque(val, JS_CLASS_C_CLOSURE);
+
+    if (s) {
+        if (s->opaque_finalize)
+           s->opaque_finalize(s->opaque);
+
+        js_free_rt(rt, s);
+    }
+}
+
+static JSValue js_call_c_closure(JSContext *ctx, JSValueConst func_obj,
+                                 JSValueConst this_val,
+                                 int argc, JSValueConst *argv, int flags)
+{
+    JSCClosureRecord *s = JS_GetOpaque(func_obj, JS_CLASS_C_CLOSURE);
+    JSValueConst *arg_buf;
+    int i;
+
+    /* XXX: could add the function on the stack for debug */
+    if (unlikely(argc < s->length)) {
+        arg_buf = alloca(sizeof(arg_buf[0]) * s->length);
+        for(i = 0; i < argc; i++)
+            arg_buf[i] = argv[i];
+        for(i = argc; i < s->length; i++)
+            arg_buf[i] = JS_UNDEFINED;
+    } else {
+        arg_buf = argv;
+    }
+
+    return s->func(ctx, this_val, argc, arg_buf, s->magic, s->opaque);
+}
+
+JSValue JS_NewCClosure(JSContext *ctx, JSCClosure *func,
+                       int length, int magic, void *opaque,
+                       void (*opaque_finalize)(void*))
+{
+    JSCClosureRecord *s;
+    JSValue func_obj;
+
+    func_obj = JS_NewObjectProtoClass(ctx, ctx->function_proto,
+                                      JS_CLASS_C_CLOSURE);
+    if (JS_IsException(func_obj))
+        return func_obj;
+    s = js_malloc(ctx, sizeof(*s));
+    if (!s) {
+        JS_FreeValue(ctx, func_obj);
+        return JS_EXCEPTION;
+    }
+    s->func = func;
+    s->length = length;
+    s->magic = magic;
+    s->opaque = opaque;
+    s->opaque_finalize = opaque_finalize;
+    JS_SetOpaque(func_obj, s);
+    js_function_set_properties(ctx, func_obj,
+                               JS_ATOM_empty_string, length);
+    return func_obj;
+}
+
 static void free_property(JSRuntime *rt, JSProperty *pr, int prop_flags)
 {
     if (unlikely(prop_flags & JS_PROP_TMASK)) {
@@ -6452,6 +6529,15 @@ void JS_ComputeMemoryUsage(JSRuntime *rt, JSMemoryUsage *s)
                     }
                     s->memory_used_count += 1;
                     s->memory_used_size += sizeof(*fd) + fd->data_len * sizeof(*fd->data);
+                }
+            }
+            break;
+        case JS_CLASS_C_CLOSURE:   /* u.c_closure_record */
+            {
+                JSCClosureRecord *c = p->u.c_closure_record;
+                if (c) {
+                    s->memory_used_count += 1;
+                    s->memory_used_size += sizeof(*c);
                 }
             }
             break;

--- a/quickjs.c
+++ b/quickjs.c
@@ -5636,7 +5636,7 @@ JSValue JS_NewCClosure(JSContext* ctx, JSCClosure* func, const char* name,
     s->magic = magic;
     s->opaque = opaque;
     s->opaque_finalize = opaque_finalize;
-    JS_SetOpaque(func_obj, s);
+    JS_SetOpaqueInternal(func_obj, s);
     name_atom = JS_ATOM_empty_string;
     if (name && *name) {
         name_atom = JS_NewAtom(ctx, name);

--- a/quickjs.c
+++ b/quickjs.c
@@ -5560,7 +5560,7 @@ typedef struct JSCClosureRecord {
     uint16_t length;
     uint16_t magic;
     void *opaque;
-    void (*opaque_finalize)(void*);
+    void (*opaque_finalize)(void *opaque);
 } JSCClosureRecord;
 
 static void js_c_closure_finalizer(JSRuntime *rt, JSValueConst val)
@@ -5579,10 +5579,10 @@ static JSValue js_call_c_closure(JSContext *ctx, JSValueConst func_obj,
                                  JSValueConst this_val,
                                  int argc, JSValueConst *argv, int flags)
 {
-    JSRuntime* rt = ctx->rt;
-    JSStackFrame sf_s, * sf = &sf_s, * prev_sf;
-    JSCClosureRecord* s = JS_GetOpaque(func_obj, JS_CLASS_C_CLOSURE);
-    JSValueConst* arg_buf;
+    JSRuntime *rt = ctx->rt;
+    JSStackFrame sf_s, *sf = &sf_s, *prev_sf;
+    JSCClosureRecord *s = JS_GetOpaque(func_obj, JS_CLASS_C_CLOSURE);
+    JSValueConst *arg_buf;
     JSValue ret;
     int arg_count;
     int i;
@@ -5614,11 +5614,11 @@ static JSValue js_call_c_closure(JSContext *ctx, JSValueConst func_obj,
     return ret;
 }
 
-JSValue JS_NewCClosure(JSContext* ctx, JSCClosure* func, const char* name,
+JSValue JS_NewCClosure(JSContext *ctx, JSCClosure *func, const char *name,
                        JSCClosureFinalizerFunc *opaque_finalize,
-                       int length, int magic, void* opaque)
+                       int length, int magic, void *opaque)
 {
-    JSCClosureRecord* s;
+    JSCClosureRecord *s;
     JSAtom name_atom;
     JSValue func_obj;
 

--- a/quickjs.h
+++ b/quickjs.h
@@ -394,6 +394,7 @@ static inline bool JS_VALUE_IS_NAN(JSValue v)
 typedef JSValue JSCFunction(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv);
 typedef JSValue JSCFunctionMagic(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv, int magic);
 typedef JSValue JSCFunctionData(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv, int magic, JSValueConst *func_data);
+typedef JSValue JSCClosure(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv, int magic, void *opaque);
 
 typedef struct JSMallocFunctions {
     void *(*js_calloc)(void *opaque, size_t count, size_t size);
@@ -1165,6 +1166,9 @@ JS_EXTERN JSValue JS_NewCFunctionData2(JSContext *ctx, JSCFunctionData *func,
                                        const char *name,
                                        int length, int magic, int data_len,
                                        JSValueConst *data);
+JS_EXTERN JSValue JS_NewCClosure(JSContext *ctx, JSCClosure *func,
+                       int length, int magic, void *opaque,
+                       void (*opaque_finalize)(void*));
 
 static inline JSValue JS_NewCFunction(JSContext *ctx, JSCFunction *func,
                                       const char *name, int length)

--- a/quickjs.h
+++ b/quickjs.h
@@ -1166,9 +1166,11 @@ JS_EXTERN JSValue JS_NewCFunctionData2(JSContext *ctx, JSCFunctionData *func,
                                        const char *name,
                                        int length, int magic, int data_len,
                                        JSValueConst *data);
-JS_EXTERN JSValue JS_NewCClosure(JSContext *ctx, JSCClosure *func,
-                       int length, int magic, void *opaque,
-                       void (*opaque_finalize)(void*));
+typedef void JSCClosureFinalizerFunc(void*);
+JS_EXTERN JSValue JS_NewCClosure(JSContext* ctx, JSCClosure* func,
+                                 const char* name,
+                                 JSCClosureFinalizerFunc* opaque_finalize,
+                                 int length, int magic, void* opaque);
 
 static inline JSValue JS_NewCFunction(JSContext *ctx, JSCFunction *func,
                                       const char *name, int length)

--- a/quickjs.h
+++ b/quickjs.h
@@ -1167,10 +1167,10 @@ JS_EXTERN JSValue JS_NewCFunctionData2(JSContext *ctx, JSCFunctionData *func,
                                        int length, int magic, int data_len,
                                        JSValueConst *data);
 typedef void JSCClosureFinalizerFunc(void*);
-JS_EXTERN JSValue JS_NewCClosure(JSContext* ctx, JSCClosure* func,
-                                 const char* name,
-                                 JSCClosureFinalizerFunc* opaque_finalize,
-                                 int length, int magic, void* opaque);
+JS_EXTERN JSValue JS_NewCClosure(JSContext *ctx, JSCClosure *func,
+                                 const char *name,
+                                 JSCClosureFinalizerFunc *opaque_finalize,
+                                 int length, int magic, void *opaque);
 
 static inline JSValue JS_NewCFunction(JSContext *ctx, JSCFunction *func,
                                       const char *name, int length)


### PR DESCRIPTION
This allows C objects to be attached to functions, and it also allows C code to be notified when these functions are finalized.

Import of https://github.com/tbluemel/quickjscpp/blob/98bf1ddb00e39d93840c4b67211c9260943b5a83/patches/2024-01-13/0001-Add-C-Closures.patch. Trivial renaming of functions and function annotations to match local style.

Closes #1212. Closes https://github.com/tbluemel/quickjscpp/issues/3.