### PR TITLE
Fix UAF when handling non-detached var-refs in mapped arguments

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -16019,7 +16019,7 @@ static void js_mapped_arguments_mark(JSRuntime *rt, JSValueConst val,
         int i;
         if (var_refs) {
             for(i = 0; i < p->u.array.count; i++) {
-                if (var_refs[i])
+                if (var_refs[i] && var_refs[i]->is_detached)
                     mark_func(rt, &var_refs[i]->header);
             }
         }

--- a/run-test262.c
+++ b/run-test262.c
@@ -909,6 +909,13 @@ static JSValue js_IsHTMLDDA(JSContext *ctx, JSValueConst this_val,
     return JS_NULL;
 }
 
+static JSValue js_gc(JSContext *ctx, JSValueConst this_val,
+                     int argc, JSValueConst *argv)
+{
+    JS_RunGC(JS_GetRuntime(ctx));
+    return JS_UNDEFINED;
+}
+
 static JSValue add_helpers1(JSContext *ctx)
 {
     JSValue global_obj;
@@ -918,6 +925,8 @@ static JSValue add_helpers1(JSContext *ctx)
 
     JS_SetPropertyStr(ctx, global_obj, "print",
                       JS_NewCFunction(ctx, js_print_262, "print", 1));
+    JS_SetPropertyStr(ctx, global_obj, "gc",
+                      JS_NewCFunction(ctx, js_gc, "gc", 0));
 
     is_html_dda = JS_NewCFunction(ctx, js_IsHTMLDDA, "IsHTMLDDA", 0);
     JS_SetIsHTMLDDA(ctx, is_html_dda);

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -287,6 +287,13 @@ function test_arguments()
         assert(arguments[1], 3, "arguments");
     }
     f2(1, 3);
+
+    /* mapped arguments with GC must not crash (non-detached var_refs) */
+    function f3(a) {
+        arguments;
+        gc();
+    }
+    f3(0);
 }
 
 function test_class()


### PR DESCRIPTION
js_mapped_arguments_mark was calling mark_func on non-detached var_refs,
which are not GC objects.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1400
