### PR TITLE
Validate function locals count when deserializing

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -38026,6 +38026,10 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
         goto fail;
     if (bc_get_leb128_int(s, &local_count))
         goto fail;
+    if (local_count < 0 || local_count > JS_MAX_LOCAL_VARS) {
+        JS_ThrowSyntaxError(s->ctx, "bad function object");
+        goto fail;
+    }
 
     function_size = sizeof(*b);
     cpool_offset = function_size;

--- a/tests/test_bjson.js
+++ b/tests/test_bjson.js
@@ -290,6 +290,7 @@ function bjson_test_fuzz()
         ["FwARABMGBgYGBgYGBgYGBv////8QABEALxH/vy8R/78="],
         ["FwAIfwAK/////3//////////////////////////////3/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAD5+fn5+fn5+fn5+fkAAAAAAAYAqw=="],
         ["FwAOAAAAFAA=", bjson.READ_OBJ_REFERENCE],
+        ["FwAMAAAAAAAAAAAAAAAAgICAgAQAAAAA=", bjson.READ_OBJ_BYTECODE],
     ];
     for (var [input, flags] of corpus) {
         var buf = base64decode(input);


### PR DESCRIPTION
Fixes: https://github.com/quickjs-ng/quickjs/issues/1379