### PR TITLE
Fix segfault in JS_NewSymbol with NULL description and align with ES semantics

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -962,6 +962,58 @@ static void get_uint8array(void)
     JS_FreeRuntime(rt);
 }
 
+static void new_symbol(void)
+{
+    JSRuntime *rt = JS_NewRuntime();
+    JSContext *ctx = JS_NewContext(rt);
+    JSValue global = JS_GetGlobalObject(ctx);
+    JSValue sym, ret;
+
+    /* Local symbol with NULL description -> Symbol() */
+    sym = JS_NewSymbol(ctx, NULL, false);
+    assert(!JS_IsException(sym));
+    assert(JS_IsSymbol(sym));
+    JS_SetPropertyStr(ctx, global, "sym_local_null", sym);
+
+    ret = eval(ctx, "typeof sym_local_null === 'symbol' && sym_local_null.description === undefined && Symbol.keyFor(sym_local_null) === undefined");
+    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    JS_FreeValue(ctx, ret);
+
+    /* Global symbol with NULL description -> Symbol.for() -> Symbol.for('undefined') */
+    sym = JS_NewSymbol(ctx, NULL, true);
+    assert(!JS_IsException(sym));
+    assert(JS_IsSymbol(sym));
+    JS_SetPropertyStr(ctx, global, "sym_global_null", sym);
+
+    ret = eval(ctx, "typeof sym_global_null === 'symbol' && sym_global_null.description === 'undefined' && Symbol.keyFor(sym_global_null) === 'undefined'");
+    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    JS_FreeValue(ctx, ret);
+
+    /* Local symbol with description -> Symbol('test_local') */
+    sym = JS_NewSymbol(ctx, "test_local", false);
+    assert(!JS_IsException(sym));
+    assert(JS_IsSymbol(sym));
+    JS_SetPropertyStr(ctx, global, "sym_local_str", sym);
+
+    ret = eval(ctx, "sym_local_str.description === 'test_local' && Symbol.keyFor(sym_local_str) === undefined");
+    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    JS_FreeValue(ctx, ret);
+
+    /* Global symbol with description -> Symbol.for('test_global') */
+    sym = JS_NewSymbol(ctx, "test_global", true);
+    assert(!JS_IsException(sym));
+    assert(JS_IsSymbol(sym));
+    JS_SetPropertyStr(ctx, global, "sym_global_str", sym);
+
+    ret = eval(ctx, "sym_global_str.description === 'test_global' && Symbol.keyFor(sym_global_str) === 'test_global'");
+    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    JS_FreeValue(ctx, ret);
+
+    JS_FreeValue(ctx, global);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     cfunctions();
@@ -981,5 +1033,6 @@ int main(void)
     slice_string_tocstring();
     immutable_array_buffer();
     get_uint8array();
+    new_symbol();
     return 0;
 }

--- a/api-test.c
+++ b/api-test.c
@@ -976,7 +976,8 @@ static void new_symbol(void)
     JS_SetPropertyStr(ctx, global, "sym_local_null", sym);
 
     ret = eval(ctx, "typeof sym_local_null === 'symbol' && sym_local_null.description === undefined && Symbol.keyFor(sym_local_null) === undefined");
-    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    assert(JS_IsBool(ret));
+    assert(JS_VALUE_GET_BOOL(ret));
     JS_FreeValue(ctx, ret);
 
     /* Global symbol with NULL description -> Symbol.for() -> Symbol.for('undefined') */
@@ -986,7 +987,8 @@ static void new_symbol(void)
     JS_SetPropertyStr(ctx, global, "sym_global_null", sym);
 
     ret = eval(ctx, "typeof sym_global_null === 'symbol' && sym_global_null.description === 'undefined' && Symbol.keyFor(sym_global_null) === 'undefined'");
-    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    assert(JS_IsBool(ret));
+    assert(JS_VALUE_GET_BOOL(ret));
     JS_FreeValue(ctx, ret);
 
     /* Local symbol with description -> Symbol('test_local') */
@@ -996,7 +998,8 @@ static void new_symbol(void)
     JS_SetPropertyStr(ctx, global, "sym_local_str", sym);
 
     ret = eval(ctx, "sym_local_str.description === 'test_local' && Symbol.keyFor(sym_local_str) === undefined");
-    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    assert(JS_IsBool(ret));
+    assert(JS_VALUE_GET_BOOL(ret));
     JS_FreeValue(ctx, ret);
 
     /* Global symbol with description -> Symbol.for('test_global') */
@@ -1006,7 +1009,8 @@ static void new_symbol(void)
     JS_SetPropertyStr(ctx, global, "sym_global_str", sym);
 
     ret = eval(ctx, "sym_global_str.description === 'test_global' && Symbol.keyFor(sym_global_str) === 'test_global'");
-    assert(JS_IsBool(ret) && JS_VALUE_GET_BOOL(ret));
+    assert(JS_IsBool(ret));
+    assert(JS_VALUE_GET_BOOL(ret));
     JS_FreeValue(ctx, ret);
 
     JS_FreeValue(ctx, global);

--- a/quickjs.c
+++ b/quickjs.c
@@ -3404,6 +3404,15 @@ static JSValue JS_NewSymbolFromAtom(JSContext *ctx, JSAtom descr,
 /* `description` may be pure ASCII or UTF-8 encoded */
 JSValue JS_NewSymbol(JSContext *ctx, const char *description, bool is_global)
 {
+    if (description == NULL) {
+        if (!is_global) {
+            /* Local symbol without description: Symbol() */
+            return JS_NewSymbolInternal(ctx, NULL, JS_ATOM_TYPE_SYMBOL);
+        }
+        /* Global symbol without description: Symbol.for() 
+           Per ES spec, ToString(undefined) becomes "undefined" */
+        description = "undefined";    
+    }
     JSAtom atom = JS_NewAtom(ctx, description);
     if (atom == JS_ATOM_NULL)
         return JS_EXCEPTION;


### PR DESCRIPTION
Currently, calling `JS_NewSymbol(ctx, NULL, false)` triggers a segmentation fault because `JS_NewAtom` unconditionally calls `strlen()` on the `description`.

This PR fixes the crash and aligns the C-API with ECMAScript semantics:
1. **Local Symbols (`is_global = false`)**: Passing `NULL` now creates a description-less Symbol (equivalent to `Symbol()`), correctly utilizing the internal sentinel `JS_NewSymbolInternal(ctx, NULL, ...)`.
2. **Global Symbols (`is_global = true`)**: Passing `NULL` now mimics `Symbol.for()`. Per the [ES specification](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.for), `Symbol.for()` coerces `undefined` to the string `"undefined"`. We fallback the `NULL` pointer to `"undefined"`, avoiding any artificial C-level `TypeError` exceptions.

This makes `JS_NewSymbol` completely safe to use with optional C strings.