### PR TITLE
Don't set -Werror by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: build
         run: |
-          cmake -B build -DQJS_BUILD_EXAMPLES=ON -G "Visual Studio 17 2022" -A ${{matrix.config.arch}}
+          cmake -B build -DQJS_BUILD_WERROR=ON -DQJS_BUILD_EXAMPLES=ON -G "Visual Studio 17 2022" -A ${{matrix.config.arch}}
           cmake --build build --config ${{matrix.config.buildType}}
       - name: stats
         run: |
@@ -225,7 +225,7 @@ jobs:
       - name: build
         run: |
           git submodule update --init --checkout --depth 1
-          cmake -B build -DQJS_BUILD_EXAMPLES=ON -G "Visual Studio 17 2022" -T ClangCL
+          cmake -B build -DQJS_BUILD_WERROR=ON -DQJS_BUILD_EXAMPLES=ON -G "Visual Studio 17 2022" -T ClangCL
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
         run: |
@@ -261,7 +261,7 @@ jobs:
       - name: build
         run: |
           git submodule update --init --checkout --depth 1
-          cmake -B build -DQJS_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -G "Ninja"
+          cmake -B build -DQJS_BUILD_WERROR=ON -DQJS_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -G "Ninja"
           cmake --build build
       - name: stats
         run: |
@@ -294,7 +294,7 @@ jobs:
           features: 'OptionId.DesktopCPPx86,OptionId.DesktopCPPx64'
       - name: build
         run: |
-          cmake -B build -DQJS_BUILD_EXAMPLES=ON -DCMAKE_SYSTEM_VERSION="10.0.26100.0" -A ${{matrix.arch}}
+          cmake -B build -DQJS_BUILD_WERROR=ON -DQJS_BUILD_EXAMPLES=ON -DCMAKE_SYSTEM_VERSION="10.0.26100.0" -A ${{matrix.arch}}
           cmake --build build --config ${{matrix.buildType}}
       - name: stats
         run: |
@@ -398,7 +398,7 @@ jobs:
         run: emcc -v
       - name: build
         run: |
-          emcmake cmake -B build -DQJS_BUILD_LIBC=ON
+          emcmake cmake -B build -DQJS_BUILD_WERROR=ON -DQJS_BUILD_LIBC=ON
           emmake make -C build qjs_wasm "-j$(getconf _NPROCESSORS_ONLN)"
       - name: result
         run: ls -lh build
@@ -413,14 +413,14 @@ jobs:
           sudo apt install /tmp/wasi-sdk*.deb
       - name: test
         run: |
-          cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake
+          cmake -B build -DQJS_BUILD_WERROR=ON -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake
           make -C build qjs_exe
           wasmtime run build/qjs -qd
           echo "console.log('hello wasi!');" > t.js
           wasmtime run --dir . build/qjs t.js
       - name: build wasi reactor
         run: |
-          cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_WASI_REACTOR=ON
+          cmake -B build -DQJS_BUILD_WERROR=ON -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_WASI_REACTOR=ON
           make -C build qjs_wasi
           ls -lh build/qjs.wasm
 
@@ -507,7 +507,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: configure
         run: |
-          cmake -B build -GXcode -DCMAKE_SYSTEM_NAME:STRING=iOS -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED:BOOL=NO -DQJS_BUILD_LIBC=ON
+          cmake -B build -GXcode -DQJS_BUILD_WERROR=ON -DCMAKE_SYSTEM_NAME:STRING=iOS -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED:BOOL=NO -DQJS_BUILD_LIBC=ON
       - name: build
         run: |
           cmake --build build --config Release --target qjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DQJS_BUILD_CLI_STATIC=ON ..
+          cmake -DQJS_BUILD_WERROR=ON -DQJS_BUILD_CLI_STATIC=ON ..
           cd ..
           cmake --build build --target qjs_exe -j$(getconf _NPROCESSORS_ONLN)
           cmake --build build --target qjsc -j$(getconf _NPROCESSORS_ONLN)
@@ -61,7 +61,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" ..
+          cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DQJS_BUILD_WERROR=ON ..
           make -j$(getconf _NPROCESSORS_ONLN)
           make -C .. amalgam # writes build/quickjs-amalgam.zip
           mv qjs qjs-darwin
@@ -128,12 +128,12 @@ jobs:
           sudo apt install /tmp/wasi-sdk*.deb
       - name: build
         run: |
-          cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake
+          cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_BUILD_WERROR=ON
           make -C build qjs_exe
           mv build/qjs build/qjs-wasi.wasm
       - name: build wasi reactor
         run: |
-          cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_WASI_REACTOR=ON
+          cmake -B build -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_BUILD_WERROR=ON -DQJS_WASI_REACTOR=ON
           make -C build qjs_wasi
           mv build/qjs.wasm build/qjs-wasi-reactor.wasm
       - name: upload

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
       - name: build
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DQJS_ENABLE_TSAN=ON
+          cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DQJS_BUILD_WERROR=ON -DQJS_ENABLE_TSAN=ON
           cmake --build build -j`nproc`
       - name: test
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,34 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 set(CMAKE_C_STANDARD 11)
 
