### PR TITLE
cmake: bundle cutils into libqjs.a via OBJECT library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,18 +285,17 @@ if(M_LIBRARIES OR CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
     list(APPEND qjs_libs m)
 endif()
 
-add_library(cutils STATIC cutils.c)
+# OBJECT library so cutils is bundled into libqjs.a (self-contained for embedding)
+add_library(cutils OBJECT cutils.c)
 target_compile_definitions(cutils PRIVATE ${qjs_defines})
-target_link_libraries(cutils PRIVATE ${qjs_libs})
 
-add_library(qjs ${qjs_sources})
+add_library(qjs ${qjs_sources} $<TARGET_OBJECTS:cutils>)
 target_compile_definitions(qjs PRIVATE ${qjs_defines})
 target_include_directories(qjs PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(qjs PUBLIC ${qjs_libs})
-target_link_libraries(qjs PRIVATE $<BUILD_INTERFACE:cutils>)
 
 # Pass a compiler definition so that Windows gets its declspec's right.
 get_target_property(QJS_LIB_TYPE qjs TYPE)
@@ -327,7 +326,7 @@ endif()
 if(NOT QJS_BUILD_LIBC)
     add_library(qjs-libc STATIC quickjs-libc.c)
     target_compile_definitions(qjs-libc PRIVATE ${qjs_defines})
-    target_link_libraries(qjs-libc PRIVATE ${qjs_libs} qjs cutils)
+    target_link_libraries(qjs-libc PRIVATE ${qjs_libs} qjs)
 endif()
 
 if(EMSCRIPTEN)
@@ -358,7 +357,7 @@ add_executable(qjsc
 add_qjs_libc_if_needed(qjsc)
 add_static_if_needed(qjsc)
 target_compile_definitions(qjsc PRIVATE ${qjs_defines})
-target_link_libraries(qjsc PRIVATE qjs cutils)
+target_link_libraries(qjsc PRIVATE qjs)
 
 
 # QuickJS CLI
@@ -375,7 +374,7 @@ set_target_properties(qjs_exe PROPERTIES
     OUTPUT_NAME "qjs"
 )
 target_compile_definitions(qjs_exe PRIVATE ${qjs_defines})
-target_link_libraries(qjs_exe PRIVATE qjs cutils)
+target_link_libraries(qjs_exe PRIVATE qjs)
 if (NOT WIN32)
     set_target_properties(qjs_exe PROPERTIES ENABLE_EXPORTS TRUE)
 endif()
@@ -428,7 +427,7 @@ if(NOT EMSCRIPTEN)
     )
     add_qjs_libc_if_needed(run-test262)
     target_compile_definitions(run-test262 PRIVATE ${qjs_defines})
-    target_link_libraries(run-test262 PRIVATE qjs cutils)
+    target_link_libraries(run-test262 PRIVATE qjs)
 endif()
 
 # Interrupt test
@@ -438,7 +437,7 @@ add_executable(api-test
     api-test.c
 )
 target_compile_definitions(api-test PRIVATE ${qjs_defines})
-target_link_libraries(api-test PRIVATE qjs cutils)
+target_link_libraries(api-test PRIVATE qjs)
 
 # Unicode generator
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ if(WIN32)
 endif()
 
 if(NOT QJS_BUILD_LIBC)
-    add_library(qjs-libc STATIC quickjs-libc.c)
+    add_library(qjs-libc STATIC quickjs-libc.c $<TARGET_OBJECTS:cutils>)
     target_compile_definitions(qjs-libc PRIVATE ${qjs_defines})
     target_link_libraries(qjs-libc PRIVATE ${qjs_libs} qjs)
 endif()
@@ -353,6 +353,7 @@ endif()
 
 add_executable(qjsc
     qjsc.c
+    $<TARGET_OBJECTS:cutils>
 )
 add_qjs_libc_if_needed(qjsc)
 add_static_if_needed(qjsc)
@@ -445,9 +446,9 @@ target_link_libraries(api-test PRIVATE qjs)
 add_executable(unicode_gen EXCLUDE_FROM_ALL
     libunicode.c
     unicode_gen.c
+    $<TARGET_OBJECTS:cutils>
 )
 target_compile_definitions(unicode_gen PRIVATE ${qjs_defines})
-target_link_libraries(unicode_gen PRIVATE cutils)
 
 add_executable(function_source
     gen/function_source.c


### PR DESCRIPTION
## Summary

Use OBJECT library for cutils so its symbols are included in libqjs.a, making the installed static library self-contained for embedding.

Previously, cutils was built as a separate STATIC library and linked privately to qjs. This meant libqjs.a didn't contain cutils symbols, causing undefined reference errors when embedding via `find_package()`:

```
undefined reference to `utf8_decode'
undefined reference to `__dbuf_putc'
undefined reference to `__dbuf_put_u16'
undefined reference to `js_mutex_init'
```

## The fix

1. Change cutils from `STATIC` to `OBJECT` library
2. Include cutils objects directly in libqjs via `$<TARGET_OBJECTS:cutils>`
3. Remove redundant cutils links from targets that already link qjs (since qjs now contains cutils)

This is an alternative to PR #1344 which inlines all of cutils. This approach:
- Is a smaller change (8 lines changed vs 3800+ lines)
- Keeps the cutils.c/cutils.h separation
- Uses standard CMake OBJECT library pattern

Fixes #1343

## Test plan

- [x] `cmake .. && make` builds successfully
- [x] `ar -t libqjs.a` shows `cutils.c.o` included
- [x] `qjs -e 'console.log("test")'` works
- [x] `qjsc --help` works