### PR TITLE
Added libonly option to meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -232,7 +232,7 @@ if qjs_libc
     include_directories: include_directories('.'),
     dependencies: qjs_dep,
   )
-else
+elif not lib_only
   qjs_libc_lib = static_library(
     'quickjs-libc',
     qjs_libc_srcs,

--- a/meson.build
+++ b/meson.build
@@ -130,8 +130,10 @@ qjs_sys_deps = []
 
 m_dep = cc.find_library('m', required: false)
 qjs_sys_deps += m_dep
-qjs_sys_deps += dependency('threads', required: false)
-qjs_sys_deps += dependency('dl', required: false)
+if host_system != 'dos'
+  qjs_sys_deps += dependency('threads', required: false)
+  qjs_sys_deps += dependency('dl', required: false)
+endif
 
 qjs_srcs = files(
   'dtoa.c',
@@ -143,6 +145,7 @@ qjs_hdrs = files(
   'quickjs.h',
 )
 
+lib_only = get_option('libonly')
 qjs_libc = get_option('libc')
 qjs_libc_srcs = files('quickjs-libc.c')
 qjs_libc_hdrs = files('quickjs-libc.h')
@@ -314,15 +317,20 @@ endif
 qjsc_srcs = files(
   'qjsc.c',
 )
-qjsc_exe = executable(
-  'qjsc',
-  qjsc_srcs,
 
-  c_args: qjs_c_args,
-  link_with: [cutils_lib],
-  dependencies: [qjs_dep, qjs_libc_dep],
-  install: true,
-)
+if lib_only
+  qjsc_exe = '/bin/true'
+else
+  qjsc_exe = executable(
+    'qjsc',
+    qjsc_srcs,
+
+    c_args: qjs_c_args,
+    link_with: [cutils_lib],
+    dependencies: [qjs_dep, qjs_libc_dep],
+    install: true,
+  )
+endif
 
 mimalloc_dep = []
 mimalloc_sys_dep = dependency('mimalloc', required: get_option('cli_mimalloc'))
@@ -339,17 +347,22 @@ qjs_exe_srcs = files(
   'gen/standalone.c',
   'qjs.c',
 )
-qjs_exe = executable(
-  'qjs',
-  qjs_exe_srcs,
 
-  c_args: qjs_c_args,
-  link_with: [cutils_lib],
-  dependencies: [qjs_dep, qjs_libc_dep, mimalloc_dep],
-  export_dynamic: true,
+if lib_only
+  qjs_exe = '/bin/true'
+else
+  qjs_exe = executable(
+    'qjs',
+    qjs_exe_srcs,
 
-  install: true,
-)
+    c_args: qjs_c_args,
+    link_with: [cutils_lib],
+    dependencies: [qjs_dep, qjs_libc_dep, mimalloc_dep],
+    export_dynamic: true,
+
+    install: true,
+  )
+endif
 
 if meson.is_cross_build()
   mimalloc_native_dep = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('libc', type: 'boolean', value: false, description: 'build qjs standard l
 option('cli_mimalloc', type: 'feature', value: 'disabled', description: 'build qjs cli with mimalloc')
 option('docdir', type: 'string', description: 'documentation directory')
 option('parser', type: 'boolean', value: true, description: 'Enable JS source code parser')
+option('libonly', type: 'boolean', value: false, description: 'Build qjs library only')


### PR DESCRIPTION
I wanted only library for djgpp.
Compiler installed from rpm packages.

Here is the build script:

// mes.sh
rm -rf /tmp/builddir_qjs

PREFIX=/opt/qjs
DESTDIR=$HOME/qjs

LIBRARY_PATH="$PREFIX/lib" \
PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" \
C_INCLUDE_PATH="$PREFIX/include" \
CFLAGS="-O2 -I$PREFIX/include" \
CXXFLAGS="-O2 -I$PREFIX/include" \
LDFLAGS="-L$PREFIX/lib" \
meson setup /tmp/builddir_qjs --cross-file cross/linux-djgpp.ini \ -Dprefix=$PREFIX \
-Dexamples=disabled \
-Dlibc=false \
-Dtests=disabled \
-Dlibonly=true || exit 1

meson compile -C /tmp/builddir_qjs || exit 2

mkdir -p $DESTDIR
meson install -C /tmp/builddir_qjs --destdir $DESTDIR || exit 3

// linux-djgpp.ini
[binaries]
c = ['/usr/bin/i586-pc-msdosdjgpp-gcc', '-Wno-incompatible-pointer-types']
cpp = '/usr/bin/i586-pc-msdosdjgpp-g++'
objc = '/usr/bin/i586-pc-msdosdjgpp-gcc'
ar = '/usr/bin/i586-pc-msdosdjgpp-ar'
pkg-config = '/usr/bin/pkg-config'
strip = '/usr/bin/i586-pc-msdosdjgpp-strip'
exe_wrapper = '/bin/true'
ld = '/usr/bin/i586-pc-msdosdjgpp-ld'
cmake = '/usr/bin/cmake'

[properties]
root = '/usr/i586-pc-msdosdjgpp'
need_exe_wrapper = false

[host_machine]
system = 'dos'
cpu_family = 'x86'
cpu = 'i586'
endian = 'little'

[cmake]

CMAKE_BUILD_WITH_INSTALL_RPATH     = 'ON'
CMAKE_FIND_ROOT_PATH_MODE_PROGRAM  = 'NEVER'
CMAKE_FIND_ROOT_PATH_MODE_LIBRARY  = 'ONLY'
CMAKE_FIND_ROOT_PATH_MODE_INCLUDE  = 'ONLY'
CMAKE_FIND_ROOT_PATH_MODE_PACKAGE  = 'ONLY'