### PR TITLE
Make malloc(0) always return NULL

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -58219,7 +58219,7 @@ static int typed_array_init(JSContext *ctx, JSValue obj, JSValue buffer,
     list_add_tail(&ta->link, &abuf->array_list);
     p->u.typed_array = ta;
     p->u.array.count = len;
-    p->u.array.u.ptr = abuf->data + offset;
+    p->u.array.u.ptr = abuf->data ? abuf->data + offset : NULL;
     return 0;
 }
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -1613,7 +1613,8 @@ void *js_malloc_rt(JSRuntime *rt, size_t size)
     JSMallocState *s;
 
     /* Do not allocate zero bytes: behavior is platform dependent */
-    assert(size != 0);
+    if (unlikely(size == 0))
+        return NULL;
 
     s = &rt->malloc_state;
     /* When malloc_limit is 0 (unlimited), malloc_limit - 1 will be SIZE_MAX. */


### PR DESCRIPTION
- **Ensure we never call malloc for zero**
- **Fix UBsan: applying zero offset to null pointer**
