### PR TITLE
Add support for text imports

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -788,26 +788,12 @@ int js_module_set_import_meta(JSContext *ctx, JSValueConst func_val,
     return 0;
 }
 
-static int json_module_init(JSContext *ctx, JSModuleDef *m)
+static int default_module_init(JSContext *ctx, JSModuleDef *m)
 {
     JSValue val;
     val = JS_GetModulePrivateValue(ctx, m);
     JS_SetModuleExport(ctx, m, "default", val);
     return 0;
-}
-
-static JSModuleDef *create_json_module(JSContext *ctx, const char *module_name, JSValue val)
-{
-    JSModuleDef *m;
-    m = JS_NewCModule(ctx, module_name, json_module_init);
-    if (!m) {
-        JS_FreeValue(ctx, val);
-        return NULL;
-    }
-    /* only export the "default" symbol which will contain the JSON object */
-    JS_AddModuleExport(ctx, m, "default");
-    JS_SetModulePrivateValue(ctx, m, val);
-    return m;
 }
 
 /* in order to conform with the specification, only the keys should be
@@ -842,8 +828,14 @@ int js_module_check_attributes(JSContext *ctx, void *opaque,
     return ret;
 }
 
+enum {
+    JS_IMPORT_TYPE_JS,
+    JS_IMPORT_TYPE_JSON,
+    JS_IMPORT_TYPE_TEXT,
+};
+
 /* return > 0 if the attributes indicate a JSON module, 0 otherwise, -1 on error */
-int js_module_test_json(JSContext *ctx, JSValueConst attributes)
+static int js_module_import_type(JSContext *ctx, JSValueConst attributes)
 {
     JSValue str;
     const char *cstr;
@@ -851,80 +843,98 @@ int js_module_test_json(JSContext *ctx, JSValueConst attributes)
     int res;
 
     if (JS_IsUndefined(attributes))
-        return 0;
+        return JS_IMPORT_TYPE_JS;
     str = JS_GetPropertyStr(ctx, attributes, "type");
     if (JS_IsException(str))
         return -1;
     if (!JS_IsString(str)) {
         JS_FreeValue(ctx, str);
-        return 0;
+        return JS_IMPORT_TYPE_JS;
     }
     cstr = JS_ToCStringLen(ctx, &len, str);
     JS_FreeValue(ctx, str);
     if (!cstr)
         return -1;
     if (len == 4 && !memcmp(cstr, "json", len)) {
-        res = 1;
+        res = JS_IMPORT_TYPE_JSON;
+    } else if (len == 4 && !memcmp(cstr, "text", len)) {
+        res = JS_IMPORT_TYPE_TEXT;
     } else {
         /* unknown type - throw error */
         JS_ThrowTypeError(ctx, "unsupported module type: '%s'", cstr);
-        JS_FreeCString(ctx, cstr);
-        return -1;
+        res = -1;
     }
     JS_FreeCString(ctx, cstr);
     return res;
 }
 
