### PR TITLE
Fix atom leak in JS_NewSymbol

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -3415,7 +3415,9 @@ JSValue JS_NewSymbol(JSContext *ctx, const char *description, bool is_global)
     JSAtom atom = JS_NewAtom(ctx, description);
     if (atom == JS_ATOM_NULL)
         return JS_EXCEPTION;
-    return JS_NewSymbolFromAtom(ctx, atom, is_global ? JS_ATOM_TYPE_GLOBAL_SYMBOL : JS_ATOM_TYPE_SYMBOL);
+    JSValue symbol = JS_NewSymbolFromAtom(ctx, atom, is_global ? JS_ATOM_TYPE_GLOBAL_SYMBOL : JS_ATOM_TYPE_SYMBOL);
+    JS_FreeAtom(ctx, atom);
+    return symbol;
 }
 
 #define ATOM_GET_STR_BUF_SIZE 64


### PR DESCRIPTION
**This leak was introduced in commit 4a66289 when the public `JS_NewSymbol` API was first added.** The function calls `JS_NewAtom` to create an atom from the description string, but never calls `JS_FreeAtom` after passing it to `JS_NewSymbolFromAtom`. This results in the atom's reference count never reaching zero, leaking memory for every symbol created via this C API.