### PR TITLE
Fix missing include guards for dtoa header

### DIFF
--- a/dtoa.h
+++ b/dtoa.h
@@ -21,6 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#ifndef DTOA_H
+#define DTOA_H
 
 //#define JS_DTOA_DUMP_STATS
 
@@ -81,3 +83,5 @@ size_t u64toa(char *buf, uint64_t n);
 size_t i64toa(char *buf, int64_t n);
 size_t u64toa_radix(char *buf, uint64_t n, unsigned int radix);
 size_t i64toa_radix(char *buf, int64_t n, unsigned int radix);
+
+#endif /* DTOA_H */


### PR DESCRIPTION
The new `dtoa.h` header is missing include guards, which breaks unity/jumbo builds