### PR TITLE
Fix atom leak in JS_NewSymbol

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -7,6 +7,15 @@
 #include "quickjs.h"
 #include "cutils.h"
 
+static JSRuntime *new_runtime(void)
+{
+    JSRuntime *rt = JS_NewRuntime();
+
+    if (rt)
+        JS_SetDumpFlags(rt, JS_ABORT_ON_LEAKS);
+    return rt;
+}
+
 static JSValue eval(JSContext *ctx, const char *code)
 {
     return JS_Eval(ctx, code, strlen(code), "<input>", JS_EVAL_TYPE_GLOBAL);
@@ -46,7 +55,7 @@ static void cfunctions(void)
     const char *s;
     JSValue ret, stack;
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     JSValue cfunc = JS_NewCFunction(ctx, cfunc_callback, "cfunc", 42);
     JSValue cfuncdata =
@@ -179,7 +188,7 @@ static void sync_call(void)
     } catch (e) {} \
 })();";
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     int time = 0;
     JS_SetInterruptHandler(rt, timeout_interrupt_handler, &time);
@@ -206,7 +215,7 @@ static void async_call(void)
     await loop().catch(() => {}); \
 })();";
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     int time = 0;
     JS_SetInterruptHandler(rt, timeout_interrupt_handler, &time);
@@ -250,7 +259,7 @@ static void async_call_stack_overflow(void)
     } \
 })();";
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     JSValue value = JS_UNDEFINED;
     JS_SetContextOpaque(ctx, &value);
