### PR TITLE
ci: remove meaningless clang-cl+msan config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,11 +660,6 @@ jobs:
             extra_envs:
               CC: clang-cl
               CXX: clang-cl
-          - name: clang-cl+msan
-            args: -Db_sanitize=memory
-            extra_envs:
-              CC: clang-cl
-              CXX: clang-cl
         platform:
           - ubuntu-latest
           - windows-latest
@@ -678,12 +673,6 @@ jobs:
           - platform: macos-latest
             mode:
               name: clang-cl+sanitize
-          - platform: ubuntu-latest
-            mode:
-              name: clang-cl+msan
-          - platform: macos-latest
-            mode:
-              name: clang-cl+msan
 
           # Use clang-cl instead of MSYS2 clang.
           #


### PR DESCRIPTION
MemorySanitizer is not available on Windows, this is a no-op.
