### PR TITLE
Fix UAF in fast array delete

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -9779,16 +9779,6 @@ static int delete_property(JSContext *ctx, JSObject *p, JSAtom atom)
                 if (p->class_id == JS_CLASS_ARRAY ||
                     p->class_id == JS_CLASS_ARGUMENTS ||
                     p->class_id == JS_CLASS_MAPPED_ARGUMENTS) {
-                    /* Special case deleting the last element of a fast Array */
-                    if (idx == p->u.array.count - 1) {
-                        if (p->class_id == JS_CLASS_MAPPED_ARGUMENTS) {
-                            free_var_ref(ctx->rt, p->u.array.u.var_refs[idx]);
-                        } else {
-                            JS_FreeValue(ctx, p->u.array.u.values[idx]);
-                        }
-                        p->u.array.count = idx;
-                        return true;
-                    }
                     if (convert_fast_array_to_array(ctx, p))
                         return -1;
                     goto redo;

--- a/tests/bug1430.js
+++ b/tests/bug1430.js
@@ -1,0 +1,17 @@
+import { assert } from "./assert.js";
+
+const arr = [{ x: 0 }, { x: 1 }];
+
+delete arr[1];
+
+assert(arr.length, 2);
+assert(1 in arr, false);
+assert(arr[1], undefined);
+
+arr.push({ y: 2 });
+
+assert(arr.length, 3);
+assert(1 in arr, false);
+assert(2 in arr, true);
+assert(arr[1], undefined);
+assert(arr[2].y, 2);


### PR DESCRIPTION
This is an extension of [#1430](https://github.com/quickjs-ng/quickjs/issues/1430).

## Patch

`delete arr[last]` must preserve `arr.length`, so the fix should not try to shrink the public length. This change removes the special-case last-element fast path in `delete_property()` and falls back to the existing `convert_fast_array_to_array(ctx, p)` path before `goto redo;`.

## Testing

- `build/qjs tests/bug1430.js`
- `make test`