### PR TITLE
Fix receiver extensibility checks in property sets

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -10236,12 +10236,11 @@ retry:
         goto done;
     }
 
-    if (unlikely(!p->extensible)) {
-        ret = JS_ThrowTypeErrorOrFalse(ctx, flags, "object is not extensible");
-        goto done;
-    }
-
     if (p == JS_VALUE_GET_OBJ(obj)) {
+        if (unlikely(!p->extensible)) {
+            ret = JS_ThrowTypeErrorOrFalse(ctx, flags, "object is not extensible");
+            goto done;
+        }
         if (p->is_exotic) {
             if (p->class_id == JS_CLASS_ARRAY && p->fast_array &&
                 __JS_AtomIsTaggedInt(prop)) {
@@ -10282,6 +10281,10 @@ retry:
                                 JS_UNDEFINED, JS_UNDEFINED,
                                 JS_PROP_HAS_VALUE);
     } else {
+        if (unlikely(!p->extensible)) {
+            ret = JS_ThrowTypeErrorOrFalse(ctx, flags, "object is not extensible");
+            goto done;
+        }
     generic_create_prop:
         ret = JS_CreateProperty(ctx, p, prop, val, JS_UNDEFINED, JS_UNDEFINED,
                                 flags |

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -82,7 +82,6 @@ test262/test/language/module-code/ambiguous-export-bindings/import-and-export-pr
 test262/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-export-star-as-from-and-import-star-as-and-export.js:74: SyntaxError: export 'foo' in module 'test262/test/language/module-code/ambiguous-export-bindings/nam' is ambiguous
 test262/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-export-star-as-from.js:75: SyntaxError: export 'foo' in module 'test262/test/language/module-code/ambiguous-export-bindings/nam' is ambiguous
 test262/test/language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-star-as-and-export.js:74: SyntaxError: export 'foo' in module 'test262/test/language/module-code/ambiguous-export-bindings/nam' is ambiguous
-test262/test/language/module-code/namespace/internals/super-access-to-tdz-binding.js:32: Test262Error: Expected a ReferenceError but got a TypeError
 test262/test/language/module-code/top-level-await/module-graphs-does-not-hang.js:10: TypeError: $DONE() not called
 test262/test/language/module-code/top-level-await/rejection-order.js:20: TypeError: $DONE() not called
 test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js:40: SyntaxError: invalid property name

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -227,34 +227,6 @@ function test_enum()
     assert(tab, ["1","4294967294","x","18014398509481984","9007199254740992","9007199254740991","4294967296","4294967295","y"], "keys");
 }
 
-function test_non_extensible_receiver_existing_property_set()
-{
-    var proto, receiver, ret;
-
-    proto = { x: 1 };
-    receiver = { x: 0 };
-    Object.preventExtensions(receiver);
-    ret = Reflect.set(proto, "x", 2, receiver);
-    assert(ret, true, "non-extensible receiver existing property Reflect.set result");
-    assert(receiver.x, 2, "non-extensible receiver existing property Reflect.set value");
-
-    class A {
-    }
-    A.prototype.x = 1;
-
-    class B extends A {
-        setX(value) {
-            super.x = value;
-        }
-    }
-
-    receiver = new B();
-    receiver.x = 0;
-    Object.preventExtensions(receiver);
-    receiver.setX(3);
-    assert(receiver.x, 3, "non-extensible receiver existing property super set value");
-}
-
 function test_array()
 {
     var a, err;
@@ -1314,7 +1286,6 @@ function test_cur_pc()
 test();
 test_function();
 test_enum();
-test_non_extensible_receiver_existing_property_set();
 test_array();
 test_string();
 test_rope();

--- a/tests/test_builtin.js
+++ b/tests/test_builtin.js
@@ -227,6 +227,34 @@ function test_enum()
     assert(tab, ["1","4294967294","x","18014398509481984","9007199254740992","9007199254740991","4294967296","4294967295","y"], "keys");
 }
 
+function test_non_extensible_receiver_existing_property_set()
+{
+    var proto, receiver, ret;
+
+    proto = { x: 1 };
+    receiver = { x: 0 };
+    Object.preventExtensions(receiver);
+    ret = Reflect.set(proto, "x", 2, receiver);
+    assert(ret, true, "non-extensible receiver existing property Reflect.set result");
+    assert(receiver.x, 2, "non-extensible receiver existing property Reflect.set value");
+
+    class A {
+    }
+    A.prototype.x = 1;
+
+    class B extends A {
+        setX(value) {
+            super.x = value;
+        }
+    }
+
+    receiver = new B();
+    receiver.x = 0;
+    Object.preventExtensions(receiver);
+    receiver.setX(3);
+    assert(receiver.x, 3, "non-extensible receiver existing property super set value");
+}
+
 function test_array()
 {
     var a, err;
@@ -1286,6 +1314,7 @@ function test_cur_pc()
 test();
 test_function();
 test_enum();
+test_non_extensible_receiver_existing_property_set();
 test_array();
 test_string();
 test_rope();

--- a/tests/test_language.js
+++ b/tests/test_language.js
@@ -735,6 +735,34 @@ function test_parse_semicolon()
     }
 }
 
+function test_non_extensible_receiver_existing_property_set()
+{
+    var proto, receiver, ret;
+
+    proto = { x: 1 };
+    receiver = { x: 0 };
+    Object.preventExtensions(receiver);
+    ret = Reflect.set(proto, "x", 2, receiver);
+    assert(ret, true, "non-extensible receiver existing property Reflect.set result");
+    assert(receiver.x, 2, "non-extensible receiver existing property Reflect.set value");
+
+    class A {
+    }
+    A.prototype.x = 1;
+
+    class B extends A {
+        setX(value) {
+            super.x = value;
+        }
+    }
+
+    receiver = new B();
+    receiver.x = 0;
+    Object.preventExtensions(receiver);
+    receiver.setX(3);
+    assert(receiver.x, 3, "non-extensible receiver existing property super set value");
+}
+
 test_op1();
 test_cvt();
 test_eq();
@@ -760,3 +788,4 @@ test_number_literals();
 test_syntax();
 test_optional_chaining();
 test_parse_semicolon();
+test_non_extensible_receiver_existing_property_set();


### PR DESCRIPTION
This PR fixes property assignment by delaying the receiver extensibility check until the assignment would create a new own property.

This fixes two issues:

1. It preserves TDZ ReferenceError precedence for module namespace super assignment.
2. It matches ES semantics: a non-extensible receiver can still update an existing writable own property.