### PR TITLE
fix(bytecode): initialise rme->attributes to JS_UNDEFINED in JS_ReadM…

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1027,8 +1027,62 @@ static void new_symbol(void)
     JS_FreeRuntime(rt);
 }
 
+/* Records the import-attributes value passed to a module loader installed
+   via JS_SetModuleLoaderFunc2. JS_ReadModule must hand the loader
+   JS_UNDEFINED for entries that the writer didn't decorate with
+   attributes; before the fix the slot was zero-initialised by js_mallocz,
+   which yields JS_MKVAL(JS_TAG_INT, 0) — a numeric zero — not
+   JS_UNDEFINED. */
+static int bc_module_attrs_recorded_tag = -42;
+
+static JSModuleDef *bc_module_attrs_loader(JSContext *ctx, const char *name,
+                                           void *opaque, JSValueConst attrs)
+{
+    bc_module_attrs_recorded_tag = JS_VALUE_GET_TAG(attrs);
+    /* Returning NULL aborts the JS_ReadObject. We only needed to record
+       what the loader saw. */
+    return NULL;
+}
+
+static void bc_module_attributes_init(void)
+{
+    JSRuntime *rt = new_runtime();
+    JS_SetModuleLoaderFunc2(rt, /*normalize*/NULL, bc_module_attrs_loader,
+                            /*check_attrs*/NULL, /*opaque*/NULL);
+    JSContext *ctx = JS_NewContext(rt);
+
+    /* The outer module is named with builtin atom JS_ATOM_false ("false")
+       and the imported entry uses builtin atom JS_ATOM_true ("true") so
+       js_find_loaded_module's cache lookup for the imported name does
+       NOT collide with the outer module's name (an empty atom or matching
+       name would resolve to the outer module itself and the loader would
+       never be called). */
+    const uint8_t blob[] = {
+        /* BC_VERSION   */ 26,
+        /* checksum     */ 0xFF, 0xFF, 0xFF, 0xFF,
+        /* atom_count=0 */ 0x00,
+        /* tag = BC_TAG_MODULE (13) */ 0x0D,
+        /* module_name = builtin atom 2 ("false"): LEB128 (2<<1)=4 */ 0x04,
+        /* req_module_entries_count = 1 */ 0x01,
+        /*   rme[0].module_name = builtin atom 3 ("true"): LEB128 (3<<1)=6 */ 0x06,
+        /* (reader invokes loader here; rest is unreachable on this path) */
+    };
+    bc_module_attrs_recorded_tag = -42;
+    JSValue v = JS_ReadObject(ctx, blob, sizeof(blob), JS_READ_OBJ_BYTECODE);
+    /* The loader returned NULL, so the read failed regardless of the
+       attributes init; what matters is what value the loader saw. */
+    assert(JS_IsException(v));
+    JS_FreeValue(ctx, JS_GetException(ctx));
+
+    assert(bc_module_attrs_recorded_tag == JS_TAG_UNDEFINED);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
+    bc_module_attributes_init();
     cfunctions();
     sync_call();
     async_call();

--- a/quickjs.c
+++ b/quickjs.c
@@ -39097,6 +39097,14 @@ static JSValue JS_ReadModule(BCReaderState *s)
         m->req_module_entries = js_mallocz(ctx, sizeof(m->req_module_entries[0]) * m->req_module_entries_size);
         if (!m->req_module_entries)
             goto fail;
+        /* js_mallocz zeroes attributes to 0x0, which is
+           JS_MKVAL(JS_TAG_INT, 0), not JS_UNDEFINED. The host-provided
+           module normalizer/loader is called below with rme->attributes
+           and expects either JS_UNDEFINED or an object; receiving an
+           int with value 0 is wrong (and any embedder that inspects the
+           value as an object would dereference into the runtime). */
+        for(i = 0; i < m->req_module_entries_count; i++)
+            m->req_module_entries[i].attributes = JS_UNDEFINED;
         for(i = 0; i < m->req_module_entries_count; i++) {
             JSReqModuleEntry *rme = &m->req_module_entries[i];
             JSModuleDef **pm = &rme->module;


### PR DESCRIPTION
…odule

js_mallocz zeroes the freshly allocated req_module_entries to all-bits- zero. JS_MKVAL(JS_TAG_INT, 0) is 0, not JS_UNDEFINED — so the zeroed slot decoded as the number 0, not as "undefined". The host-provided module normalizer/loader is then invoked with rme->attributes as a JSValueConst argument and expects either JS_UNDEFINED or an object (per the documented contract); receiving an int collides with the hot path that defensively reads properties off of the value.

Initialise each rme->attributes to JS_UNDEFINED explicitly after the mallocz, before any read can dispatch into the loader.

Test: api-test now registers a JSModuleLoaderFunc2 that records JS_VALUE_GET_TAG(attrs) and returns NULL, then hands JS_ReadObject a module blob with req_module_entries_count=1.

Pre-fix:
  recorded tag = JS_TAG_INT (= 0)
  api-test: bc_module_attributes_init: Assertion
            `bc_module_attrs_recorded_tag == JS_TAG_UNDEFINED' failed.

Post-fix:
  recorded tag = JS_TAG_UNDEFINED, test passes.