### PR TITLE
fix(libc): correct transient-errno predicate in js_waker_signal

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -2640,7 +2640,7 @@ static void js_waker_signal(JSWaker *w)
         ret = write(w->write_fd, "", 1);
         if (ret == 1)
             break;
-        if (ret < 0 && (errno != EAGAIN || errno != EINTR))
+        if (ret < 0 && errno != EAGAIN && errno != EINTR)
             break;
     }
 }


### PR DESCRIPTION
The retry loop in js_waker_signal used `errno != EAGAIN || errno != EINTR`, which is always true (any single errno value is unequal to at least one of the two), so the loop bailed on the first short-write error and silently dropped the wakeup. Replace with `&&` so the loop only exits on a fatal errno.

No test: js_waker_signal's transient-error path is reached only when the pipe is full or the syscall is interrupted by a signal, neither of which is reliably reproducible in a portable unit test.