### PR TITLE
Fix big-endian crashes when loading cross-compiled bytecode

### DIFF
--- a/libregexp.c
+++ b/libregexp.c
@@ -2596,14 +2596,14 @@ int lre_byte_swap(uint8_t *buf, size_t len, bool is_byte_swapped)
             case REOP_range32: // variable length
                 nw = get_u16(&p[1]);  // number of pairs of uint32_t
                 if (is_byte_swapped)
-                    n = bswap16(n);
+                    nw = bswap16(nw);
                 for (r = 3 + 8 * nw; n < r; n += 4)
                     inplace_bswap32(&p[n]);
                 goto doswap16;
             case REOP_range: // variable length
                 nw = get_u16(&p[1]);  // number of pairs of uint16_t
                 if (is_byte_swapped)
-                    n = bswap16(n);
+                    nw = bswap16(nw);
                 for (r = 3 + 4 * nw; n < r; n += 2)
                     inplace_bswap16(&p[n]);
                 goto doswap16;

--- a/lre-test.c
+++ b/lre-test.c
@@ -65,9 +65,66 @@ static void invalid_opcode_byte_swap(void)
     assert(ret < 0);
 }
 
+// https://github.com/quickjs-ng/quickjs/issues/1122
+static void range_byte_swap(void)
+{
+    // Test that lre_byte_swap correctly handles REOP_range instructions.
+    // lre_byte_swap used to swap the wrong variable (n instead of nw),
+    // corrupting the bytecode walk and leaving subsequent instructions
+    // un-swapped.
+    //
+    // REOP_range = opcode 22 (0x16), size field = 3 (variable length)
+    // Layout: [opcode] [nw:u16] [low0:u16] [high0:u16] ...
+    //
+    // This bytecode represents /[ab]/ with 1 range pair: 0x0061-0x0063
+    // Multi-byte values are in native byte order (as produced by the
+    // regex compiler on this platform).
+    uint16_t flags = 0;
+    uint32_t bc_len = 8;
+    uint16_t nw = 1;
+    uint16_t low = 0x0061;
+    uint16_t high = 0x0063;
+
+    uint8_t bc[16];
+    memcpy(&bc[0], &flags, 2);       // RE_HEADER_FLAGS
+    bc[2] = 1;                        // RE_HEADER_CAPTURE_COUNT
+    bc[3] = 0;                        // RE_HEADER_STACK_SIZE
+    memcpy(&bc[4], &bc_len, 4);      // RE_HEADER_BYTECODE_LEN
+    bc[8] = 0x16;                     // REOP_range (22)
+    memcpy(&bc[9], &nw, 2);          // nw = 1
+    memcpy(&bc[11], &low, 2);        // low = 0x0061 'a'
+    memcpy(&bc[13], &high, 2);       // high = 0x0063 'c'
+    bc[15] = 0x0B;                    // REOP_match (11)
+
+    // Swap as if converting from native to non-native byte order
+    int ret = lre_byte_swap(bc, sizeof(bc), /*is_byte_swapped*/false);
+    assert(ret == 0);
+
+    // Swap back from non-native to native
+    ret = lre_byte_swap(bc, sizeof(bc), /*is_byte_swapped*/true);
+    assert(ret == 0);
+
+    // Verify round-trip: all values should be back in native format
+    uint16_t got_flags, got_nw, got_low, got_high;
+    uint32_t got_bc_len;
+    memcpy(&got_flags, &bc[0], 2);
+    memcpy(&got_bc_len, &bc[4], 4);
+    memcpy(&got_nw, &bc[9], 2);
+    memcpy(&got_low, &bc[11], 2);
+    memcpy(&got_high, &bc[13], 2);
+    assert(got_flags == 0);
+    assert(got_bc_len == 8);
+    assert(bc[8] == 0x16);          // REOP_range opcode unchanged
+    assert(got_nw == 1);
+    assert(got_low == 0x0061);
+    assert(got_high == 0x0063);
+    assert(bc[15] == 0x0B);         // REOP_match unchanged
+}
+
 int main(void)
 {
     oob_save_index();
     invalid_opcode_byte_swap();
+    range_byte_swap();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -37158,11 +37158,66 @@ static int JS_WriteFunctionTag(BCWriterState *s, JSValueConst obj)
         bc_put_leb128(s, flags);
     }
 
