### PR TITLE
Propagate exceptions in Iterator.concat

### DIFF
--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -17,8 +17,6 @@ test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-reje
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-rejected-promise-close.js:74: strict mode: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-result-poisoned-wrapper.js:81: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-result-poisoned-wrapper.js:81: strict mode: TypeError: $DONE() not called
-test262/test/built-ins/Iterator/concat/next-method-returns-throwing-value.js:25: Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
-test262/test/built-ins/Iterator/concat/next-method-returns-throwing-value.js:25: strict mode: Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
 test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Unknown.js:16: SyntaxError: unknown unicode script
 test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Unknown.js:16: strict mode: SyntaxError: unknown unicode script
 test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Unknown.js:16: SyntaxError: unknown unicode script


### PR DESCRIPTION
test262 took a 180 degree turn because the test that is fixed by this commit is the polar opposite of what was tested by the test suite when I originally added Iterator.concat.

The old behavior was not very efficient, so good for them for changing their minds, but next time please do so before I spend an hour implementing it, thank you very much.