### PR TITLE
max_uint32 substitution is the minimal patch for an introduced fix to…

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -42476,7 +42476,7 @@ static JSValue js_array_push(JSContext *ctx, JSValueConst this_val,
                         p->u.array.u.values[array_len + i] = js_dup(argv[i]);
                     }
                     p->u.array.count = new_len;
-                    p->prop[0].u.value = js_int32(new_len);
+                    p->prop[0].u.value = js_uint32(new_len);
                     return js_int32(new_len);
                 }
             }

--- a/quickjs.c
+++ b/quickjs.c
@@ -9980,9 +9980,14 @@ static int expand_fast_array(JSContext *ctx, JSObject *p, uint32_t new_len)
     size_t slack;
     JSValue *new_array_prop;
 
+    if (unlikely(new_len > (uint32_t)INT32_MAX)) {
+        JS_ThrowOutOfMemory(ctx);
+        return -1;
+    }
+
     old_size = p->u.array.u1.size;
-    new_size = old_size + old_size/2;   // grow by 50%
-    if (new_size < old_size) {          // integer overflow
+    new_size = old_size + old_size/2;
+    if (new_size < old_size) {  {
         JS_ThrowOutOfMemory(ctx);
         return -1;
     }
@@ -42467,6 +42472,7 @@ static JSValue js_array_push(JSContext *ctx, JSValueConst this_val,
                        (p->shape->prop->flags & JS_PROP_WRITABLE))) {
                 array_len = JS_VALUE_GET_INT(p->prop[0].u.value);
                 new_len = array_len + argc;
+                if (likely(new_len >= array_len && new_len <= (uint32_t)INT32_MAX)) { /* no overflow and within fast-array bounds *///
                 if (likely(new_len >= array_len)) { /* no overflow */
                     if (unlikely(new_len > p->u.array.u1.size)) {
                         if (expand_fast_array(ctx, p, new_len))

--- a/quickjs.c
+++ b/quickjs.c
@@ -9987,7 +9987,7 @@ static int expand_fast_array(JSContext *ctx, JSObject *p, uint32_t new_len)
 
     old_size = p->u.array.u1.size;
     new_size = old_size + old_size/2;
-    if (new_size < old_size)  {
+    if (new_size < old_size) {
         JS_ThrowOutOfMemory(ctx);
         return -1;
     }

--- a/quickjs.c
+++ b/quickjs.c
@@ -6483,7 +6483,7 @@ static void free_var_ref(JSRuntime *rt, JSVarRef *var_ref)
 static void js_array_finalizer(JSRuntime *rt, JSValueConst val)
 {
     JSObject *p = JS_VALUE_GET_OBJ(val);
-    int i;
+    uint32_t i;
 
     for(i = 0; i < p->u.array.count; i++) {
         JS_FreeValueRT(rt, p->u.array.u.values[i]);

--- a/quickjs.c
+++ b/quickjs.c
@@ -6495,7 +6495,7 @@ static void js_array_mark(JSRuntime *rt, JSValueConst val,
                           JS_MarkFunc *mark_func)
 {
     JSObject *p = JS_VALUE_GET_OBJ(val);
-    int i;
+    uint32_t i;
 
     for(i = 0; i < p->u.array.count; i++) {
         JS_MarkValue(rt, p->u.array.u.values[i], mark_func);

--- a/quickjs.c
+++ b/quickjs.c
@@ -9986,7 +9986,7 @@ static int expand_fast_array(JSContext *ctx, JSObject *p, uint32_t new_len)
         JS_ThrowOutOfMemory(ctx);
         return -1;
     }
-    new_size = max_int(new_len, new_size);
+    new_size = max_uint32(new_len, new_size);
     new_array_prop = js_realloc2(ctx, p->u.array.u.values, sizeof(JSValue) * new_size, &slack);
     if (!new_array_prop)
         return -1;

--- a/quickjs.c
+++ b/quickjs.c
@@ -9987,7 +9987,7 @@ static int expand_fast_array(JSContext *ctx, JSObject *p, uint32_t new_len)
 
     old_size = p->u.array.u1.size;
     new_size = old_size + old_size/2;
-    if (new_size < old_size) {  {
+    if (new_size < old_size)  {
         JS_ThrowOutOfMemory(ctx);
         return -1;
     }
@@ -42472,8 +42472,7 @@ static JSValue js_array_push(JSContext *ctx, JSValueConst this_val,
                        (p->shape->prop->flags & JS_PROP_WRITABLE))) {
                 array_len = JS_VALUE_GET_INT(p->prop[0].u.value);
                 new_len = array_len + argc;
-                if (likely(new_len >= array_len && new_len <= (uint32_t)INT32_MAX)) { /* no overflow and within fast-array bounds *///
-                if (likely(new_len >= array_len)) { /* no overflow */
+                if (likely(new_len >= array_len && new_len <= (uint32_t)INT32_MAX)) { /* no overflow and within fast-array bounds */
                     if (unlikely(new_len > p->u.array.u1.size)) {
                         if (expand_fast_array(ctx, p, new_len))
                             return JS_EXCEPTION;

--- a/tests/bug1468.js
+++ b/tests/bug1468.js
@@ -1,4 +1,3 @@
-// QuickJS expand_fast_array max_int sign truncation — commit 40e197f
 // Bug: expand_fast_array calls max_int(new_len, new_size) where new_len is uint32_t.
 //      When new_len >= 0x80000000, cast to int makes it negative.
 //      max_int returns the small grow-by-50% size. Buffer is underallocated.

--- a/tests/expand_fast_array_maxint_poc.js
+++ b/tests/expand_fast_array_maxint_poc.js
@@ -9,17 +9,18 @@
 //
 // Run: qjs poc_test_fixed.js
 // Expected output: PASS: got graceful error: ...
-
 const arr = [1, 2, 3];
-arr.length = 0x7FFFFFFF;  // sets length property, no memory allocated
+arr.length = 0x7FFFFFFF;
 
 try {
-    arr.push(4);  // triggers expand_fast_array with new_len=0x80000000
-    throw new Error("FAIL: expected InternalError or RangeError was not thrown");
-} catch(e) {
-    if (e instanceof InternalError || e instanceof RangeError) {
+    const result = arr.push(4);
+    // Succeeded via slow array path — no crash, no heap corruption                                                                
+    print("PASS: push completed without crash, result:", result);
+
+} catch(e) {                   
+    if (e instanceof InternalError || e instanceof RangeError || e instanceof TypeError) {
         print("PASS: got graceful error:", e.message);
-    } else {
-        throw e;  // unexpected error type — re-throw to fail the test
-    }
+  } else {
+      throw e;  // unexpected — re-throw                      
+  }
 }

--- a/tests/expand_fast_array_maxint_poc.js
+++ b/tests/expand_fast_array_maxint_poc.js
@@ -3,10 +3,23 @@
 //      When new_len >= 0x80000000, cast to int makes it negative.
 //      max_int returns the small grow-by-50% size. Buffer is underallocated.
 //      add_fast_array_element then writes to values[new_len-1] — OOB write.
-// Run: qjs poc.js
+//
+// Pre-fix behavior: process crashes with SIGBUS (OOB write to unmapped memory)
+// Post-fix behavior: InternalError or RangeError thrown and caught cleanly
+//
+// Run: qjs poc_test_fixed.js
+// Expected output: PASS: got graceful error: ...
 
-const c = [1, 2, 3];
-c.length = 0x7FFFFFFF;  // sets length property; count stays 3
-c.push(4);              // new_len = count+1; if > size, expand_fast_array called
-                        // sign truncation: max_int underallocates; OOB write follows
-print("done");
+const arr = [1, 2, 3];
+arr.length = 0x7FFFFFFF;  // sets length property, no memory allocated
+
+try {
+    arr.push(4);  // triggers expand_fast_array with new_len=0x80000000
+    throw new Error("FAIL: expected InternalError or RangeError was not thrown");
+} catch(e) {
+    if (e instanceof InternalError || e instanceof RangeError) {
+        print("PASS: got graceful error:", e.message);
+    } else {
+        throw e;  // unexpected error type — re-throw to fail the test
+    }
+}

--- a/tests/expand_fast_array_maxint_poc.js
+++ b/tests/expand_fast_array_maxint_poc.js
@@ -1,0 +1,12 @@
+// QuickJS expand_fast_array max_int sign truncation — commit 40e197f
+// Bug: expand_fast_array calls max_int(new_len, new_size) where new_len is uint32_t.
+//      When new_len >= 0x80000000, cast to int makes it negative.
+//      max_int returns the small grow-by-50% size. Buffer is underallocated.
+//      add_fast_array_element then writes to values[new_len-1] — OOB write.
+// Run: qjs poc.js
+
+const c = [1, 2, 3];
+c.length = 0x7FFFFFFF;  // sets length property; count stays 3
+c.push(4);              // new_len = count+1; if > size, expand_fast_array called
+                        // sign truncation: max_int underallocates; OOB write follows
+print("done");


### PR DESCRIPTION
- bug introduced by 40e197f
- Address GHSA-mc32-gh5c-8v82 

Long term solution is the slow-array conversion is the semantically correct fix for supporting arrays with more than 2^31 elements.