### PR TITLE
Make JSString smaller

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -565,13 +565,13 @@ typedef enum {
 struct JSString {
     JSRefCountHeader header; /* must come first, 32-bit */
     uint32_t len : 31;
-    uint8_t is_wide_char : 1; /* 0 = 8 bits, 1 = 16 bits characters */
+    uint32_t is_wide_char : 1; /* 0 = 8 bits, 1 = 16 bits characters */
     /* for JS_ATOM_TYPE_SYMBOL: hash = 0, atom_type = 3,
        for JS_ATOM_TYPE_PRIVATE: hash = 1, atom_type = 3
        XXX: could change encoding to have one more bit in hash */
     uint32_t hash : 29;
-    uint8_t kind : 1;
-    uint8_t atom_type : 2; /* != 0 if atom, JS_ATOM_TYPE_x */
+    uint32_t kind : 1;
+    uint32_t atom_type : 2; /* != 0 if atom, JS_ATOM_TYPE_x */
     uint32_t hash_next; /* atom_index for JS_ATOM_TYPE_SYMBOL */
     JSWeakRefRecord *first_weak_ref;
 #ifdef ENABLE_DUMPS // JS_DUMP_LEAKS


### PR DESCRIPTION
MSVC apparently doesn't merge adjacent bit fields if they don't have the same type. Change the uint8_t fields to uint32_t.

It was reported that `sizeof(JSString)` was 48 bytes on Windows but it should be 40 bytes now, like it is on x86_64 Linux.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1250