-JSModuleDef *js_module_loader(JSContext *ctx,
-                              const char *module_name, void *opaque,
-                              JSValueConst attributes)
+JSModuleDef *js_module_load(JSContext *ctx, const char *module_name,
+                            void *opaque, JSValueConst attributes,
+                            JSLoadFileFunc *load_file)
 {
     JSModuleDef *m;
+    JSValue val;
+    size_t buf_len;
+    char *buf;
+    int type;
 
-    if (js__has_suffix(module_name, QJS_NATIVE_MODULE_SUFFIX)) {
-        m = js_module_loader_so(ctx, module_name);
+    type = js_module_import_type(ctx, attributes);
+    if (type < 0)
+        return NULL;
+    if (js__has_suffix(module_name, ".json"))
+        type = JS_IMPORT_TYPE_JSON;
+    buf = (char *)load_file(ctx, &buf_len, module_name);
+    if (!buf) {
+        JS_ThrowReferenceError(ctx, "could not load module filename '%s'",
+                               module_name);
+        return NULL;
+    }
+    switch (type) {
+    case JS_IMPORT_TYPE_JS:
+        val = JS_Eval(ctx, buf, buf_len, module_name,
+                      JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+        break;
+    case JS_IMPORT_TYPE_JSON:
+        val = JS_ParseJSON(ctx, buf, buf_len, module_name);
+        break;
+    case JS_IMPORT_TYPE_TEXT:
+        val = JS_NewStringLen(ctx, buf, buf_len);
+        break;
+    default:
+        val = JS_ThrowInternalError(ctx, "unhandled import type");
+        break;
+    }
+    js_free(ctx, buf);
+    if (JS_IsException(val))
+        return NULL;
+    if (type == JS_IMPORT_TYPE_JS) {
+        if (js_module_set_import_meta(ctx, val, true, false) < 0) {
+            JS_FreeValue(ctx, val);
+            return NULL;
+        }
+        // the module is already referenced, so we must free it
+        m = JS_VALUE_GET_PTR(val);
+        JS_FreeValue(ctx, val);
     } else {
-        int res;
-        size_t buf_len;
-        uint8_t *buf;
-
-        res = js_module_test_json(ctx, attributes);
-        if (res < 0)
-            return NULL;
-        buf = js_load_file(ctx, &buf_len, module_name);
-        if (!buf) {
-            JS_ThrowReferenceError(ctx, "could not load module filename '%s'",
-                                   module_name);
+        m = JS_NewCModule(ctx, module_name, default_module_init);
+        if (!m) {
+            JS_FreeValue(ctx, val);
             return NULL;
         }
-        if (js__has_suffix(module_name, ".json") || res > 0) {
-            /* compile as JSON */
-            JSValue val;
-            val = JS_ParseJSON(ctx, (char *)buf, buf_len, module_name);
-            js_free(ctx, buf);
-            if (JS_IsException(val))
-                return NULL;
-            m = create_json_module(ctx, module_name, val);
-            if (!m)
-                return NULL;
-        } else {
-            JSValue func_val;
-            /* compile the module */
-            func_val = JS_Eval(ctx, (char *)buf, buf_len, module_name,
-                               JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
-            js_free(ctx, buf);
-            if (JS_IsException(func_val))
-                return NULL;
-            if (js_module_set_import_meta(ctx, func_val, true, false) < 0) {
-                JS_FreeValue(ctx, func_val);
-                return NULL;
-            }
-            /* the module is already referenced, so we must free it */
-            m = JS_VALUE_GET_PTR(func_val);
-            JS_FreeValue(ctx, func_val);
-        }
+        // only export the "default" symbol which will contain the string
+        // or JSON object
+        JS_AddModuleExport(ctx, m, "default");
+        JS_SetModulePrivateValue(ctx, m, val);
     }
     return m;
+}
+
+JSModuleDef *js_module_loader(JSContext *ctx, const char *module_name,
+                              void *opaque, JSValueConst attributes)
+{
+    if (js__has_suffix(module_name, QJS_NATIVE_MODULE_SUFFIX))
+        return js_module_loader_so(ctx, module_name);
+    return js_module_load(ctx, module_name, opaque, attributes, js_load_file);
 }
 
 static JSValue js_std_exit(JSContext *ctx, JSValueConst this_val,

--- a/quickjs-libc.h
+++ b/quickjs-libc.h
@@ -25,6 +25,7 @@
 #define QUICKJS_LIBC_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -33,6 +34,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef uint8_t *JSLoadFileFunc(JSContext *ctx, size_t *pbuf_len,
+                                const char *filename);
 
 JS_LIBC_EXTERN JSModuleDef *js_init_module_std(JSContext *ctx,
                                                const char *module_name);
@@ -55,9 +59,13 @@ JS_LIBC_EXTERN int js_module_set_import_meta(JSContext *ctx, JSValueConst func_v
 JS_LIBC_EXTERN JSModuleDef *js_module_loader(JSContext *ctx,
                                              const char *module_name, void *opaque,
                                              JSValueConst attributes);
+// like js_module_loader but does not load .so objects and the file reader
+// is pluggable; js_module_loader is implemented in terms of js_module_load
+JS_LIBC_EXTERN JSModuleDef *js_module_load(JSContext *ctx, const char *module_name,
+                                           void *opaque, JSValueConst attributes,
+                                           JSLoadFileFunc *load_file);
 JS_LIBC_EXTERN int js_module_check_attributes(JSContext *ctx, void *opaque,
                                               JSValueConst attributes);
-JS_LIBC_EXTERN int js_module_test_json(JSContext *ctx, JSValueConst attributes);
 JS_LIBC_EXTERN void js_std_eval_binary(JSContext *ctx, const uint8_t *buf,
                                        size_t buf_len, int flags);
 JS_LIBC_EXTERN void js_std_promise_rejection_tracker(JSContext *ctx,

--- a/run-test262.c
+++ b/run-test262.c
@@ -970,24 +970,11 @@ static char *load_file(const char *filename, size_t *lenp)
     return buf;
 }
 
-static int json_module_init(JSContext *ctx, JSModuleDef *m)
-{
-    JSValue val;
-    val = JS_GetModulePrivateValue(ctx, m);
-    JS_SetModuleExport(ctx, m, "default", val);
-    return 0;
-}
-
 static JSModuleDef *js_module_loader_test(JSContext *ctx,
                                           const char *module_name, void *opaque,
                                           JSValueConst attributes)
 {
-    size_t buf_len;
-    uint8_t *buf;
-    JSModuleDef *m;
-    JSValue func_val;
     char *filename, *slash, path[1024];
-    int res;
 
     // interpret import("bar.js") from path/to/foo.js as
     // import("path/to/bar.js") but leave import("./bar.js") untouched
@@ -1000,46 +987,7 @@ static JSModuleDef *js_module_loader_test(JSContext *ctx,
             module_name = path;
         }
     }
-
-    /* check for JSON module */
-    res = js_module_test_json(ctx, attributes);
-    if (res < 0)
-        return NULL;
-
-    buf = js_load_file(ctx, &buf_len, module_name);
-    if (!buf) {
-        JS_ThrowReferenceError(ctx, "could not load module filename '%s'",
-                               module_name);
-        return NULL;
-    }
-
-    if (res > 0 || js__has_suffix(module_name, ".json")) {
-        /* compile as JSON */
-        JSValue val;
-        val = JS_ParseJSON(ctx, (char *)buf, buf_len, module_name);
-        js_free(ctx, buf);
-        if (JS_IsException(val))
-            return NULL;
-        m = JS_NewCModule(ctx, module_name, json_module_init);
-        if (!m) {
-            JS_FreeValue(ctx, val);
-            return NULL;
-        }
-        JS_AddModuleExport(ctx, m, "default");
-        JS_SetModulePrivateValue(ctx, m, val);
-        return m;
-    }
-
-    /* compile the module */
-    func_val = JS_Eval(ctx, (char *)buf, buf_len, module_name,
-                       JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
-    js_free(ctx, buf);
-    if (JS_IsException(func_val))
-        return NULL;
-    /* the module is already referenced, so we must free it */
-    m = JS_VALUE_GET_PTR(func_val);
-    JS_FreeValue(ctx, func_val);
-    return m;
+    return js_module_load(ctx, module_name, opaque, attributes, js_load_file);
 }
 
 int is_line_sep(char c)

--- a/test262.conf
+++ b/test262.conf
@@ -116,7 +116,7 @@ immutable-arraybuffer
 import-attributes
 import-bytes=skip
 import-defer=skip
-import-text=skip
+import-text
 import.meta
 Int16Array
 Int32Array

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -75,10 +75,13 @@ test262/test/language/expressions/assignment/target-member-computed-reference.js
 test262/test/language/expressions/assignment/target-member-computed-reference.js:22: strict mode: Test262Error: Expected a DummyError but got a Test262Error
 test262/test/language/expressions/assignment/target-super-computed-reference.js:20: Test262Error: Expected a DummyError but got a Test262Error
 test262/test/language/expressions/assignment/target-super-computed-reference.js:20: strict mode: Test262Error: Expected a DummyError but got a Test262Error
+test262/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-type-text.js:10: TypeError: $DONE() not called
+test262/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-type-text.js:10: strict mode: TypeError: $DONE() not called
 test262/test/language/expressions/in/private-field-invalid-assignment-target.js:23: unexpected error type: Test262: This statement should not be evaluated.
 test262/test/language/expressions/in/private-field-invalid-assignment-target.js:23: strict mode: unexpected error type: Test262: This statement should not be evaluated.
 test262/test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:31: Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
 test262/test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:31: strict mode: Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
+test262/test/language/import/import-attributes/text-self.js:10: SyntaxError: Could not find export 'default' in module 'test262/test/language/import/import-attributes/text-self.js'
 test262/test/language/module-code/ambiguous-export-bindings/import-and-export-propagates-binding.js:75: SyntaxError: export 'foo' in module 'test262/test/language/module-code/ambiguous-export-bindings/imp' is ambiguous
 test262/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-export-star-as-from-and-import-star-as-and-export.js:74: SyntaxError: export 'foo' in module 'test262/test/language/module-code/ambiguous-export-bindings/nam' is ambiguous
 test262/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-export-star-as-from.js:75: SyntaxError: export 'foo' in module 'test262/test/language/module-code/ambiguous-export-bindings/nam' is ambiguous


### PR DESCRIPTION
The two failing tests are:

- a quine (imports itself); needs some more work in the module loader
- dynamic imports; the dynamic loader doesn't support attributes at all
  at the moment