### PR TITLE
Rename TwoByte functions to UTF16

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -420,12 +420,12 @@ static void runtime_cstring_free(void)
     JS_FreeRuntime(rt);
 }
 
-static void two_byte_string(void)
+static void utf16_string(void)
 {
     JSRuntime *rt = JS_NewRuntime();
     JSContext *ctx = JS_NewContext(rt);
     {
-        JSValue v = JS_NewTwoByteString(ctx, NULL, 0);
+        JSValue v = JS_NewStringUTF16(ctx, NULL, 0);
         assert(!JS_IsException(v));
         const char *s = JS_ToCString(ctx, v);
         assert(s);
@@ -434,23 +434,23 @@ static void two_byte_string(void)
         JS_FreeValue(ctx, v);
     }
     {
-        JSValue v = JS_NewTwoByteString(ctx, (uint16_t[]){'o','k'}, 2);
+        JSValue v = JS_NewStringUTF16(ctx, (uint16_t[]){'o','k'}, 2);
         assert(!JS_IsException(v));
         const char *s = JS_ToCString(ctx, v);
         assert(s);
         assert(!strcmp(s, "ok"));
         JS_FreeCString(ctx, s);
         size_t n;
-        const uint16_t *u = JS_ToCStringTwoByteLen(ctx, &n, v);
+        const uint16_t *u = JS_ToCStringLenUTF16(ctx, &n, v);
         assert(u);
         assert(n == 2);
         assert(u[0] == 'o');
         assert(u[1] == 'k');
-        JS_FreeCStringTwoByte(ctx, u);
+        JS_FreeCStringUTF16(ctx, u);
         JS_FreeValue(ctx, v);
     }
     {
-        JSValue v = JS_NewTwoByteString(ctx, (uint16_t[]){0xD800}, 1);
+        JSValue v = JS_NewStringUTF16(ctx, (uint16_t[]){0xD800}, 1);
         assert(!JS_IsException(v));
         const char *s = JS_ToCString(ctx, v);
         assert(s);
@@ -458,23 +458,23 @@ static void two_byte_string(void)
         assert(!strcmp(s, "\xED\xA0\x80"));
         JS_FreeCString(ctx, s);
         size_t n;
-        const uint16_t *u = JS_ToCStringTwoByteLen(ctx, &n, v);
+        const uint16_t *u = JS_ToCStringLenUTF16(ctx, &n, v);
         assert(u);
         assert(n == 1);
         assert(u[0] == 0xD800);
-        JS_FreeCStringTwoByte(ctx, u);
+        JS_FreeCStringUTF16(ctx, u);
         JS_FreeValue(ctx, v);
     }
     {
         JSValue v = JS_NewStringLen(ctx, "ok", 2); // ascii -> ucs
         assert(!JS_IsException(v));
         size_t n;
-        const uint16_t *u = JS_ToCStringTwoByteLen(ctx, &n, v);
+        const uint16_t *u = JS_ToCStringLenUTF16(ctx, &n, v);
         assert(u);
         assert(n == 2);
         assert(u[0] == 'o');
         assert(u[1] == 'k');
-        JS_FreeCStringTwoByte(ctx, u);
+        JS_FreeCStringUTF16(ctx, u);
         JS_FreeValue(ctx, v);
     }
     JS_FreeContext(ctx);
@@ -868,7 +868,7 @@ int main(void)
     is_array();
     module_serde();
     runtime_cstring_free();
-    two_byte_string();
+    utf16_string();
     weak_map_gc_check();
     promise_hook();
     dump_memory_usage();

--- a/quickjs.c
+++ b/quickjs.c
@@ -4177,7 +4177,7 @@ JSValue JS_NewStringLen(JSContext *ctx, const char *buf, size_t buf_len)
     return JS_MKPTR(JS_TAG_STRING, str);
 }
 
-JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len)
+JSValue JS_NewStringUTF16(JSContext *ctx, const uint16_t *buf, size_t len)
 {
     JSString *str;
 
@@ -4354,8 +4354,8 @@ fail:
     return NULL;
 }
 
