### PR TITLE
fix(cutils): handle vsnprintf encoding error in dbuf_printf

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -846,6 +846,12 @@ static inline int JS_PRINTF_FORMAT_ATTR(2, 3) dbuf_printf(DynBuf *s, JS_PRINTF_F
     va_start(ap, fmt);
     len = vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
+    if (len < 0) {
+        /* vsnprintf encoding error: don't let the caller wrap s->size by
+           advancing it by -1, which would underflow to near SIZE_MAX. */
+        s->error = true;
+        return -1;
+    }
     if (len < (int)sizeof(buf)) {
         /* fast case */
         return dbuf_put(s, (uint8_t *)buf, len);


### PR DESCRIPTION
When vsnprintf returns -1 (encoding error - e.g. an %ls conversion that hits an invalid multibyte sequence), dbuf_printf's slow path advanced s->size by len = -1, wrapping the size_t to ~SIZE_MAX. Subsequent dbuf operations then treated the buffer as essentially unlimited and indexed off the end.

Bail out, flag the buffer as errored, and let callers propagate.

No automated test: dbuf_printf is internal and reaching the vsnprintf encoding-error branch requires either an invalid multibyte input to %ls (locale-dependent and not portable) or a vsnprintf implementation that returns -1 for other reasons. Reviewed by inspection.