### PR TITLE
Fix compiler warnings when compileing with -Wpedantic

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -4568,22 +4568,22 @@ static void js_free_cstring(JSRuntime *rt, const void *ptr)
 
 void JS_FreeCString(JSContext *ctx, const char *ptr)
 {
-    return js_free_cstring(ctx->rt, ptr);
+    js_free_cstring(ctx->rt, ptr);
 }
 
 void JS_FreeCStringRT(JSRuntime *rt, const char *ptr)
 {
-    return js_free_cstring(rt, ptr);
+    js_free_cstring(rt, ptr);
 }
 
 void JS_FreeCStringUTF16(JSContext *ctx, const uint16_t *ptr)
 {
-    return js_free_cstring(ctx->rt, ptr);
+    js_free_cstring(ctx->rt, ptr);
 }
 
 void JS_FreeCStringRT_UTF16(JSRuntime *rt, const uint16_t *ptr)
 {
-    return js_free_cstring(rt, ptr);
+    js_free_cstring(rt, ptr);
 }
 
 static int memcmp16_8(const uint16_t *src1, const uint8_t *src2, int len)


### PR DESCRIPTION
1d47486936700e2b6a013e0cdb3fca24bc0c4605 intruduced new UTF16 string lifetime functions. This commit removes redundant return statements that trigger a warning when building with `-Wpedantic`.