### PR TITLE
Guard against calling _msize(NULL)

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -600,6 +600,8 @@ static inline size_t js__malloc_usable_size(const void *ptr)
 #if defined(__APPLE__)
     return malloc_size(ptr);
 #elif defined(_WIN32)
+    if (!ptr)
+        return 0;
     return _msize((void *)ptr);
 #elif defined(__linux__) || defined(__ANDROID__) || defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__GLIBC__)
     return malloc_usable_size((void *)ptr);


### PR DESCRIPTION
It will call the invalid parameter handler, aka, crash.
See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/msize?view=msvc-170