-const uint16_t *JS_ToCStringTwoByteLen(JSContext *ctx, size_t *plen,
-                                       JSValueConst val1)
+const uint16_t *JS_ToCStringLenUTF16(JSContext *ctx, size_t *plen,
+                                     JSValueConst val1)
 {
     JSString *p, *q;
     uint32_t i;
@@ -4402,12 +4402,12 @@ void JS_FreeCStringRT(JSRuntime *rt, const char *ptr)
     return js_free_cstring(rt, ptr);
 }
 
-void JS_FreeCStringTwoByte(JSContext *ctx, const uint16_t *ptr)
+void JS_FreeCStringUTF16(JSContext *ctx, const uint16_t *ptr)
 {
     return js_free_cstring(ctx->rt, ptr);
 }
 
-void JS_FreeCStringTwoByteRT(JSRuntime *rt, const uint16_t *ptr)
+void JS_FreeCStringRT_UTF16(JSRuntime *rt, const uint16_t *ptr)
 {
     return js_free_cstring(rt, ptr);
 }

--- a/quickjs.h
+++ b/quickjs.h
@@ -805,8 +805,8 @@ static inline JSValue JS_NewString(JSContext *ctx, const char *str) {
 }
 // makes a copy of the input; does not check if the input is valid UTF-16,
 // that is the responsibility of the caller
-JS_EXTERN JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf,
-                                      size_t len);
+JS_EXTERN JSValue JS_NewStringUTF16(JSContext *ctx, const uint16_t *buf,
+                                    size_t len);
 JS_EXTERN JSValue JS_NewAtomString(JSContext *ctx, const char *str);
 JS_EXTERN JSValue JS_ToString(JSContext *ctx, JSValueConst val);
 JS_EXTERN JSValue JS_ToPropertyKey(JSContext *ctx, JSValueConst val);
@@ -819,17 +819,21 @@ static inline const char *JS_ToCString(JSContext *ctx, JSValueConst val1)
 {
     return JS_ToCStringLen2(ctx, NULL, val1, 0);
 }
-JS_EXTERN const uint16_t *JS_ToCStringTwoByteLen(JSContext *ctx, size_t *plen,
-                                                 JSValueConst val1);
-static inline const uint16_t *JS_ToCStringTwoByte(JSContext *ctx,
-                                                  JSValueConst val1)
+// returns a utf-16 version of the string in native endianness; the
+// string is not nul terminated and can contain unmatched surrogates
+// |*plen| is in uint16s, not code points; a surrogate pair such as
+// U+D834 U+DF06 has len=2; an unmatched surrogate has len=1
+JS_EXTERN const uint16_t *JS_ToCStringLenUTF16(JSContext *ctx, size_t *plen,
+                                               JSValueConst val1);
+static inline const uint16_t *JS_ToCStringUTF16(JSContext *ctx,
+                                                JSValueConst val1)
 {
-    return JS_ToCStringTwoByteLen(ctx, NULL, val1);
+    return JS_ToCStringLenUTF16(ctx, NULL, val1);
 }
 JS_EXTERN void JS_FreeCString(JSContext *ctx, const char *ptr);
 JS_EXTERN void JS_FreeCStringRT(JSRuntime *rt, const char *ptr);
-JS_EXTERN void JS_FreeCStringTwoByte(JSContext *ctx, const uint16_t *ptr);
-JS_EXTERN void JS_FreeCStringTwoByteRT(JSRuntime *rt, const uint16_t *ptr);
+JS_EXTERN void JS_FreeCStringUTF16(JSContext *ctx, const uint16_t *ptr);
+JS_EXTERN void JS_FreeCStringRT_UTF16(JSRuntime *rt, const uint16_t *ptr);
 
 JS_EXTERN JSValue JS_NewObjectProtoClass(JSContext *ctx, JSValueConst proto,
                                          JSClassID class_id);


### PR DESCRIPTION
See discussion in https://github.com/quickjs-ng/quickjs/pull/1293.