### PR TITLE
Fix Atomics.pause on 32 bits platforms

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -57112,7 +57112,7 @@ static JSValue js_atomics_pause(JSContext *ctx, JSValueConst this_obj,
     double d;
 
     if (argc > 0) {
-        switch (JS_VALUE_GET_TAG(argv[0])) {
+        switch (JS_VALUE_GET_NORM_TAG(argv[0])) {
         case JS_TAG_FLOAT64: // accepted if and only if fraction == 0.0
             d = JS_VALUE_GET_FLOAT64(argv[0]);
             if (isfinite(d))


### PR DESCRIPTION
Use JS_VALUE_GET_NORM_TAG to get the type tag, not JS_VALUE_GET_TAG. The latter doesn't work correctly with NaN boxing.

Refs: https://github.com/quickjs-ng/quickjs/issues/986#issuecomment-3508547332