### PR TITLE
Compilation fixes for DJGPP

### DIFF
--- a/cutils.c
+++ b/cutils.c
@@ -937,12 +937,19 @@ uint64_t js__hrtime_ns(void) {
 }
 #else
 uint64_t js__hrtime_ns(void) {
+#ifdef __DJGPP
+  struct timeval tv;
+  if (gettimeofday(&tv, NULL))
+    abort();
+  return ((uint64_t)tv.tv_sec * NANOSEC) + tv.tv_usec * 1000;
+#else
   struct timespec t;
 
   if (clock_gettime(CLOCK_MONOTONIC, &t))
     abort();
 
   return t.tv_sec * NANOSEC + t.tv_nsec;
+#endif
 }
 #endif
 

--- a/cutils.c
+++ b/cutils.c
@@ -941,7 +941,7 @@ uint64_t js__hrtime_ns(void) {
   struct timeval tv;
   if (gettimeofday(&tv, NULL))
     abort();
-  return ((uint64_t)tv.tv_sec * NANOSEC) + tv.tv_usec * 1000;
+  return tv.tv_sec * NANOSEC + tv.tv_usec * 1000;
 #else
   struct timespec t;
 

--- a/cutils.h
+++ b/cutils.h
@@ -50,7 +50,7 @@ extern "C" {
 #elif defined(_WIN32)
 #include <windows.h>
 #endif
-#if !defined(_WIN32) && !defined(EMSCRIPTEN) && !defined(__wasi__)
+#if !defined(_WIN32) && !defined(EMSCRIPTEN) && !defined(__wasi__) && !defined(__DJGPP)
 #include <errno.h>
 #include <pthread.h>
 #endif
@@ -578,7 +578,7 @@ int js_exepath(char* buffer, size_t* size);
 
 /* Cross-platform threading APIs. */
 
-#if defined(EMSCRIPTEN) || defined(__wasi__)
+#if defined(EMSCRIPTEN) || defined(__wasi__) || defined(__DJGPP)
 
 #define JS_HAVE_THREADS 0
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -40,7 +40,9 @@
 #include <intrin.h>
 #endif
 #include <time.h>
+#ifndef __DJGPP
 #include <fenv.h>
+#endif
 #include <math.h>
 
 #include "cutils.h"
@@ -68,7 +70,7 @@
 // atomic_store etc. are completely busted in recent versions of tcc;
 // somehow the compiler forgets to load |ptr| into %rdi when calling
 // the __atomic_*() helpers in its lib/stdatomic.c and lib/atomic.S
-#if !defined(__TINYC__) && !defined(EMSCRIPTEN) && !defined(__wasi__) && !__STDC_NO_ATOMICS__
+#if !defined(__TINYC__) && !defined(EMSCRIPTEN) && !defined(__wasi__) && !__STDC_NO_ATOMICS__ && !defined(__DJGPP)
 #include "quickjs-c-atomics.h"
 #define CONFIG_ATOMICS
 #endif

--- a/quickjs.c
+++ b/quickjs.c
@@ -40,9 +40,6 @@
 #include <intrin.h>
 #endif
 #include <time.h>
-#ifndef __DJGPP
-#include <fenv.h>
-#endif
 #include <math.h>
 
 #include "cutils.h"


### PR DESCRIPTION
I just want a library only, so changes to the library code. It is the first step.

I compiled library by these commands:

mkdir build
cd build
cmake ..
make clean
/usr/bin/i586-pc-msdosdjgpp-gcc -D_GNU_SOURCE -I/home/git/GIT/quickjs -O3 -DNDEBUG -std=gnu11 -Wall -Wextra -Wformat=2 -Wno-implicit-fallthrough -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-result -Wno-stringop-truncation -Wno-array-bounds -funsigned-char -MD -MT CMakeFiles/qjs.dir/cutils.c.o -MF CMakeFiles/qjs.dir/cutils.c.o.d -o CMakeFiles/qjs.dir/cutils.c.o -c /home/git/GIT/quickjs/cutils.c

/usr/bin/i586-pc-msdosdjgpp-gcc -D_GNU_SOURCE -I/home/git/GIT/quickjs -O3 -DNDEBUG -std=gnu11 -Wall -Wextra -Wformat=2 -Wno-implicit-fallthrough -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-result -Wno-stringop-truncation -Wno-array-bounds -funsigned-char -MD -MT CMakeFiles/qjs.dir/dtoa.c.o -MF CMakeFiles/qjs.dir/dtoa.c.o.d -o CMakeFiles/qjs.dir/dtoa.c.o -c /home/git/GIT/quickjs/dtoa.c

/usr/bin/i586-pc-msdosdjgpp-gcc -D_GNU_SOURCE -I/home/git/GIT/quickjs -O3 -DNDEBUG -std=gnu11 -Wall -Wextra -Wformat=2 -Wno-implicit-fallthrough -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-result -Wno-stringop-truncation -Wno-array-bounds -funsigned-char -MD -MT CMakeFiles/qjs.dir/libregexp.c.o -MF CMakeFiles/qjs.dir/libregexp.c.o.d -o CMakeFiles/qjs.dir/libregexp.c.o -c /home/git/GIT/quickjs/libregexp.c

/usr/bin/i586-pc-msdosdjgpp-gcc -D_GNU_SOURCE -I/home/git/GIT/quickjs -O3 -DNDEBUG -std=gnu11 -Wall -Wextra -Wformat=2 -Wno-implicit-fallthrough -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-result -Wno-stringop-truncation -Wno-array-bounds -funsigned-char -MD -MT CMakeFiles/qjs.dir/libunicode.c.o -MF CMakeFiles/qjs.dir/libunicode.c.o.d -o CMakeFiles/qjs.dir/libunicode.c.o -c /home/git/GIT/quickjs/libunicode.c

/usr/bin/i586-pc-msdosdjgpp-gcc -D_GNU_SOURCE -I/home/git/GIT/quickjs -O3 -DNDEBUG -std=gnu11 -Wall -Wextra -Wformat=2 -Wno-implicit-fallthrough -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-result -Wno-stringop-truncation -Wno-array-bounds -funsigned-char -MD -MT CMakeFiles/qjs.dir/quickjs.c.o -MF CMakeFiles/qjs.dir/quickjs.c.o.d -o CMakeFiles/qjs.dir/quickjs.c.o -c /home/git/GIT/quickjs/quickjs.c

/usr/bin/i586-pc-msdosdjgpp-ar qc libqjs.a CMakeFiles/qjs.dir/cutils.c.o CMakeFiles/qjs.dir/dtoa.c.o CMakeFiles/qjs.dir/libregexp.c.o CMakeFiles/qjs.dir/libunicode.c.o CMakeFiles/qjs.dir/quickjs.c.o

/usr/bin/ranlib libqjs.a
