### PR TITLE
Fix memory leak in Iterator.prototype.map

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -44196,6 +44196,7 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
             args[1] = index_val;
             ret = JS_Call(ctx, it->func, JS_UNDEFINED, countof(args), args);
             JS_FreeValue(ctx, index_val);
+            JS_FreeValue(ctx, item);
             if (JS_IsException(ret))
                 goto fail;
             goto done;

--- a/tests/bug493.js
+++ b/tests/bug493.js
@@ -1,0 +1,10 @@
+// Iterator.prototype.map must not leak the original item
+function* gen() {
+    for (let i = 0; i < 5; i++) {
+        yield { index: i };
+    }
+}
+
+const mapped = gen().map(x => x.index * 2);
+
+for (const val of mapped) {}


### PR DESCRIPTION
Fixes: https://github.com/bellard/quickjs/issues/493
