### PR TITLE
Change the naming of a type error to be more specific, of either set/add

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -49506,7 +49506,7 @@ static JSValue js_map_constructor(JSContext *ctx, JSValueConst new_target,
         if (JS_IsException(adder))
             goto fail;
         if (!JS_IsFunction(ctx, adder)) {
-            JS_ThrowTypeError(ctx, "set/add is not a function");
+            JS_ThrowTypeError(ctx, "%s is not a function", is_set ? "set" : "add");
             goto fail;
         }
 


### PR DESCRIPTION
While using quickJS, I got the error message, `"set/add is not a function"` so I wanted to see if I could make it so that the error message was more descriptive, whether it was set or add erroring so that lead me to opening this small PR. Now instead it either prints `"set is not a function"` or `"add is not a function"`