### PR TITLE
Add run-test262 --no-can-block flag

### DIFF
--- a/run-test262.c
+++ b/run-test262.c
@@ -1988,7 +1988,7 @@ int run_test(ThreadLocalStorage *tls, const char *filename, int *msec)
 
 /* run a test when called by test262-harness+eshost */
 int run_test262_harness_test(ThreadLocalStorage *tls, const char *filename,
-                             bool is_module)
+                             bool is_module, bool can_block)
 {
     JSRuntime *rt;
     JSContext *ctx;
@@ -1996,7 +1996,6 @@ int run_test262_harness_test(ThreadLocalStorage *tls, const char *filename,
     size_t buf_len;
     int eval_flags, ret_code, ret;
     JSValue res_val;
-    bool can_block;
 
     outfile = stdout; /* for js_print_262 */
 
@@ -2013,7 +2012,6 @@ int run_test262_harness_test(ThreadLocalStorage *tls, const char *filename,
     }
     JS_SetRuntimeInfo(rt, filename);
 
-    can_block = true;
     JS_SetCanBlock(rt, can_block);
 
     /* loader for ES6 modules */
@@ -2136,7 +2134,8 @@ void help(void)
            "-d dir         run all test files in directory tree 'dir'\n"
            "-e file        load the known errors from 'file'\n"
            "-f file        execute single test from 'file'\n"
-           "-x file        exclude tests listed in 'file'\n",
+           "-x file        exclude tests listed in 'file'\n"
+           "--no-can-block set [[CanBlock]] to false (Atomics.wait will throw)\n",
            JS_GetVersion());
     exit(1);
 }
@@ -2159,6 +2158,7 @@ int main(int argc, char **argv)
     const char *ignore = "";
     bool is_test262_harness = false;
     bool is_module = false;
+    bool can_block = true;
     bool enable_progress = true;
 
     js_std_set_worker_new_context_func(JS_NewCustomContext);
@@ -2227,6 +2227,8 @@ int main(int argc, char **argv)
             is_test262_harness = true;
         } else if (str_equal(arg, "--module")) {
             is_module = true;
+        } else if (str_equal(arg, "--no-can-block")) {
+            can_block = false;
         } else {
             fatal(1, "unknown option: %s", arg);
             break;
@@ -2237,7 +2239,7 @@ int main(int argc, char **argv)
         help();
 
     if (is_test262_harness) {
-        return run_test262_harness_test(tls, argv[optind], is_module);
+        return run_test262_harness_test(tls, argv[optind], is_module, can_block);
     }
 
     nthreads = max_int(nthreads, 1);


### PR DESCRIPTION
The flag is needed to pass the two CanBlockIsFalse tests from test262 when running individual preprocessed tests via `run-test262 -N`.

Fixes #1431