### PR TITLE
Fix parsing error involving private fields and division

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -24030,6 +24030,7 @@ static bool is_regexp_allowed(int tok)
     case TOK_FALSE:
     case TOK_TRUE:
     case TOK_THIS:
+    case TOK_PRIVATE_NAME:
     case ')':
     case ']':
     case '}': /* XXX: regexp may occur after */

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -369,6 +369,13 @@ function test_class()
     assert(new P().set(), "456");
     assert(new P().async(), "789");
     assert(new P().static(), 42);
+
+    /* test that division after private field in parens is not parsed as regex */
+    class Q {
+        #x = 10;
+        f() { return (this.#x / 2); }
+    }
+    assert(new Q().f(), 5);
 };
 
 function test_template()


### PR DESCRIPTION
The expression evaluatesd correctly, but a deferred parse error was
emitted.
