### PR TITLE
Add 'JS_FreeCStringRT'

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -4360,6 +4360,14 @@ void JS_FreeCString(JSContext *ctx, const char *ptr)
     JS_FreeValue(ctx, JS_MKPTR(JS_TAG_STRING, (JSString *)ptr - 1));
 }
 
+void JS_FreeCStringRT(JSRuntime *rt, const char *ptr)
+{
+    if (!ptr)
+        return;
+    /* purposely removing constness */
+    JS_FreeValueRT(rt, JS_MKPTR(JS_TAG_STRING, (JSString *)ptr - 1));
+}
+
 static int memcmp16_8(const uint16_t *src1, const uint8_t *src2, int len)
 {
     int c, i;

--- a/quickjs.h
+++ b/quickjs.h
@@ -820,6 +820,7 @@ static inline const char *JS_ToCString(JSContext *ctx, JSValueConst val1)
     return JS_ToCStringLen2(ctx, NULL, val1, 0);
 }
 JS_EXTERN void JS_FreeCString(JSContext *ctx, const char *ptr);
+JS_EXTERN void JS_FreeCStringRT(JSRuntime *rt, const char *ptr);
 
 JS_EXTERN JSValue JS_NewObjectProtoClass(JSContext *ctx, JSValueConst proto,
                                          JSClassID class_id);


### PR DESCRIPTION
Hello!

I've got a PR here for adding a new 'JS_FreeCStringRT' function that (if I understand the code correctly) should function the same as the existing 'JS_FreeCString' but takes a JSRuntime instead of a JSContext. It looks like the c-string being returned is just actually a JSString value with the string data trailing off the end of the allocation. I can't see any obvious reason why it needs to be tied to a JSContext.

My motivation for this feature follows on from my question in [this discussion](https://github.com/quickjs-ng/quickjs/discussions/1257). My Rust bindings rely on a single, thread local JSRuntime for each thread. Nothing can get sent to other threads so I get a reasonably safe API without lifetime soup. The c-strings were the odd one left, still needing a reference to the JSContext they were created from so I could clean them up with RAII. With this change that can go away.

If this is API internals you don't want to commit to I understand, as this is a whole new API, but thought I'd forward this for discussion.

Seems to work in my Rust code but I haven't tested very thoroughly.