### PR TITLE
fix: use __wasi_proc_exit() for WASI targets

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -58,7 +58,9 @@
 #else
 #include <sys/ioctl.h>
 #include <poll.h>
-#if !defined(__wasi__)
+#if defined(__wasi__)
+#include <wasi/api.h>
+#else
 #include <dlfcn.h>
 #include <termios.h>
 #include <sys/resource.h>
@@ -825,7 +827,11 @@ static JSValue js_std_exit(JSContext *ctx, JSValueConst this_val,
     int status;
     if (JS_ToInt32(ctx, &status, argv[0]))
         status = -1;
+#if defined(__wasi__)
+    __wasi_proc_exit(status);
+#else
     exit(status);
+#endif
     return JS_UNDEFINED;
 }
 


### PR DESCRIPTION
## Problem
When targeting WASI, `exit()` may not be properly interceptable by the WebAssembly runtime.
WASI defines `__wasi_proc_exit()` as the standard way to terminate the process.

## Solution
1. Include `<wasi/api.h>` when building for WASI
2. Use `__wasi_proc_exit()` instead of `exit()` in `js_std_exit()`

## Use Case
Running QuickJS in WebAssembly runtimes (WAMR, Wasmtime, WasmEdge) where the runtime needs to trap process exit.