### PR TITLE
Fix C23 -Wdiscarded-qualifiers compiler warning

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -29083,9 +29083,9 @@ static char *js_default_module_normalize_name(JSContext *ctx,
         return js_strdup(ctx, name);
     }
 
-    p = strrchr(base_name, '/');
-    if (p)
-        len = p - base_name;
+    r = strrchr(base_name, '/');
+    if (r)
+        len = r - base_name;
     else
         len = 0;
 


### PR DESCRIPTION
The return type of strrchr depends on the type of the first argument in C23. Not that quickjs-ng is a C23 project at this time but it's easy to fix.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1333