### PR TITLE
Fix native Big Endian build

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -286,17 +286,6 @@ static inline uint32_t get_u32(const uint8_t *tab)
     return v;
 }
 
-static inline uint32_t get_u32_le(const uint8_t *tab)
-{
-    uint32_t a, b, c, d;
-
-    a = (uint32_t)tab[0];
-    b = (uint32_t)tab[1];
-    c = (uint32_t)tab[2];
-    d = (uint32_t)tab[3];
-    return a | b<<8 | c<<16 | d<<24;
-}
-
 static inline int32_t get_i32(const uint8_t *tab)
 {
     int32_t v;
@@ -307,14 +296,6 @@ static inline int32_t get_i32(const uint8_t *tab)
 static inline void put_u32(uint8_t *tab, uint32_t val)
 {
     memcpy(tab, &val, sizeof(val));
-}
-
-static inline void put_u32_le(uint8_t *tab, uint32_t val)
-{
-    tab[0] = val >> 0;
-    tab[1] = val >> 8;
-    tab[2] = val >> 16;
-    tab[3] = val >> 24;
 }
 
 static inline uint32_t get_u16(const uint8_t *tab)

--- a/fuzz.c
+++ b/fuzz.c
@@ -30,7 +30,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
         exit(1);
     uint32_t csum = bc_csum(&buf[1], len-1);    // skip version field
     newbuf[0] = buf[0];                         // copy version field
-    put_u32_le(&newbuf[1], csum);               // insert checksum
+    put_u32(&newbuf[1], csum);                  // insert checksum
     memcpy(&newbuf[5], &buf[1], len-1);         // copy rest of payload
     JSValue val = JS_ReadObject(ctx, newbuf, newlen, /*flags*/0);
     free(newbuf);

--- a/quickjs.c
+++ b/quickjs.c
@@ -36904,7 +36904,7 @@ static uint32_t bc_csum(const uint8_t *p, size_t n)
 
     h = 0;
     for (i = 0; i+4 < n; i += 4) {
-        h += get_u32_le(p+i);
+        h += get_u32(p+i);
         h *= 0x9e370001;
     }
     a = b = c = 0;
@@ -37561,7 +37561,7 @@ uint8_t *JS_WriteObject2(JSContext *ctx, size_t *psize, JSValueConst obj,
     // don't include version and checksum fields in checksum
     d = &s->dbuf;
     h = bc_csum(&d->buf[5], d->size - 5);
-    put_u32_le(&d->buf[1], h);
+    put_u32(&d->buf[1], h);
     return d->buf;
  fail:
     js_object_list_end(ctx, &s->object_list);


### PR DESCRIPTION
Store bytecode checksum in native endianness.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1417