+macro(xoption OPTION_NAME OPTION_TEXT OPTION_DEFAULT)
+    option(${OPTION_NAME} ${OPTION_TEXT} ${OPTION_DEFAULT})
+    if(DEFINED ENV{${OPTION_NAME}})
+        # Allow setting the option through an environment variable.
+        set(${OPTION_NAME} $ENV{${OPTION_NAME}})
+    endif()
+    if(${OPTION_NAME})
+        add_definitions(-D${OPTION_NAME})
+    endif()
+    message(STATUS "  ${OPTION_NAME}: ${${OPTION_NAME}}")
+endmacro()
+
+# note: QJS_ENABLE_TSAN is currently incompatible with the other sanitizers but we
+# don't explicitly check for that because who knows what the future will bring?
+# QJS_ENABLE_MSAN only works with clang at the time of writing; also not checked
+# for the same reason
+xoption(BUILD_SHARED_LIBS "Build a shared library" OFF)
+xoption(QJS_BUILD_WERROR "Build with -Werror" OFF)
+xoption(QJS_BUILD_EXAMPLES "Build examples" OFF)
+xoption(QJS_BUILD_CLI_STATIC "Build a static qjs executable" OFF)
+xoption(QJS_BUILD_CLI_WITH_MIMALLOC "Build the qjs executable with mimalloc" OFF)
+xoption(QJS_BUILD_CLI_WITH_STATIC_MIMALLOC "Build the qjs executable with mimalloc (statically linked)" OFF)
+xoption(QJS_DISABLE_PARSER "Disable JS source code parser" OFF)
+xoption(QJS_ENABLE_ASAN "Enable AddressSanitizer (ASan)" OFF)
+xoption(QJS_ENABLE_MSAN "Enable MemorySanitizer (MSan)" OFF)
+xoption(QJS_ENABLE_TSAN "Enable ThreadSanitizer (TSan)" OFF)
+xoption(QJS_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" OFF)
+
 # Used to properly define JS_LIBC_EXTERN.
 add_compile_definitions(QUICKJS_NG_BUILD)
 
@@ -59,7 +87,9 @@ endmacro()
 
 xcheck_add_c_compiler_flag(-Wall)
 if(NOT MSVC AND NOT IOS AND NOT TVOS AND NOT WATCHOS)
-    xcheck_add_c_compiler_flag(-Werror)
+    if(QJS_BUILD_WERROR)
+        xcheck_add_c_compiler_flag(-Werror)
+    endif()
     xcheck_add_c_compiler_flag(-Wextra)
 endif()
 xcheck_add_c_compiler_flag(-Wformat=2)
@@ -141,36 +171,9 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
     xcheck_add_c_compiler_flag(-fno-omit-frame-pointer)
 endif()
 
-macro(xoption OPTION_NAME OPTION_TEXT OPTION_DEFAULT)
-    option(${OPTION_NAME} ${OPTION_TEXT} ${OPTION_DEFAULT})
-    if(DEFINED ENV{${OPTION_NAME}})
-        # Allow setting the option through an environment variable.
-        set(${OPTION_NAME} $ENV{${OPTION_NAME}})
-    endif()
-    if(${OPTION_NAME})
-        add_definitions(-D${OPTION_NAME})
-    endif()
-    message(STATUS "  ${OPTION_NAME}: ${${OPTION_NAME}}")
-endmacro()
-
-xoption(BUILD_SHARED_LIBS "Build a shared library" OFF)
 if(BUILD_SHARED_LIBS)
     message(STATUS "Building a shared library")
 endif()
-
-# note: QJS_ENABLE_TSAN is currently incompatible with the other sanitizers but we
-# don't explicitly check for that because who knows what the future will bring?
-# QJS_ENABLE_MSAN only works with clang at the time of writing; also not checked
-# for the same reason
-xoption(QJS_BUILD_EXAMPLES "Build examples" OFF)
-xoption(QJS_BUILD_CLI_STATIC "Build a static qjs executable" OFF)
-xoption(QJS_BUILD_CLI_WITH_MIMALLOC "Build the qjs executable with mimalloc" OFF)
-xoption(QJS_BUILD_CLI_WITH_STATIC_MIMALLOC "Build the qjs executable with mimalloc (statically linked)" OFF)
-xoption(QJS_DISABLE_PARSER "Disable JS source code parser" OFF)
-xoption(QJS_ENABLE_ASAN "Enable AddressSanitizer (ASan)" OFF)
-xoption(QJS_ENABLE_MSAN "Enable MemorySanitizer (MSan)" OFF)
-xoption(QJS_ENABLE_TSAN "Enable ThreadSanitizer (TSan)" OFF)
-xoption(QJS_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" OFF)
 
 if(QJS_ENABLE_ASAN)
 message(STATUS "Building with ASan")


### PR DESCRIPTION
It's annoying for downstream users when they don't use the exact same compiler as we do because any random new (or old) compiler warning breaks the build.

Only set the flag on CI or when explicitly requested with the new QJS_BUILD_WERROR cmake option.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1339