### PR TITLE
fix(bytecode): reject high-bit-set atom indices in JS_ReadObjectAtoms

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1027,8 +1027,45 @@ static void new_symbol(void)
     JS_FreeRuntime(rt);
 }
 
+/* Feeds JS_ReadObject a hand-crafted bytecode blob whose constant-atom
+   index has the high bit set (0x80000001). Before the fix the reader's
+   __JS_AtomIsConst cast atom to int32_t, so any high-bit-set value
+   compared "negative < JS_ATOM_END" and slipped through, ending up in
+   s->idx_to_atom for later use as a property key. After the fix the
+   reader rejects the blob and JS_ReadObject returns an exception. */
+static void bc_atom_range_check(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+
+    /* BC layout: version, checksum=UINT32_MAX (skips csum check),
+       LEB128 atom_count=1, u8 type=0, u32 atom=0x80000001 (LE),
+       u8 body tag (any; we never reach the body). */
+    const uint8_t blob[] = {
+        /* BC_VERSION   */ 26,
+        /* checksum     */ 0xFF, 0xFF, 0xFF, 0xFF,
+        /* atom_count=1 */ 0x01,
+        /* type=0       */ 0x00,
+        /* atom=0x80000001 little-endian */ 0x01, 0x00, 0x00, 0x80,
+        /* body tag (BC_TAG_NULL) */ 0x01,
+    };
+    JSValue v = JS_ReadObject(ctx, blob, sizeof(blob), 0);
+    assert(JS_IsException(v));
+    JSValue e = JS_GetException(ctx);
+    assert(JS_IsError(e));
+    const char *s = JS_ToCString(ctx, e);
+    assert(s);
+    assert(strstr(s, "out of range atom") != NULL);
+    JS_FreeCString(ctx, s);
+    JS_FreeValue(ctx, e);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
+    bc_atom_range_check();
     cfunctions();
     sync_call();
     async_call();

--- a/quickjs.c
+++ b/quickjs.c
@@ -39665,7 +39665,12 @@ static int JS_ReadObjectAtoms(BCReaderState *s)
         if (type == 0) {
             if (bc_get_u32(s, &atom))
                 return -1;
-            if (!__JS_AtomIsConst(atom)) {
+            /* The previous check was !__JS_AtomIsConst(atom), which casts to
+               int32_t. Any value with the high bit set became negative and
+               compared "less than JS_ATOM_END", letting attacker-controlled
+               atom values (e.g. 0x80000000-0xFFFFFFFF) slip into
+               s->idx_to_atom. Use an unsigned comparison. */
+            if (atom == 0 || atom >= JS_ATOM_END) {
                 JS_ThrowInternalError(s->ctx, "out of range atom");
                 return -1;
             }


### PR DESCRIPTION
The constant-atom validation used __JS_AtomIsConst(atom), defined as ((int32_t)atom < JS_ATOM_END). Atom values with the high bit set became negative as int32_t and compared "less than JS_ATOM_END", slipping past the check and ending up in s->idx_to_atom for later use as property keys / lookup tags.

Use an unsigned comparison: 0 (JS_ATOM_NULL) and >= JS_ATOM_END are both rejected.

Test: api-test now hands JS_ReadObject a hand-crafted bytecode blob whose type-0 atom slot holds 0x80000001. Before the fix the reader accepts the blob and returns a non-exception value; after the fix the reader throws "out of range atom".