### PR TITLE
Replace fmin/fmax with plain comparison

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -44845,7 +44845,7 @@ static double js_fmin(double a, double b)
         a1.u64 |= b1.u64;
         return a1.d;
     } else {
-        return fmin(a, b);
+        return a < b ? a : b;
     }
 }
 
@@ -44859,7 +44859,7 @@ static double js_fmax(double a, double b)
         a1.u64 &= b1.u64;
         return a1.d;
     } else {
-        return fmax(a, b);
+        return a < b ? b : a;
     }
 }
 


### PR DESCRIPTION
It was reported that DJGPP lacks fmin and fmax. The surrounding code code already takes care of NaNs and signed zeros, so there is no real need to call out to said functions.

Refs: https://github.com/quickjs-ng/quickjs/pull/1287