### PR TITLE
fix: heap-use-after-free in build_backtrace when dbuf OOM frees current_exception

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -765,6 +765,37 @@ static void new_errors(void)
     JS_FreeRuntime(rt);
 }
 
+static void backtrace_oom_current_exception(void)
+{
+    static const char setup_code[] =
+        "globalThis.f = function() { missing; };\n"
+        "Object.defineProperty(f, 'name', { value: 'x'.repeat(2 * 1024 * 1024) });";
+    JSMemoryUsage stats;
+    JSValue ret, exception;
+    JSRuntime *rt;
+    JSContext *ctx;
+
+    rt = new_runtime();
+    ctx = JS_NewContext(rt);
+
+    ret = eval(ctx, setup_code);
+    assert(!JS_IsException(ret));
+    JS_FreeValue(ctx, ret);
+
+    JS_ComputeMemoryUsage(rt, &stats);
+    JS_SetMemoryLimit(rt, (size_t)stats.malloc_size + 128 * 1024);
+
+    ret = eval(ctx, "f()");
+    assert(JS_IsException(ret));
+    assert(JS_HasException(ctx));
+    exception = JS_GetException(ctx);
+    JS_FreeValue(ctx, exception);
+    JS_SetMemoryLimit(rt, 0);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 static int gop_get_own_property(JSContext *ctx, JSPropertyDescriptor *desc,
                                 JSValueConst obj, JSAtom prop)
 {
@@ -1042,6 +1073,7 @@ int main(void)
     promise_hook();
     dump_memory_usage();
     new_errors();
+    backtrace_oom_current_exception();
     global_object_prototype();
     slice_string_tocstring();
     immutable_array_buffer();

--- a/quickjs.c
+++ b/quickjs.c
@@ -7743,7 +7743,7 @@ static void build_backtrace(JSContext *ctx, JSValueConst error_val,
                             int line_num, int col_num, int backtrace_flags)
 {
     JSStackFrame *sf, *sf_start;
-    JSValue stack, prepare, saved_exception;
+    JSValue stack, prepare, saved_exception, error_obj;
     DynBuf dbuf;
     const char *func_name_str;
     const char *str1;
@@ -7760,6 +7760,7 @@ static void build_backtrace(JSContext *ctx, JSValueConst error_val,
     if (rt->in_build_stack_trace)
         return;
     rt->in_build_stack_trace = true;
+    error_obj = JS_DupValue(ctx, error_val);
 
     // Save exception because conversion to double may fail.
     saved_exception = JS_GetException(ctx);
@@ -7905,7 +7906,7 @@ static void build_backtrace(JSContext *ctx, JSValueConst error_val,
             JS_FreeValue(ctx, csd[k].func_name);
         }
         JSValueConst args[] = {
-            error_val,
+            error_obj,
             stack,
         };
         JSValue stack2 = JS_Call(ctx, prepare, ctx->error_ctor, countof(args), args);
@@ -7926,13 +7927,14 @@ static void build_backtrace(JSContext *ctx, JSValueConst error_val,
 
     if (JS_IsUndefined(ctx->error_back_trace))
         ctx->error_back_trace = js_dup(stack);
-    if (has_filter_func || can_add_backtrace(error_val)) {
-        JS_DefinePropertyValue(ctx, error_val, JS_ATOM_stack, stack,
+    if (has_filter_func || can_add_backtrace(error_obj)) {
+        JS_DefinePropertyValue(ctx, error_obj, JS_ATOM_stack, stack,
                                JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
     } else {
         JS_FreeValue(ctx, stack);
     }
 
+    JS_FreeValue(ctx, error_obj);
     rt->in_build_stack_trace = false;
 }
 


### PR DESCRIPTION
## Summary

If `JS_NewError` during `build_backtrace` triggered dbuf OOM, the OOM path freed the current exception (which is `error_val` on the caller's stack), then `build_backtrace` kept using the dangling `error_val` for both the `prepareStackTrace` call and the `JS_DefinePropertyValue` of the `stack` property. Fix is to duplicate `error_val` into a local `error_obj`, use that throughout the function, and free it at exit.

## Why this matters

ASan flags this as a clean heap-use-after-free with a small repro that exercises `Error.prepareStackTrace` under low-memory conditions. The `rt->in_build_stack_trace` guard prevents recursion but not the freed-pointer reuse, since the free happens via `JS_ThrowOutOfMemory` -> exception slot replacement, not via recursion.

## Changes

- `quickjs.c` - add `JSValue error_obj = JS_DupValue(ctx, error_val)` at function entry, use `error_obj` for the two remaining references after the dbuf-can-fail region, free at exit.
- `api-test.c` - add a regression test that constructs the OOM scenario and walks the backtrace path.

## Testing

`make all && ./run-test262 -c tests/test262.conf` clean. ASan build with the new api-test passes.

Fixes #1469
