### PR TITLE
add JS_WriteMemeroyUsage for reporting back memory usage out in different ways

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -535,6 +535,9 @@ typedef struct JSMemoryUsage {
 JS_EXTERN void JS_ComputeMemoryUsage(JSRuntime *rt, JSMemoryUsage *s);
 JS_EXTERN void JS_DumpMemoryUsage(FILE *fp, const JSMemoryUsage *s, JSRuntime *rt);
 
+typedef int (*JS_MemoryUsageCB)(void* opaque, const char* data, size_t data_len);
+JS_EXTERN int JS_WriteMemoryUsage(JS_MemoryUsageCB cb, const JSMemoryUsage *s, JSRuntime *rt, void* opaque);
+
 /* atom support */
 #define JS_ATOM_NULL 0
 


### PR DESCRIPTION
I recently saw this project as a good candidate for a new Javascript interpreter library for Python & Cython and as I was going about binding python and quickjs-ng together I came across an issue with using `FILE*` pointers since Python does not have a very clear way of gaining access to these `FILE*` pointers and I saw extracting objects from `PyObject*` to `const char*` types to be rather annoying and not very efficient and may limit what programmers may be able to do with this data so I decided to write a newer callback system to try and make up for this. annoyance. The way I plan to use it in Cython will be the following code.

But for the code I'm demonstrating I'll cut to the important stuff that makes use of these functions that I am needing.

```cython

cdef int js_write_memory_usage_cb(void* opaque, const char* data, size_t data_len) noexcept with gil:
    cdef str py_data
    cdef object write_cb = <object>opaque
    try:
        PyObject_CallOneArg(write_cb, PyUnicode_FromStringAndSize(data, data_len))
        # success!
        return 0
    except BaseException:
        # reraise later...
        return -1
 

cdef class Runtime:
    """
    Represents a JavaScript runtime corresponding to an
    object heap. Several runtimes can exist at the same time but they
    cannot exchange objects. Inside a given runtime, no multi-threading is
    supported.
    """
    cdef:
        JSRuntime* rt
    
    cpdef object dump_memory_usage(self, object io):
        """dumps memory to an StringIO type object or file type object"""
        cdef object write = io.write # SEE: https://docs.python.org/3/c-api/file.html
        cdef JSMemoryUsage memory_usage
        cdef int ret
        JS_ComputeMemoryUsage(self.rt, &memory_usage)
        
        ret = JS_WriteMemoryUsage(js_write_memory_usage_cb, memory_usage, self.rt, <void*>(write))
        if ret < 0:
            # Reraise Last Seen Python Exception
            raise
 ```
 
 Please let me know if any names or things in these additions should be changed or if there's a better way for me to come up with a less costly implementation for the library I am planning to make.
 