### PR TITLE
Fix OOB access in TA sort

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -56185,25 +56185,29 @@ static JSValue js_typed_array_sort(JSContext *ctx, JSValueConst this_val,
             case 1:
                 for(i = 0; i < len; i++) {
                     j = array_idx[i];
-                    p->u.array.u.uint8_ptr[i] = ((uint8_t *)array_tmp)[j];
+                    if (j < len)
+                        p->u.array.u.uint8_ptr[i] = ((uint8_t *)array_tmp)[j];
                 }
                 break;
             case 2:
                 for(i = 0; i < len; i++) {
                     j = array_idx[i];
-                    p->u.array.u.uint16_ptr[i] = ((uint16_t *)array_tmp)[j];
+                    if (j < len)
+                        p->u.array.u.uint16_ptr[i] = ((uint16_t *)array_tmp)[j];
                 }
                 break;
             case 4:
                 for(i = 0; i < len; i++) {
                     j = array_idx[i];
-                    p->u.array.u.uint32_ptr[i] = ((uint32_t *)array_tmp)[j];
+                    if (j < len)
+                        p->u.array.u.uint32_ptr[i] = ((uint32_t *)array_tmp)[j];
                 }
                 break;
             case 8:
                 for(i = 0; i < len; i++) {
                     j = array_idx[i];
-                    p->u.array.u.uint64_ptr[i] = ((uint64_t *)array_tmp)[j];
+                    if (j < len)
+                        p->u.array.u.uint64_ptr[i] = ((uint64_t *)array_tmp)[j];
                 }
                 break;
             default:

--- a/tests/bug1297.js
+++ b/tests/bug1297.js
@@ -1,0 +1,22 @@
+// Test for issue #1297: Heap buffer overflow in js_typed_array_sort
+// The bug occurs when a comparator function resizes the ArrayBuffer during sort
+
+const sz = 256;
+const newSz = 10;
+const ab = new ArrayBuffer(sz, { maxByteLength: sz * 10 });
+const u8 = new Uint8Array(ab);
+
+for (let i = 0; i < sz; i++) u8[i] = i;
+u8[sz - 1] = 0;
+
+let cnt = 0;
+u8.sort((a, b) => {
+    for (let i = 0; i < 3000; i++) {
+      try { ab.resize(newSz); } catch(e){}
+    }
+
+    return a - b;
+});
+
+// If we get here without crashing, the fix works
+print("PASS: bug1297 - typed array sort with resize did not crash");


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/1297

Disclaimer: I tested the use of AI to fix the bug in this codebase. Upon inspection the fix LGTM.
