### PR TITLE
[wip] Record async stack traces

### DIFF
--- a/run-test262.c
+++ b/run-test262.c
@@ -1529,6 +1529,17 @@ static int eval_buf(JSContext *ctx, const char *buf, size_t buf_len,
 
     if (local) {
         ret = js_std_loop(ctx);
+        if (!ret) {
+            JSValue obj = JS_GetGlobalObject(ctx);
+            JSValue fun = JS_GetPropertyStr(ctx, obj, "exit");
+            JS_FreeValue(ctx, obj);
+            if (!JS_IsUndefined(fun)) {
+                JSValue val = JS_Call(ctx, fun, JS_UNDEFINED, 0, NULL);
+                ret = JS_IsException(val);
+                JS_FreeValue(ctx, val);
+            }
+            JS_FreeValue(ctx, fun);
+        }
         if (ret)
             js_std_dump_error(ctx);
     }

--- a/tests/async-stack-trace.js
+++ b/tests/async-stack-trace.js
@@ -1,0 +1,21 @@
+import {assert} from "../tests/assert.js"
+
+let ok = false
+globalThis.exit = function() { assert(ok) }
+
+f().catch(e => {
+    assert(e instanceof Error)
+    assert(typeof e.stack, "string")
+    assert(e.message, "boom")
+    assert(e.stack.includes(" at f "))
+    ok = true
+})
+
+async function f() {
+    await g()
+}
+
+async function g() {
+    await 42
+    throw Error("boom")
+}


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/1248

<hr>

Definitely work in progress. Currently no way to limit the stack trace size, sometimes records the same stack frame twice,  loses track around `new Promise(...)`, and no doubt there's more.