### PR TITLE
fix(bytecode): widen function-header offsets to size_t to prevent ove…

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1027,8 +1027,53 @@ static void new_symbol(void)
     JS_FreeRuntime(rt);
 }
 
+/* Feeds JS_ReadObject a hand-crafted bytecode-function blob whose
+   cpool_count is the LEB128 encoding of 0xFFFFFFFF (=-1 as int). Before
+   the fix the reader cast that to int, treated it as negative, and built
+   a tiny allocation while accepting the blob; the resulting JSFunctionBytecode
+   has cpool=NULL with cpool_count=-1 — a corrupt object that escapes to
+   the caller. After the fix the reader rejects the blob outright. */
+static void bc_function_cpool_overflow(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+
+    /* Minimal valid function-bytecode prefix:
+         version, csum-skip, atom_count=0, BC_TAG_FUNCTION_BYTECODE,
+         u16 flags=0, u8 strict=0, atom func_name=builtin atom 1
+         (LEB128 (1<<1)|0 = 0x02),
+         arg/var/defined_arg/stack/var_ref/closure_var counts all 0,
+         cpool_count = 0xFFFFFFFF as LEB128 (5 bytes),
+         byte_code_len=0, local_count=0. */
+    const uint8_t blob[] = {
+        /* BC_VERSION   */ 26,
+        /* checksum     */ 0xFF, 0xFF, 0xFF, 0xFF,
+        /* atom_count=0 */ 0x00,
+        /* tag = BC_TAG_FUNCTION_BYTECODE (12) */ 0x0C,
+        /* flags (u16)  */ 0x00, 0x00,
+        /* is_strict    */ 0x00,
+        /* func_name (LEB128 = builtin atom 1) */ 0x02,
+        /* arg_count    */ 0x00,
+        /* var_count    */ 0x00,
+        /* defined_arg  */ 0x00,
+        /* stack_size   */ 0x00,
+        /* var_ref_count*/ 0x00,
+        /* closure_var  */ 0x00,
+        /* cpool_count = 0xFFFFFFFF (LEB128) */ 0xFF, 0xFF, 0xFF, 0xFF, 0x0F,
+        /* byte_code_len*/ 0x00,
+        /* local_count  */ 0x00,
+    };
+    JSValue v = JS_ReadObject(ctx, blob, sizeof(blob), JS_READ_OBJ_BYTECODE);
+    assert(JS_IsException(v));
+    JS_FreeValue(ctx, JS_GetException(ctx));
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
+    bc_function_cpool_overflow();
     cfunctions();
     sync_call();
     async_call();

--- a/quickjs.c
+++ b/quickjs.c
@@ -38712,7 +38712,7 @@ static uint32_t bc_get_flags(uint32_t flags, int *pidx, int n)
 }
 
 static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
-                                   int byte_code_offset, uint32_t bc_len)
+                                   size_t byte_code_offset, uint32_t bc_len)
 {
     uint8_t *bc_buf;
     int pos, len, op;
@@ -38836,8 +38836,8 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
     uint16_t v16;
     uint8_t v8;
     int idx, i, local_count, has_debug_info;
-    int function_size, cpool_offset, byte_code_offset;
-    int closure_var_offset, vardefs_offset;
+    size_t function_size, cpool_offset, byte_code_offset;
+    size_t closure_var_offset, vardefs_offset;
 
     memset(&bc, 0, sizeof(bc));
     bc.header.ref_count = 1;
@@ -38881,15 +38881,31 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
     if (bc_get_leb128_int(s, &local_count))
         goto fail;
 
+    /* Defence in depth: reject negative or implausibly large counts so the
+       size arithmetic below cannot wrap. Before this guard, an int sum like
+       sizeof(*b) + cpool_count * sizeof(JSValue) would truncate when
+       cpool_count * sizeof(JSValue) exceeded INT_MAX, producing a tiny
+       allocation that subsequent OOB writes to b->cpool / b->vardefs /
+       b->byte_code corrupted. The cap (SIZE_MAX / 16) / sizeof(*field)
+       keeps every per-section size — and the final sum — well within
+       size_t on any supported host. closure_var_count is a uint16_t and
+       cannot overflow the size formula. */
+    if (bc.cpool_count < 0 || bc.byte_code_len < 0 || local_count < 0)
+        goto fail;
+    if ((size_t)bc.cpool_count   > (SIZE_MAX / 16) / sizeof(*bc.cpool) ||
+        (size_t)local_count      > (SIZE_MAX / 16) / sizeof(*bc.vardefs) ||
+        (size_t)bc.byte_code_len > SIZE_MAX / 16)
+        goto fail;
+
     function_size = sizeof(*b);
     cpool_offset = function_size;
-    function_size += bc.cpool_count * sizeof(*bc.cpool);
+    function_size += (size_t)bc.cpool_count * sizeof(*bc.cpool);
     vardefs_offset = function_size;
-    function_size += local_count * sizeof(*bc.vardefs);
+    function_size += (size_t)local_count * sizeof(*bc.vardefs);
     closure_var_offset = function_size;
-    function_size += bc.closure_var_count * sizeof(*bc.closure_var);
+    function_size += (size_t)bc.closure_var_count * sizeof(*bc.closure_var);
     byte_code_offset = function_size;
-    function_size += bc.byte_code_len;
+    function_size += (size_t)bc.byte_code_len;
 
     b = js_mallocz(ctx, function_size);
     if (!b)


### PR DESCRIPTION
…rflow

JS_ReadFunctionTag computed the per-section offsets and the final allocation size in `int`:

    int function_size = sizeof(*b);
    function_size += bc.cpool_count * sizeof(*bc.cpool);
    ...
    b = js_mallocz(ctx, function_size);

A bytecode blob with cpool_count = 0x10000000 made the partial product 0x100000000 overflow to 0 in the int sum (or wrap to a small value), producing a tiny allocation. Subsequent writes through b->cpool, b->vardefs, and b->byte_code then corrupted adjacent heap chunks.

Switch function_size and the per-section offsets to size_t, reject negative counts explicitly, cap each section at SIZE_MAX/16 (which also keeps the final sum within size_t on any supported host), and cast each partial product to size_t.

JS_ReadFunctionBytecode's byte_code_offset parameter is widened to size_t to match.

Test: api-test now hands JS_ReadObject a hand-crafted function blob with cpool_count = 0xFFFFFFFF (LEB128). Before the fix this triggers heap corruption — glibc's malloc consistency check aborts the process:

    Fatal glibc error: malloc.c:2599 (sysmalloc): assertion failed: ...

After the fix the reader rejects the blob and returns an exception cleanly.