### PR TITLE
Add JS_ToCStringTwoByte

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -440,6 +440,13 @@ static void two_byte_string(void)
         assert(s);
         assert(!strcmp(s, "ok"));
         JS_FreeCString(ctx, s);
+        size_t n;
+        const uint16_t *u = JS_ToCStringTwoByteLen(ctx, &n, v);
+        assert(u);
+        assert(n == 2);
+        assert(u[0] == 'o');
+        assert(u[1] == 'k');
+        JS_FreeCStringTwoByte(ctx, u);
         JS_FreeValue(ctx, v);
     }
     {
@@ -450,6 +457,24 @@ static void two_byte_string(void)
         // questionable but surrogates don't map to UTF-8 without WTF-8
         assert(!strcmp(s, "\xED\xA0\x80"));
         JS_FreeCString(ctx, s);
+        size_t n;
+        const uint16_t *u = JS_ToCStringTwoByteLen(ctx, &n, v);
+        assert(u);
+        assert(n == 1);
+        assert(u[0] == 0xD800);
+        JS_FreeCStringTwoByte(ctx, u);
+        JS_FreeValue(ctx, v);
+    }
+    {
+        JSValue v = JS_NewStringLen(ctx, "ok", 2); // ascii -> ucs
+        assert(!JS_IsException(v));
+        size_t n;
+        const uint16_t *u = JS_ToCStringTwoByteLen(ctx, &n, v);
+        assert(u);
+        assert(n == 2);
+        assert(u[0] == 'o');
+        assert(u[1] == 'k');
+        JS_FreeCStringTwoByte(ctx, u);
         JS_FreeValue(ctx, v);
     }
     JS_FreeContext(ctx);

--- a/quickjs.h
+++ b/quickjs.h
@@ -819,8 +819,17 @@ static inline const char *JS_ToCString(JSContext *ctx, JSValueConst val1)
 {
     return JS_ToCStringLen2(ctx, NULL, val1, 0);
 }
+JS_EXTERN const uint16_t *JS_ToCStringTwoByteLen(JSContext *ctx, size_t *plen,
+                                                 JSValueConst val1);
+static inline const uint16_t *JS_ToCStringTwoByte(JSContext *ctx,
+                                                  JSValueConst val1)
+{
+    return JS_ToCStringTwoByteLen(ctx, NULL, val1);
+}
 JS_EXTERN void JS_FreeCString(JSContext *ctx, const char *ptr);
 JS_EXTERN void JS_FreeCStringRT(JSRuntime *rt, const char *ptr);
+JS_EXTERN void JS_FreeCStringTwoByte(JSContext *ctx, const uint16_t *ptr);
+JS_EXTERN void JS_FreeCStringTwoByteRT(JSRuntime *rt, const uint16_t *ptr);
 
 JS_EXTERN JSValue JS_NewObjectProtoClass(JSContext *ctx, JSValueConst proto,
                                          JSClassID class_id);


### PR DESCRIPTION
Refs: https://github.com/quickjs-ng/quickjs/issues/992

<hr>

I'm kind of starting to hate that whole TwoByte name scheme. @chqrlie suggested `16Bits`, I'm thinking of renaming to `UCS` myself. Thoughts?