### PR TITLE
Bundle cutils and namespace all its exported symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,18 +285,17 @@ if(M_LIBRARIES OR CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
     list(APPEND qjs_libs m)
 endif()
 
-add_library(cutils STATIC cutils.c)
+# OBJECT library so cutils is bundled into libqjs.a (self-contained for embedding)
+add_library(cutils OBJECT cutils.c)
 target_compile_definitions(cutils PRIVATE ${qjs_defines})
-target_link_libraries(cutils PRIVATE ${qjs_libs})
 
-add_library(qjs ${qjs_sources})
+add_library(qjs ${qjs_sources} $<TARGET_OBJECTS:cutils>)
 target_compile_definitions(qjs PRIVATE ${qjs_defines})
 target_include_directories(qjs PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(qjs PUBLIC ${qjs_libs})
-target_link_libraries(qjs PRIVATE $<BUILD_INTERFACE:cutils>)
 
 # Pass a compiler definition so that Windows gets its declspec's right.
 get_target_property(QJS_LIB_TYPE qjs TYPE)
@@ -327,7 +326,7 @@ endif()
 if(NOT QJS_BUILD_LIBC)
     add_library(qjs-libc STATIC quickjs-libc.c)
     target_compile_definitions(qjs-libc PRIVATE ${qjs_defines})
-    target_link_libraries(qjs-libc PRIVATE ${qjs_libs} qjs cutils)
+    target_link_libraries(qjs-libc PRIVATE ${qjs_libs} qjs)
 endif()
 
 if(EMSCRIPTEN)
@@ -358,7 +357,7 @@ add_executable(qjsc
 add_qjs_libc_if_needed(qjsc)
 add_static_if_needed(qjsc)
 target_compile_definitions(qjsc PRIVATE ${qjs_defines})
-target_link_libraries(qjsc PRIVATE qjs cutils)
+target_link_libraries(qjsc PRIVATE qjs)
 
 
 # QuickJS CLI
@@ -375,7 +374,7 @@ set_target_properties(qjs_exe PROPERTIES
     OUTPUT_NAME "qjs"
 )
 target_compile_definitions(qjs_exe PRIVATE ${qjs_defines})
-target_link_libraries(qjs_exe PRIVATE qjs cutils)
+target_link_libraries(qjs_exe PRIVATE qjs)
 if (NOT WIN32)
     set_target_properties(qjs_exe PROPERTIES ENABLE_EXPORTS TRUE)
 endif()
@@ -428,7 +427,7 @@ if(NOT EMSCRIPTEN)
     )
     add_qjs_libc_if_needed(run-test262)
     target_compile_definitions(run-test262 PRIVATE ${qjs_defines})
-    target_link_libraries(run-test262 PRIVATE qjs cutils)
+    target_link_libraries(run-test262 PRIVATE qjs)
 endif()
 
 # Interrupt test
@@ -438,7 +437,7 @@ add_executable(api-test
     api-test.c
 )
 target_compile_definitions(api-test PRIVATE ${qjs_defines})
-target_link_libraries(api-test PRIVATE qjs cutils)
+target_link_libraries(api-test PRIVATE qjs)
 
 # Unicode generator
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ if(WIN32)
 endif()
 
 if(NOT QJS_BUILD_LIBC)
-    add_library(qjs-libc STATIC quickjs-libc.c)
+    add_library(qjs-libc STATIC quickjs-libc.c $<TARGET_OBJECTS:cutils>)
     target_compile_definitions(qjs-libc PRIVATE ${qjs_defines})
     target_link_libraries(qjs-libc PRIVATE ${qjs_libs} qjs)
 endif()
@@ -353,6 +353,7 @@ endif()
 
 add_executable(qjsc
     qjsc.c
+    $<TARGET_OBJECTS:cutils>
 )
 add_qjs_libc_if_needed(qjsc)
 add_static_if_needed(qjsc)
@@ -445,9 +446,9 @@ target_link_libraries(api-test PRIVATE qjs)
 add_executable(unicode_gen EXCLUDE_FROM_ALL
     libunicode.c
     unicode_gen.c
+    $<TARGET_OBJECTS:cutils>
 )
 target_compile_definitions(unicode_gen PRIVATE ${qjs_defines})
-target_link_libraries(unicode_gen PRIVATE cutils)
 
 add_executable(function_source
     gen/function_source.c

--- a/cutils.c
+++ b/cutils.c
@@ -109,7 +109,7 @@ static void *dbuf_default_realloc(void *opaque, void *ptr, size_t size)
     return realloc(ptr, size);
 }
 
-void dbuf_init2(DynBuf *s, void *opaque, DynBufReallocFunc *realloc_func)
+void js__dbuf_init2(DynBuf *s, void *opaque, DynBufReallocFunc *realloc_func)
 {
     memset(s, 0, sizeof(*s));
     if (!realloc_func)
@@ -118,13 +118,13 @@ void dbuf_init2(DynBuf *s, void *opaque, DynBufReallocFunc *realloc_func)
     s->realloc_func = realloc_func;
 }
 
-void dbuf_init(DynBuf *s)
+void js__dbuf_init(DynBuf *s)
 {
-    dbuf_init2(s, NULL, NULL);
+    js__dbuf_init2(s, NULL, NULL);
 }
 
 /* Try to allocate 'len' more bytes. return < 0 if error */
-int dbuf_claim(DynBuf *s, size_t len)
+int js__dbuf_claim(DynBuf *s, size_t len)
 {
     size_t new_size, size, new_allocated_size;
     uint8_t *new_buf;
@@ -150,10 +150,10 @@ int dbuf_claim(DynBuf *s, size_t len)
     return 0;
 }
 
-int dbuf_put(DynBuf *s, const void *data, size_t len)
+int js__dbuf_put(DynBuf *s, const void *data, size_t len)
 {
     if (unlikely((s->size + len) > s->allocated_size)) {
-        if (dbuf_claim(s, len))
+        if (js__dbuf_claim(s, len))
             return -1;
     }
     if (len > 0) {
@@ -163,10 +163,10 @@ int dbuf_put(DynBuf *s, const void *data, size_t len)
     return 0;
 }
 
-int dbuf_put_self(DynBuf *s, size_t offset, size_t len)
+int js__dbuf_put_self(DynBuf *s, size_t offset, size_t len)
 {
     if (unlikely((s->size + len) > s->allocated_size)) {
-        if (dbuf_claim(s, len))
+        if (js__dbuf_claim(s, len))
             return -1;
     }
     if (len > 0) {
@@ -176,32 +176,32 @@ int dbuf_put_self(DynBuf *s, size_t offset, size_t len)
     return 0;
 }
 
-int __dbuf_putc(DynBuf *s, uint8_t c)
+int js__dbuf_putc(DynBuf *s, uint8_t c)
 {
-    return dbuf_put(s, &c, 1);
+    return js__dbuf_put(s, &c, 1);
 }
 
-int __dbuf_put_u16(DynBuf *s, uint16_t val)
+int js__dbuf_put_u16(DynBuf *s, uint16_t val)
 {
-    return dbuf_put(s, (uint8_t *)&val, 2);
+    return js__dbuf_put(s, (uint8_t *)&val, 2);
 }
 
-int __dbuf_put_u32(DynBuf *s, uint32_t val)
+int js__dbuf_put_u32(DynBuf *s, uint32_t val)
 {
-    return dbuf_put(s, (uint8_t *)&val, 4);
+    return js__dbuf_put(s, (uint8_t *)&val, 4);
 }
 
-int __dbuf_put_u64(DynBuf *s, uint64_t val)
+int js__dbuf_put_u64(DynBuf *s, uint64_t val)
 {
-    return dbuf_put(s, (uint8_t *)&val, 8);
+    return js__dbuf_put(s, (uint8_t *)&val, 8);
 }
 
-int dbuf_putstr(DynBuf *s, const char *str)
+int js__dbuf_putstr(DynBuf *s, const char *str)
 {
-    return dbuf_put(s, (const uint8_t *)str, strlen(str));
+    return js__dbuf_put(s, (const uint8_t *)str, strlen(str));
 }
 
-int JS_PRINTF_FORMAT_ATTR(2, 3) dbuf_printf(DynBuf *s, JS_PRINTF_FORMAT const char *fmt, ...)
+int JS_PRINTF_FORMAT_ATTR(2, 3) js__dbuf_printf(DynBuf *s, JS_PRINTF_FORMAT const char *fmt, ...)
 {
     va_list ap;
     char buf[128];
@@ -212,9 +212,9 @@ int JS_PRINTF_FORMAT_ATTR(2, 3) dbuf_printf(DynBuf *s, JS_PRINTF_FORMAT const ch
     va_end(ap);
     if (len < (int)sizeof(buf)) {
         /* fast case */
-        return dbuf_put(s, (uint8_t *)buf, len);
+        return js__dbuf_put(s, (uint8_t *)buf, len);
     } else {
-        if (dbuf_claim(s, len + 1))
+        if (js__dbuf_claim(s, len + 1))
             return -1;
         va_start(ap, fmt);
         vsnprintf((char *)(s->buf + s->size), s->allocated_size - s->size,
@@ -225,7 +225,7 @@ int JS_PRINTF_FORMAT_ATTR(2, 3) dbuf_printf(DynBuf *s, JS_PRINTF_FORMAT const ch
     return 0;
 }
 
-void dbuf_free(DynBuf *s)
+void js__dbuf_free(DynBuf *s)
 {
     /* we test s->buf as a fail safe to avoid crashing if dbuf_free()
        is called twice */
@@ -245,7 +245,7 @@ void dbuf_free(DynBuf *s)
    Returns the number of bytes. If a codepoint is beyond 0x10FFFF the
    return value is 3 as the codepoint would be encoded as 0xFFFD.
  */
-size_t utf8_encode_len(uint32_t c)
+size_t js__utf8_encode_len(uint32_t c)
 {
     if (c < 0x80)
         return 1;
@@ -266,7 +266,7 @@ size_t utf8_encode_len(uint32_t c)
    No null byte is stored after the encoded bytes.
    Return value is in range 1..4
  */
-size_t utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c)
+size_t js__utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c)
 {
     if (c < 0x80) {
         buf[0] = c;
@@ -310,7 +310,7 @@ size_t utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c)
    If `p[0]` is '\0', the return value is `0` and the byte is consumed.
    cf: https://encoding.spec.whatwg.org/#utf-8-encoder
  */
-uint32_t utf8_decode(const uint8_t *p, const uint8_t **pp)
+uint32_t js__utf8_decode(const uint8_t *p, const uint8_t **pp)
 {
     uint32_t c;
     uint8_t lower, upper;
@@ -378,7 +378,7 @@ uint32_t utf8_decode(const uint8_t *p, const uint8_t **pp)
     return 0xFFFD;
 }
 
-uint32_t utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp) {
+uint32_t js__utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp) {
     switch (max_len) {
     case 0:
         *pp = p;
@@ -397,7 +397,7 @@ uint32_t utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp) {
         break;
     default:
     good:
-        return utf8_decode(p, pp);
+        return js__utf8_decode(p, pp);
     }
     *pp = p + 1;
     return 0xFFFD;
@@ -414,7 +414,7 @@ uint32_t utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp) {
    - `UTF8_HAS_NON_BMP1`: bit for non-BMP1 code points, needs UTF-16 surrogate pairs
    - `UTF8_HAS_ERRORS`: bit for encoding errors
  */
-int utf8_scan(const char *buf, size_t buf_len, size_t *plen)
+int js__utf8_scan(const char *buf, size_t buf_len, size_t *plen)
 {
     const uint8_t *p, *p_end, *p_next;
     size_t i, len;
@@ -436,7 +436,7 @@ int utf8_scan(const char *buf, size_t buf_len, size_t *plen)
             len++;
             if (*p++ >= 0x80) {
                 /* parse UTF-8 sequence, check for encoding error */
-                uint32_t c = utf8_decode_len(p - 1, p_end - (p - 1), &p_next);
+                uint32_t c = js__utf8_decode_len(p - 1, p_end - (p - 1), &p_next);
                 if (p_next == p)
                     kind |= UTF8_HAS_ERRORS;
                 p = p_next;
@@ -462,7 +462,7 @@ int utf8_scan(const char *buf, size_t buf_len, size_t *plen)
    `dest_len` is the length of the destination array. A null
    terminator is stored at the end of the array unless `dest_len` is `0`.
  */
-size_t utf8_decode_buf8(uint8_t *dest, size_t dest_len, const char *src, size_t src_len)
+size_t js__utf8_decode_buf8(uint8_t *dest, size_t dest_len, const char *src, size_t src_len)
 {
     const uint8_t *p, *p_end;
     size_t i;
@@ -490,7 +490,7 @@ size_t utf8_decode_buf8(uint8_t *dest, size_t dest_len, const char *src, size_t 
    `dest_len` is the length of the destination array. No null terminator is
    stored at the end of the array.
  */
-size_t utf8_decode_buf16(uint16_t *dest, size_t dest_len, const char *src, size_t src_len)
+size_t js__utf8_decode_buf16(uint16_t *dest, size_t dest_len, const char *src, size_t src_len)
 {
     const uint8_t *p, *p_end;
     size_t i;
@@ -501,7 +501,7 @@ size_t utf8_decode_buf16(uint16_t *dest, size_t dest_len, const char *src, size_
         uint32_t c = *p++;
         if (c >= 0x80) {
             /* parse utf-8 sequence */
-            c = utf8_decode_len(p - 1, p_end - (p - 1), &p);
+            c = js__utf8_decode_len(p - 1, p_end - (p - 1), &p);
             /* encoding errors are converted as 0xFFFD and use a single byte */
             if (c > 0xFFFF) {
                 if (i < dest_len)
@@ -523,7 +523,7 @@ size_t utf8_decode_buf16(uint16_t *dest, size_t dest_len, const char *src, size_
    `dest_len` is the length in bytes of the destination array. A null
    terminator is stored at the end of the array unless `dest_len` is `0`.
  */
-size_t utf8_encode_buf8(char *dest, size_t dest_len, const uint8_t *src, size_t src_len)
+size_t js__utf8_encode_buf8(char *dest, size_t dest_len, const uint8_t *src, size_t src_len)
 {
     size_t i, j;
     uint32_t c;
@@ -560,7 +560,7 @@ overflow:
    `dest_len` is the length in bytes of the destination array. A null
    terminator is stored at the end of the array unless `dest_len` is `0`.
  */
-size_t utf8_encode_buf16(char *dest, size_t dest_len, const uint16_t *src, size_t src_len)
+size_t js__utf8_encode_buf16(char *dest, size_t dest_len, const uint16_t *src, size_t src_len)
 {
     size_t i, j;
     uint32_t c;
@@ -574,9 +574,9 @@ size_t utf8_encode_buf16(char *dest, size_t dest_len, const uint16_t *src, size_
         } else {
             if (is_hi_surrogate(c) && i < src_len && is_lo_surrogate(src[i]))
                 c = from_surrogate(c, src[i++]);
-            if (j + utf8_encode_len(c) >= dest_len)
+            if (j + js__utf8_encode_len(c) >= dest_len)
                 goto overflow;
-            j += utf8_encode((uint8_t *)dest + j, c);
+            j += js__utf8_encode((uint8_t *)dest + j, c);
         }
     }
     if (j < dest_len)
@@ -594,7 +594,7 @@ overflow:
         } else {
             if (is_hi_surrogate(c) && i < src_len && is_lo_surrogate(src[i]))
                 c = from_surrogate(c, src[i++]);
-            j += utf8_encode_len(c);
+            j += js__utf8_encode_len(c);
         }
     }
     return j;
@@ -782,7 +782,7 @@ static inline void *med3(void *a, void *b, void *c, cmp_f cmp, void *opaque)
 }
 
 /* pointer based version with local stack and insertion sort threshhold */
-void rqsort(void *base, size_t nmemb, size_t size, cmp_f cmp, void *opaque)
+void js__rqsort(void *base, size_t nmemb, size_t size, cmp_f cmp, void *opaque)
 {
     struct { uint8_t *base; size_t count; int depth; } stack[50], *sp = stack;
     uint8_t *ptr, *pi, *pj, *plt, *pgt, *top, *m;

--- a/cutils.h
+++ b/cutils.h
@@ -435,27 +435,27 @@ typedef struct DynBuf {
     void *opaque; /* for realloc_func */
 } DynBuf;
 
-void dbuf_init(DynBuf *s);
-void dbuf_init2(DynBuf *s, void *opaque, DynBufReallocFunc *realloc_func);
-int dbuf_claim(DynBuf *s, size_t len);
-int dbuf_put(DynBuf *s, const void *data, size_t len);
-int dbuf_put_self(DynBuf *s, size_t offset, size_t len);
-int __dbuf_putc(DynBuf *s, uint8_t c);
-int __dbuf_put_u16(DynBuf *s, uint16_t val);
-int __dbuf_put_u32(DynBuf *s, uint32_t val);
-int __dbuf_put_u64(DynBuf *s, uint64_t val);
-int dbuf_putstr(DynBuf *s, const char *str);
+void js__dbuf_init(DynBuf *s);
+void js__dbuf_init2(DynBuf *s, void *opaque, DynBufReallocFunc *realloc_func);
+int js__dbuf_claim(DynBuf *s, size_t len);
+int js__dbuf_put(DynBuf *s, const void *data, size_t len);
+int js__dbuf_put_self(DynBuf *s, size_t offset, size_t len);
+int js__dbuf_putc(DynBuf *s, uint8_t c);
+int js__dbuf_put_u16(DynBuf *s, uint16_t val);
+int js__dbuf_put_u32(DynBuf *s, uint32_t val);
+int js__dbuf_put_u64(DynBuf *s, uint64_t val);
+int js__dbuf_putstr(DynBuf *s, const char *str);
 static inline int dbuf_putc(DynBuf *s, uint8_t val)
 {
     if (unlikely((s->allocated_size - s->size) < 1))
-        return __dbuf_putc(s, val);
+        return js__dbuf_putc(s, val);
     s->buf[s->size++] = val;
     return 0;
 }
 static inline int dbuf_put_u16(DynBuf *s, uint16_t val)
 {
     if (unlikely((s->allocated_size - s->size) < 2))
-        return __dbuf_put_u16(s, val);
+        return js__dbuf_put_u16(s, val);
     put_u16(s->buf + s->size, val);
     s->size += 2;
     return 0;
@@ -463,7 +463,7 @@ static inline int dbuf_put_u16(DynBuf *s, uint16_t val)
 static inline int dbuf_put_u32(DynBuf *s, uint32_t val)
 {
     if (unlikely((s->allocated_size - s->size) < 4))
-        return __dbuf_put_u32(s, val);
+        return js__dbuf_put_u32(s, val);
     put_u32(s->buf + s->size, val);
     s->size += 4;
     return 0;
@@ -471,13 +471,13 @@ static inline int dbuf_put_u32(DynBuf *s, uint32_t val)
 static inline int dbuf_put_u64(DynBuf *s, uint64_t val)
 {
     if (unlikely((s->allocated_size - s->size) < 8))
-        return __dbuf_put_u64(s, val);
+        return js__dbuf_put_u64(s, val);
     put_u64(s->buf + s->size, val);
     s->size += 8;
     return 0;
 }
-int JS_PRINTF_FORMAT_ATTR(2, 3) dbuf_printf(DynBuf *s, JS_PRINTF_FORMAT const char *fmt, ...);
-void dbuf_free(DynBuf *s);
+int JS_PRINTF_FORMAT_ATTR(2, 3) js__dbuf_printf(DynBuf *s, JS_PRINTF_FORMAT const char *fmt, ...);
+void js__dbuf_free(DynBuf *s);
 static inline bool dbuf_error(DynBuf *s) {
     return s->error;
 }
@@ -497,15 +497,15 @@ enum {
     UTF8_HAS_NON_BMP1 = 4,  // has non-BMP1 code points, needs UTF-16 surrogate pairs
     UTF8_HAS_ERRORS   = 8,  // has encoding errors
 };
-int utf8_scan(const char *buf, size_t len, size_t *plen);
-size_t utf8_encode_len(uint32_t c);
-size_t utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c);
-uint32_t utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp);
-uint32_t utf8_decode(const uint8_t *p, const uint8_t **pp);
-size_t utf8_decode_buf8(uint8_t *dest, size_t dest_len, const char *src, size_t src_len);
-size_t utf8_decode_buf16(uint16_t *dest, size_t dest_len, const char *src, size_t src_len);
-size_t utf8_encode_buf8(char *dest, size_t dest_len, const uint8_t *src, size_t src_len);
-size_t utf8_encode_buf16(char *dest, size_t dest_len, const uint16_t *src, size_t src_len);
+int js__utf8_scan(const char *buf, size_t len, size_t *plen);
+size_t js__utf8_encode_len(uint32_t c);
+size_t js__utf8_encode(uint8_t buf[minimum_length(UTF8_CHAR_LEN_MAX)], uint32_t c);
+uint32_t js__utf8_decode_len(const uint8_t *p, size_t max_len, const uint8_t **pp);
+uint32_t js__utf8_decode(const uint8_t *p, const uint8_t **pp);
+size_t js__utf8_decode_buf8(uint8_t *dest, size_t dest_len, const char *src, size_t src_len);
+size_t js__utf8_decode_buf16(uint16_t *dest, size_t dest_len, const char *src, size_t src_len);
+size_t js__utf8_encode_buf8(char *dest, size_t dest_len, const uint8_t *src, size_t src_len);
+size_t js__utf8_encode_buf16(char *dest, size_t dest_len, const uint16_t *src, size_t src_len);
 
 static inline bool is_surrogate(uint32_t c)
 {
@@ -557,7 +557,7 @@ static inline uint8_t to_upper_ascii(uint8_t c) {
     return c >= 'a' && c <= 'z' ? c - 'a' + 'A' : c;
 }
 
-void rqsort(void *base, size_t nmemb, size_t size,
+void js__rqsort(void *base, size_t nmemb, size_t size,
             int (*cmp)(const void *, const void *, void *),
             void *arg);
 

--- a/libunicode.c
+++ b/libunicode.c
@@ -958,8 +958,8 @@ int unicode_normalize(uint32_t **pdst, const uint32_t *src, int src_len,
 
     is_compat = n_type >> 1;
 
-    dbuf_init2(dbuf, opaque, realloc_func);
-    if (dbuf_claim(dbuf, sizeof(int) * src_len))
+    js__dbuf_init2(dbuf, opaque, realloc_func);
+    if (js__dbuf_claim(dbuf, sizeof(int) * src_len))
         goto fail;
 
     /* common case: latin1 is unaffected by NFC */
@@ -1347,7 +1347,7 @@ static void cr_sort_and_remove_overlap(CharRange *cr)
     uint32_t start, end, start1, end1, i, j;
 
     /* the resulting ranges are not necessarily sorted and may overlap */
-    rqsort(cr->points, cr->len / 2, sizeof(cr->points[0]) * 2, point_cmp, NULL);
+    js__rqsort(cr->points, cr->len / 2, sizeof(cr->points[0]) * 2, point_cmp, NULL);
     j = 0;
     for(i = 0; i < cr->len; ) {
         start = cr->points[i];

--- a/unicode_gen.c
+++ b/unicode_gen.c
@@ -1478,7 +1478,7 @@ void build_prop_table(FILE *f, int prop_index, bool add_index)
     int buf_len, block_end_pos, bit;
     char cname[128];
 
-    dbuf_init(dbuf1);
+    js__dbuf_init(dbuf1);
 
     for(i = 0; i <= CHARCODE_MAX;) {
         v = get_prop(i, prop_index);
@@ -1494,8 +1494,8 @@ void build_prop_table(FILE *f, int prop_index, bool add_index)
         i += n;
     }
 
-    dbuf_init(dbuf);
-    dbuf_init(dbuf2);
+    js__dbuf_init(dbuf);
+    js__dbuf_init(dbuf2);
     buf = (uint32_t *)dbuf1->buf;
     buf_len = dbuf1->size / sizeof(buf[0]);
 
@@ -1563,9 +1563,9 @@ void build_prop_table(FILE *f, int prop_index, bool add_index)
         dump_byte_table(f, cname, dbuf2->buf, dbuf2->size);
     }
 
-    dbuf_free(dbuf);
-    dbuf_free(dbuf1);
-    dbuf_free(dbuf2);
+    js__dbuf_free(dbuf);
+    js__dbuf_free(dbuf1);
+    js__dbuf_free(dbuf2);
 }
 
 void build_flags_tables(FILE *f)
@@ -1622,7 +1622,7 @@ void build_general_category_table(FILE *f)
                     unicode_gc_short_name);
 
 
-    dbuf_init(dbuf);
+    js__dbuf_init(dbuf);
     cw_count = 0;
     for(i = 0; i < 4; i++)
         cw_len_count[i] = 0;
@@ -1681,7 +1681,7 @@ void build_general_category_table(FILE *f)
 
     dump_byte_table(f, "unicode_gc_table", dbuf->buf, dbuf->size);
 
-    dbuf_free(dbuf);
+    js__dbuf_free(dbuf);
 }
 
 void build_script_table(FILE *f)
@@ -1701,7 +1701,7 @@ void build_script_table(FILE *f)
                     unicode_script_name + i, SCRIPT_COUNT - i,
                     unicode_script_short_name + i);
 
-    dbuf_init(dbuf);
+    js__dbuf_init(dbuf);
     cw_count = 0;
     for(i = 0; i < 4; i++)
         cw_len_count[i] = 0;
@@ -1751,7 +1751,7 @@ void build_script_table(FILE *f)
 
     dump_byte_table(f, "unicode_script_table", dbuf->buf, dbuf->size);
 
-    dbuf_free(dbuf);
+    js__dbuf_free(dbuf);
 }
 
 void build_script_ext_table(FILE *f)
@@ -1760,7 +1760,7 @@ void build_script_ext_table(FILE *f)
     DynBuf dbuf_s, *dbuf = &dbuf_s;
     int cw_count;
 
-    dbuf_init(dbuf);
+    js__dbuf_init(dbuf);
     cw_count = 0;
     for(i = 0; i <= CHARCODE_MAX;) {
         script_ext_len = unicode_db[i].script_ext_len;
@@ -1801,7 +1801,7 @@ void build_script_ext_table(FILE *f)
 
     dump_byte_table(f, "unicode_script_ext_table", dbuf->buf, dbuf->size);
 
-    dbuf_free(dbuf);
+    js__dbuf_free(dbuf);
 }
 
 /* the following properties are synthetized so no table is necessary */
@@ -1976,8 +1976,8 @@ void build_cc_table(FILE *f)
     int cw_len_tab[3], cw_start, block_end_pos;
     uint32_t v;
 
-    dbuf_init(dbuf);
-    dbuf_init(dbuf1);
+    js__dbuf_init(dbuf);
+    js__dbuf_init(dbuf1);
     cc_table_len = 0;
     for(i = 0; i < countof(cw_len_tab); i++)
         cw_len_tab[i] = 0;
@@ -2059,8 +2059,8 @@ void build_cc_table(FILE *f)
         printf(" %d", cw_len_tab[i]);
     printf(" ]\n");
 #endif
-    dbuf_free(dbuf);
-    dbuf_free(dbuf1);
+    js__dbuf_free(dbuf);
+    js__dbuf_free(dbuf1);
 }
 
 /* maximum length of decomposition: 18 chars (1), then 8 */


### PR DESCRIPTION
An alternate approach to #1344, building on #1345

This completes #1345 by adding a `js_` prefix to all exported symbols to help prevent conflicts.

closes #1343, #754, #940