### PR TITLE
Fix out of bounds read in regex engine

### DIFF
--- a/libregexp.c
+++ b/libregexp.c
@@ -841,7 +841,9 @@ static int re_parse_char_class(REParseState *s, const uint8_t **pp)
         const char *s = verboten;
         int n = 1;
         do {
-            if (!memcmp(s, p, n))
+            // not memcmp because some implementations compare word instead
+            // of byte at a time and will happily read past end of input
+            if (!strncmp(s, (const char *)p, n))
                 if (p[n] == ']')
                     goto invalid_class_range;
             s += n;

--- a/tests/bug1354.js
+++ b/tests/bug1354.js
@@ -1,0 +1,1 @@
+new RegExp("[", "v") // run under ASAN

--- a/tests/bug1354.js
+++ b/tests/bug1354.js
@@ -1,1 +1,6 @@
+/*---
+negative:
+  phase: runtime
+  type: SyntaxError
+---*/
 new RegExp("[", "v") // run under ASAN


### PR DESCRIPTION
Use strncmp instead of memcmp because some implementations of the latter compare more than one byte at a time and will read past end of the input.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1354