@@ -276,7 +285,7 @@ static void async_call_stack_overflow(void)
 // https://github.com/quickjs-ng/quickjs/issues/914
 static void raw_context_global_var(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContextRaw(rt);
     JS_AddIntrinsicEval(ctx);
     {
@@ -300,7 +309,7 @@ static void raw_context_global_var(void)
 
 static void is_array(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     {
         JSValue ret = eval(ctx, "[]");
@@ -347,7 +356,7 @@ static JSModuleDef *loader(JSContext *ctx, const char *name, void *opaque)
 
 static void module_serde(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     //JS_SetDumpFlags(rt, JS_DUMP_MODULE_RESOLVE);
     JS_SetModuleLoaderFunc(rt, NULL, loader, NULL);
     JSContext *ctx = JS_NewContext(rt);
@@ -384,7 +393,7 @@ static void module_serde(void)
 
 static void runtime_cstring_free(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     // string -> cstring + JS_FreeCStringRT
     {
@@ -422,7 +431,7 @@ static void runtime_cstring_free(void)
 
 static void utf16_string(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     {
         JSValue v = JS_NewStringUTF16(ctx, NULL, 0);
@@ -493,7 +502,7 @@ function addItem() { \
 }";
     static const char test_code[] = "addItem()";
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
 
     JSValue ret = eval(ctx, init_code);
@@ -549,7 +558,7 @@ static void promise_hook(void)
 {
     int *cc = promise_hook_state.hook_type_call_count;
     JSContext *unused;
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     //JS_SetDumpFlags(rt, JS_DUMP_PROMISE);
     JS_SetPromiseHook(rt, promise_hook_cb, &promise_hook_state);
     JSContext *ctx = JS_NewContext(rt);
@@ -693,7 +702,7 @@ static void dump_memory_usage(void)
     JSRuntime *rt = NULL;
     JSContext *ctx = NULL;
 
-    rt = JS_NewRuntime();
+    rt = new_runtime();
     ctx = JS_NewContext(rt);
 
     //JS_SetDumpFlags(rt, JS_DUMP_PROMISE);
@@ -734,7 +743,7 @@ static void new_errors(void)
     };
     const Entry *e;
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     for (e = entries; e < endof(entries); e++) {
         JSValue obj = (*e->func)(ctx, "the %s", "needle");
@@ -788,7 +797,7 @@ static void global_object_prototype(void)
     int res;
 
     {
-        rt = JS_NewRuntime();
+        rt = new_runtime();
         ctx = JS_NewContext(rt);
         proto = JS_NewObject(ctx);
         assert(JS_IsObject(proto));
@@ -817,7 +826,7 @@ static void global_object_prototype(void)
             .class_name = "Global Object",
             .exotic = &exotic,
         };
-        rt = JS_NewRuntime();
+        rt = new_runtime();
         class_id = 0;
         JS_NewClassID(rt, &class_id);
         res = JS_NewClass(rt, class_id, &def);
@@ -845,7 +854,7 @@ static void global_object_prototype(void)
 // https://github.com/quickjs-ng/quickjs/issues/1178
 static void slice_string_tocstring(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     JSValue ret = eval(ctx, "'.'.repeat(16384).slice(1, -1)");
     assert(!JS_IsException(ret));
@@ -865,7 +874,7 @@ static void immutable_array_buffer(void)
     char buf[96];
     int i, v;
 
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     for (i = 0; i < 2; i++) {
         obj = JS_NewObject(ctx);
@@ -907,7 +916,7 @@ static void immutable_array_buffer(void)
 
 static void get_uint8array(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     JSValue val;
     uint8_t *p;
@@ -964,7 +973,7 @@ static void get_uint8array(void)
 
 static void new_symbol(void)
 {
-    JSRuntime *rt = JS_NewRuntime();
+    JSRuntime *rt = new_runtime();
     JSContext *ctx = JS_NewContext(rt);
     JSValue global = JS_GetGlobalObject(ctx);
     JSValue sym, ret;

--- a/quickjs.c
+++ b/quickjs.c
@@ -2265,6 +2265,7 @@ void JS_SetRuntimeInfo(JSRuntime *rt, const char *s)
 void JS_FreeRuntime(JSRuntime *rt)
 {
     struct list_head *el, *el1;
+    bool leak = false;
     int i;
 
     rt->in_free = true;
@@ -2305,6 +2306,7 @@ void JS_FreeRuntime(JSRuntime *rt)
                     header_done = true;
                 }
                 JS_DumpGCObject(rt, p);
+                leak = true;
             }
         }
 
@@ -2381,6 +2383,7 @@ void JS_FreeRuntime(JSRuntime *rt)
                     } else {
                         printf("\n");
                     }
+                    leak = true;
                 }
             }
         }
@@ -2429,6 +2432,7 @@ void JS_FreeRuntime(JSRuntime *rt)
         }
         if (rt->rt_info)
             printf("\n");
+        leak = true;
     }
 #endif
 
@@ -2448,14 +2452,20 @@ void JS_FreeRuntime(JSRuntime *rt)
             printf("Memory leak: %zd bytes lost in %zd block%s\n",
                    s->malloc_size - sizeof(JSRuntime),
                    s->malloc_count - 1, &"s"[s->malloc_count == 2]);
+            leak = true;
         }
     }
 #endif
+
+    leak &= check_dump_flag(rt, JS_ABORT_ON_LEAKS);
 
     {
         JSMallocState *ms = &rt->malloc_state;
         rt->mf.js_free(ms->opaque, rt);
     }
+
+    if (leak)
+        abort();
 }
 
 JSContext *JS_NewContextRaw(JSRuntime *rt)
@@ -3415,7 +3425,11 @@ JSValue JS_NewSymbol(JSContext *ctx, const char *description, bool is_global)
     JSAtom atom = JS_NewAtom(ctx, description);
     if (atom == JS_ATOM_NULL)
         return JS_EXCEPTION;
-    return JS_NewSymbolFromAtom(ctx, atom, is_global ? JS_ATOM_TYPE_GLOBAL_SYMBOL : JS_ATOM_TYPE_SYMBOL);
+    int atom_type =
+        is_global ? JS_ATOM_TYPE_GLOBAL_SYMBOL : JS_ATOM_TYPE_SYMBOL;
+    JSValue symbol = JS_NewSymbolFromAtom(ctx, atom, atom_type);
+    JS_FreeAtom(ctx, atom);
+    return symbol;
 }
 
 #define ATOM_GET_STR_BUF_SIZE 64

--- a/quickjs.h
+++ b/quickjs.h
@@ -499,6 +499,7 @@ typedef struct JSMallocFunctions {
 #define JS_DUMP_OBJECTS       0x20000  /* dump objects in JS_FreeRuntime */
 #define JS_DUMP_ATOMS         0x40000  /* dump atoms in JS_FreeRuntime */
 #define JS_DUMP_SHAPES        0x80000  /* dump shapes in JS_FreeRuntime */
+#define JS_ABORT_ON_LEAKS    0x10C000  /* abort on atom/object/string leaks; for testing */
 
 // Finalizers run in LIFO order at the very end of JS_FreeRuntime.
 // Intended for cleanup of associated resources; the runtime itself


### PR DESCRIPTION
Add a new JS_ABORT_ON_LEAKS flag for use in api-test.c to help catch regressions.