### PR TITLE
Fix heap buffer overflow via side-effects in js_typed_array_constructor

### DIFF
--- a/tests/bug1296.js
+++ b/tests/bug1296.js
@@ -1,0 +1,12 @@
+const ab = new ArrayBuffer(10, { maxByteLength: 10 });
+function f() {
+    return 1337;
+}
+const evil = f.bind();
+
+Object.defineProperty(evil, "prototype", { get: () => {
+    print("resizing");
+    return ab.resize();
+} });
+let u8 = Reflect.construct(Uint8Array, [ab], evil);
+print(u8);


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/1296