+    /* On big-endian, convert regex bytecodes in the constant pool from
+       native (BE) to LE format before writing. Scan bytecodes for
+       OP_regexp to identify which constants are regex bytecodes.
+       The sequence is: OP_push_const/OP_push_const8 <bc_idx>, OP_regexp */
+    if (is_be()) {
+        int prev_idx2 = -1, pos2, len2, op2;
+        pos2 = 0;
+        while (pos2 < b->byte_code_len) {
+            op2 = b->byte_code_buf[pos2];
+            len2 = short_opcode_info(op2).size;
+            if (op2 == OP_regexp && prev_idx2 >= 0) {
+                JSValue val = b->cpool[prev_idx2];
+                if (JS_VALUE_GET_TAG(val) == JS_TAG_STRING) {
+                    JSString *p = JS_VALUE_GET_STRING(val);
+                    if (!p->is_wide_char) {
+                        lre_byte_swap(str8(p), p->len,
+                                      /*is_byte_swapped*/false);
+                    }
+                }
+            }
+            prev_idx2 = -1;
+            if (op2 == OP_push_const)
+                prev_idx2 = get_u32(b->byte_code_buf + pos2 + 1);
+            else if (op2 == OP_push_const8)
+                prev_idx2 = b->byte_code_buf[pos2 + 1];
+            pos2 += len2;
+        }
+    }
+
     // write constant pool before code so code can be disassembled
     // on the fly at read time
     for(i = 0; i < b->cpool_count; i++) {
         if (JS_WriteObjectRec(s, b->cpool[i]))
             goto fail;
+    }
+
+    /* Swap the regex bytecodes back to native format after writing */
+    if (is_be()) {
+        int prev_idx2 = -1, pos2, len2, op2;
+        pos2 = 0;
+        while (pos2 < b->byte_code_len) {
+            op2 = b->byte_code_buf[pos2];
+            len2 = short_opcode_info(op2).size;
+            if (op2 == OP_regexp && prev_idx2 >= 0) {
+                JSValue val = b->cpool[prev_idx2];
+                if (JS_VALUE_GET_TAG(val) == JS_TAG_STRING) {
+                    JSString *p = JS_VALUE_GET_STRING(val);
+                    if (!p->is_wide_char) {
+                        lre_byte_swap(str8(p), p->len,
+                                      /*is_byte_swapped*/true);
+                    }
+                }
+            }
+            prev_idx2 = -1;
+            if (op2 == OP_push_const)
+                prev_idx2 = get_u32(b->byte_code_buf + pos2 + 1);
+            else if (op2 == OP_push_const8)
+                prev_idx2 = b->byte_code_buf[pos2 + 1];
+            pos2 += len2;
+        }
     }
 
     if (JS_WriteFunctionBytecode(s, b))
@@ -37974,6 +38029,37 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
 #endif
         pos += len;
     }
+
+    /* On big-endian, byte-swap regex bytecodes stored as string constants.
+       When bytecode is compiled on a little-endian machine and loaded on
+       big-endian, regex bytecodes in the constant pool remain in LE format.
+       Scan for OP_regexp and byte-swap the regex bytecode constants.
+       The sequence is: OP_push_const/OP_push_const8 <bc_idx>, OP_regexp */
+    if (is_be()) {
+        int prev_idx = -1;
+        pos = 0;
+        while (pos < (int)bc_len) {
+            op = bc_buf[pos];
+            len = short_opcode_info(op).size;
+            if (op == OP_regexp && prev_idx >= 0) {
+                JSValue val = b->cpool[prev_idx];
+                if (JS_VALUE_GET_TAG(val) == JS_TAG_STRING) {
+                    JSString *p = JS_VALUE_GET_STRING(val);
+                    if (!p->is_wide_char) {
+                        lre_byte_swap(str8(p), p->len,
+                                      /*is_byte_swapped*/true);
+                    }
+                }
+            }
+            prev_idx = -1;
+            if (op == OP_push_const)
+                prev_idx = get_u32(bc_buf + pos + 1);
+            else if (op == OP_push_const8)
+                prev_idx = bc_buf[pos + 1];
+            pos += len;
+        }
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
DISCLAIMER: Created with Claude Code. Unreviewed yet.

---

Fix two byte-swapping bugs that caused segfaults on big-endian platforms
(PowerPC, s390x) when loading bytecode compiled on little-endian systems.
This affected the REPL (which uses pre-compiled LE bytecode from gen/repl.c)
and any use of qjsc-generated bytecode across endianness boundaries.

Bug 1: lre_byte_swap swapped wrong variable for REOP_range/REOP_range32

In lre_byte_swap(), the code for variable-length REOP_range and
REOP_range32 instructions was swapping 'n' (the base instruction size,
always 3) instead of 'nw' (the number of range pairs read from the
bytecode). bswap16(3) = 0x0300 = 768, so the bytecode walk position
jumped 768 bytes forward, skipping all remaining instructions and
leaving them un-swapped. Any regex with a character class (e.g. [a-z])
would have corrupted bytecode on big-endian.

Bug 2: regex bytecodes in JS constant pool not byte-swapped

When a JS source containing regex literals (e.g. /[a-z]+/) is compiled
to bytecode by qjsc, the compiled regex bytecodes are stored as string
constants in the function's constant pool. The OP_regexp opcode later
retrieves these strings and passes them to js_regexp_constructor_internal
to create RegExp objects.

The existing JS_ReadRegExp path (for serialized RegExp objects) correctly
called lre_byte_swap to convert regex bytecodes from LE to native format.
However, the OP_regexp path (inline regex literals from the constant pool)
did not -- the regex bytecodes were read as plain 8-bit strings with no
byte-swapping applied, leaving them in LE format on a BE machine.

The fix adds byte-swap logic to both the reader and writer:

- JS_ReadFunctionBytecode: after reading JS bytecodes, scans for
  OP_regexp opcodes and byte-swaps the corresponding regex bytecode
  constants (identified by the preceding OP_push_const/OP_push_const8).

- JS_WriteFunctionTag: before writing the constant pool, converts
  regex bytecodes from native to LE format, then restores them after
  writing so the in-memory state is not affected.

Closes: https://github.com/quickjs-ng/quickjs/issues/1122
