### PR TITLE
Fix heap buffer overflow in js_typed_array_constructor_ta

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -56436,6 +56436,10 @@ static JSValue js_typed_array_constructor_ta(JSContext *ctx,
         JS_ThrowTypeErrorArrayBufferOOB(ctx);
         goto fail;
     }
+    if (len > p->u.array.count) {
+        JS_ThrowRangeError(ctx, "length out of bounds");
+        goto fail;
+    }
     ta = p->u.typed_array;
     src_buffer = ta->buffer;
     src_abuf = src_buffer->u.array_buffer;

--- a/tests/bug1305.js
+++ b/tests/bug1305.js
@@ -1,0 +1,26 @@
+import {assert} from "./assert.js"
+
+const rab = new ArrayBuffer(10, { maxByteLength: 10 });
+const src = new Uint8Array(rab, 0);
+
+function f() {
+    return 1337;
+}
+
+const EvilConstructor = new Proxy(function(){}, {
+    get: function(target, prop, receiver) {
+        if (prop === 'prototype') {
+            print("resizing");
+            rab.resize(0);
+            return Uint8Array.prototype;
+        }
+        return Reflect.get(target, prop, receiver);
+    }
+});
+
+try {
+  let u8 = Reflect.construct(Uint8Array, [src], EvilConstructor);
+  print(u8);
+} catch (e) {
+  assert(e instanceof RangeError);
+}


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/1305
