### PR TITLE
Fix underflow with generator in iterable

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -27963,8 +27963,6 @@ static __exception int js_parse_for_in_of(JSParseState *s, int label_name,
 
     if (token_is_pseudo_keyword(s, JS_ATOM_of)) {
         is_for_of = true;
-        break_entry.has_iterator = true;
-        break_entry.drop_count += 2;
         if (has_initializer)
             goto initializer_error;
     } else if (s->token.val == TOK_IN) {
@@ -27992,6 +27990,11 @@ static __exception int js_parse_for_in_of(JSParseState *s, int label_name,
        the TDZ values are in the closures */
     close_scopes(s, s->cur_func->scope_level, block_scope_level);
     if (is_for_of) {
+        /* set has_iterator after the iterable expression is parsed so
+           that a yield in the expression does not try to close a
+           not-yet-created iterator */
+        break_entry.has_iterator = true;
+        break_entry.drop_count += 2;
         if (is_async)
             emit_op(s, OP_for_await_of_start);
         else

--- a/tests/bug488-upstream.js
+++ b/tests/bug488-upstream.js
@@ -1,0 +1,7 @@
+// for-of with yield in iterable expression should not cause stack underflow
+function* x() {
+    for (var e of yield []);
+}
+var g = x();
+g.next();
+g.return("test");


### PR DESCRIPTION
Fixes: https://github.com/bellard/quickjs/issues/488