### PR TITLE
fix: lock CI to macOS 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           path: build/*-linux-${{matrix.arch}}
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
       - name: build


### PR DESCRIPTION
full context: https://github.com/quickjs-ng/quickjs/issues/1172#issuecomment-3678500403