### PR TITLE
Add libonly meson option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,8 +130,11 @@ qjs_sys_deps = []
 
 m_dep = cc.find_library('m', required: false)
 qjs_sys_deps += m_dep
-qjs_sys_deps += dependency('threads', required: false)
-qjs_sys_deps += dependency('dl', required: false)
+if host_system != 'dos'
+  qjs_sys_deps += dependency('threads', required: false)
+  qjs_sys_deps += dependency('dl', required: false)
+endif
+tools = get_option('tools')
 
 qjs_srcs = files(
   'dtoa.c',
@@ -220,6 +223,8 @@ if qjs_libc
     include_directories: include_directories('.'),
     dependencies: qjs_dep,
   )
+elif not tools.allowed()
+  qjs_libc_dep = []
 else
   qjs_libc_lib = static_library(
     'quickjs-libc',
@@ -304,13 +309,15 @@ endif
 qjsc_srcs = files(
   'qjsc.c',
 )
+
 qjsc_exe = executable(
   'qjsc',
   qjsc_srcs,
 
   c_args: qjs_c_args,
   dependencies: [qjs_dep, qjs_libc_dep],
-  install: true,
+  build_by_default: tools.allowed(),
+  install: tools.allowed(),
 )
 
 mimalloc_dep = []
@@ -328,6 +335,7 @@ qjs_exe_srcs = files(
   'gen/standalone.c',
   'qjs.c',
 )
+
 qjs_exe = executable(
   'qjs',
   qjs_exe_srcs,
@@ -335,8 +343,8 @@ qjs_exe = executable(
   c_args: qjs_c_args,
   dependencies: [qjs_dep, qjs_libc_dep, mimalloc_dep],
   export_dynamic: true,
-
-  install: true,
+  build_by_default: tools.allowed(),
+  install: tools.allowed(),
 )
 
 if meson.is_cross_build()
@@ -558,7 +566,7 @@ alias_target('codegen',
   run_target(
     'codegen_repl.c',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-ss',
       '-o', files('gen/repl.c'),
       '-m',
@@ -569,7 +577,7 @@ alias_target('codegen',
   run_target(
     'codegen_standalone.c',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-ss',
       '-o', files('gen/standalone.c'),
       '-m',
@@ -580,7 +588,7 @@ alias_target('codegen',
   run_target(
     'codegen_function_source.c',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-e',
       '-o', files('gen/function_source.c'),
       '-n', 'tests/function_source.js',
@@ -590,7 +598,7 @@ alias_target('codegen',
   run_target(
     'codegen_hello.c',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-e',
       '-o', files('gen/hello.c'),
       '-n', 'examples/hello.js',
@@ -600,7 +608,7 @@ alias_target('codegen',
   run_target(
     'codegen_hello_module.c',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-e',
       '-o', files('gen/hello_module.c'),
       '-m',
@@ -611,7 +619,7 @@ alias_target('codegen',
   run_target(
     'codegen_test_fib.c',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-e',
       '-o', files('gen/test_fib.c'),
       '-m',
@@ -622,7 +630,7 @@ alias_target('codegen',
   run_target(
     'codegen_builtin-array-fromasync.h',
     command: [
-      qjsc_exe,
+      'qjsc',
       '-C',
       '-ss',
       '-o', files('builtin-array-fromasync.h'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('libc', type: 'boolean', value: false, description: 'build qjs standard l
 option('cli_mimalloc', type: 'feature', value: 'disabled', description: 'build qjs cli with mimalloc')
 option('docdir', type: 'string', description: 'documentation directory')
 option('parser', type: 'boolean', value: true, description: 'Enable JS source code parser')
+option('tools', type: 'feature', description: 'build tools like qjs and qjsc')


### PR DESCRIPTION
Mainly for DJGPP. I don't need qjs.exe, libc. etc. only library.
Check for threads adds -pthread to flags, which cause compilation error, so it is disabled for 'dos' host_system.
Executables are replaced by text '/bin/true'. It does not break normal builds.
