### PR TITLE
fix(run-test262): bounds-check optind before argv[optind] for -N

### DIFF
--- a/run-test262.c
+++ b/run-test262.c
@@ -2239,6 +2239,8 @@ int main(int argc, char **argv)
         help();
 
     if (is_test262_harness) {
+        if (optind >= argc)
+            fatal(2, "missing test file argument for -N");
         return run_test262_harness_test(tls, argv[optind], is_module, can_block);
     }
 


### PR DESCRIPTION
Running `run-test262 -c <conf> -N` without a trailing test file argument passed `argv[optind]` to `run_test262_harness_test` → `fopen()` with `argv[argc]` being NULL on POSIX (uninitialised on some libcs), yielding a "Bad address" error or, on platforms that don't NULL-terminate argv, an out-of-bounds read.

Reject the missing argument explicitly with `fatal()`.

Manual repro before the fix:

    $ build/run-test262 -c tests.conf -N
    run-test262: Bad address     # NULL fopen
    exit code 1

After:

    $ build/run-test262 -c tests.conf -N
    run-test262: missing test file argument for -N
    exit code 2