### PR TITLE
Remove return from void functions

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -4582,22 +4582,22 @@ static void js_free_cstring(JSRuntime *rt, const void *ptr)
 
 void JS_FreeCString(JSContext *ctx, const char *ptr)
 {
-    return js_free_cstring(ctx->rt, ptr);
+    js_free_cstring(ctx->rt, ptr);
 }
 
 void JS_FreeCStringRT(JSRuntime *rt, const char *ptr)
 {
-    return js_free_cstring(rt, ptr);
+    js_free_cstring(rt, ptr);
 }
 
 void JS_FreeCStringUTF16(JSContext *ctx, const uint16_t *ptr)
 {
-    return js_free_cstring(ctx->rt, ptr);
+    js_free_cstring(ctx->rt, ptr);
 }
 
 void JS_FreeCStringRT_UTF16(JSRuntime *rt, const uint16_t *ptr)
 {
-    return js_free_cstring(rt, ptr);
+    js_free_cstring(rt, ptr);
 }
 
 static int memcmp16_8(const uint16_t *src1, const uint8_t *src2, int len)


### PR DESCRIPTION
Removes the `return` from a few `void` functions, as it was causing warnings under `-Wpedantic`:

```
  ./quickjs/quickjs.c:4573:5: warning: void function 'JS_FreeCString' should not return void expression [-Wpedantic]
  ./quickjs/quickjs.c:4578:5: warning: void function 'JS_FreeCStringRT' should not return void expression [-Wpedantic]
  ./quickjs/quickjs.c:4583:5: warning: void function 'JS_FreeCStringUTF16' should not return void expression [-Wpedantic]
  ./quickjs/quickjs.c:4588:5: warning: void function 'JS_FreeCStringRT_UTF16' should not return void expression [-Wpedantic]
```