### PR TITLE
fix(libc): avoid undefined memcpy in js_worker_postMessage with len==0

### DIFF
--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -4254,7 +4254,10 @@ static JSValue js_worker_postMessage(JSContext *ctx, JSValueConst this_val,
     msg->data = malloc(data_len);
     if (!msg->data)
         goto fail;
-    memcpy(msg->data, data, data_len);
+    /* memcpy with NULL src/dst is UB even when n == 0; the writer side
+       can produce zero-length payloads (e.g. JSON.stringify(undefined)). */
+    if (data_len > 0)
+        memcpy(msg->data, data, data_len);
     msg->data_len = data_len;
 
     if (sab_tab.len > 0) {


### PR DESCRIPTION
memcpy(dst, src, 0) is UB per C11 7.21.1 when either pointer is NULL, even if no bytes are copied — UBSan with -fsanitize=nonnull-attribute flags it and a strict optimiser may exploit the implied non-NULL attribute to elide subsequent NULL checks.

In practice JS_WriteObject2 always emits a non-empty buffer, but make the call site safe by hand so the worker pipe is robust to any future serializer change.

No test: triggering the UB requires data_len == 0 and malloc(0) returning non-NULL, which doesn't happen on the current writer. UBSan in CI would catch a regression.