### PR TITLE
fix(bytecode): bounds-check req_module_idx and var_idx in JS_ReadModule

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1027,8 +1027,44 @@ static void new_symbol(void)
     JS_FreeRuntime(rt);
 }
 
+/* Feeds JS_ReadObject a hand-crafted module blob whose star_export entry
+   references req_module index 0 even though req_module_entries_count is
+   0. js_resolve_export would later dereference
+   m->req_module_entries[0].module — an arbitrary-pointer read into
+   freshly-allocated zeroed memory at best, attacker-influenced heap
+   bytes otherwise. Before the fix the reader accepted the blob; after
+   the fix it rejects it. */
+static void bc_module_req_idx_oob(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+
+    const uint8_t blob[] = {
+        /* BC_VERSION   */ 26,
+        /* checksum     */ 0xFF, 0xFF, 0xFF, 0xFF,
+        /* atom_count=0 */ 0x00,
+        /* tag = BC_TAG_MODULE (13) */ 0x0D,
+        /* module_name = builtin atom 1 */ 0x02,
+        /* req_module_entries_count = 0 */ 0x00,
+        /* export_entries_count   = 0 */ 0x00,
+        /* star_export_entries_count = 1 */ 0x01,
+        /*   star_export[0].req_module_idx = 0 (out of range vs count=0) */ 0x00,
+        /* import_entries_count   = 0 */ 0x00,
+        /* has_tla                  = 0 */ 0x00,
+        /* func_obj: BC_TAG_NULL (any object would do — reader never
+           reaches this position on the post-fix path) */ 0x01,
+    };
+    JSValue v = JS_ReadObject(ctx, blob, sizeof(blob), JS_READ_OBJ_BYTECODE);
+    assert(JS_IsException(v));
+    JS_FreeValue(ctx, JS_GetException(ctx));
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
+    bc_module_req_idx_oob();
     cfunctions();
     sync_call();
     async_call();

--- a/quickjs.c
+++ b/quickjs.c
@@ -39133,8 +39133,21 @@ static JSValue JS_ReadModule(BCReaderState *s)
             if (me->export_type == JS_EXPORT_TYPE_LOCAL) {
                 if (bc_get_leb128_int(s, &me->u.local.var_idx))
                     goto fail;
+                /* var_idx indexes the bytecode-function's var_refs at
+                   resolution time; an early sign check is the most we
+                   can do here without the function in hand. */
+                if (me->u.local.var_idx < 0)
+                    goto fail;
             } else {
                 if (bc_get_leb128_int(s, &me->u.req_module_idx))
+                    goto fail;
+                /* req_module_idx indexes m->req_module_entries; reject any
+                   value that can't be a valid slot. Without this,
+                   js_resolve_export later dereferenced
+                   m->req_module_entries[idx].module with attacker-chosen
+                   idx, yielding an arbitrary-pointer read. */
+                if (me->u.req_module_idx < 0 ||
+                    me->u.req_module_idx >= m->req_module_entries_count)
                     goto fail;
                 if (bc_get_atom(s, &me->local_name))
                     goto fail;
@@ -39155,6 +39168,9 @@ static JSValue JS_ReadModule(BCReaderState *s)
             JSStarExportEntry *se = &m->star_export_entries[i];
             if (bc_get_leb128_int(s, &se->req_module_idx))
                 goto fail;
+            if (se->req_module_idx < 0 ||
+                se->req_module_idx >= m->req_module_entries_count)
+                goto fail;
         }
     }
 
@@ -39169,9 +39185,14 @@ static JSValue JS_ReadModule(BCReaderState *s)
             JSImportEntry *mi = &m->import_entries[i];
             if (bc_get_leb128_int(s, &mi->var_idx))
                 goto fail;
+            if (mi->var_idx < 0)
+                goto fail;
             if (bc_get_atom(s, &mi->import_name))
                 goto fail;
             if (bc_get_leb128_int(s, &mi->req_module_idx))
+                goto fail;
+            if (mi->req_module_idx < 0 ||
+                mi->req_module_idx >= m->req_module_entries_count)
                 goto fail;
         }
     }


### PR DESCRIPTION
JS_ReadModule deserialised req_module_idx (export, star-export, import) and var_idx (local-export, import) straight into m->export_entries / m->star_export_entries / m->import_entries without verifying the value was a valid index. js_resolve_export and its callers then dereferenced m->req_module_entries[idx].module / p1->u.func.var_refs[idx] with the attacker-chosen idx, yielding an arbitrary-offset OOB read of a pointer that the next opcode would deref.

Add range checks after each LEB128 read:
  - req_module_idx: 0 <= idx < m->req_module_entries_count
  - var_idx: idx >= 0 (the precise upper bound is per-function and is enforced at resolution time against var_refs[]).

Test: api-test now hands JS_ReadObject a module blob with req_module_entries_count = 0 and a star-export entry whose req_module_idx = 0. Before the fix:
  api-test: bc_module_req_idx_oob: Assertion `JS_IsException(v)' failed.
After the fix the reader rejects and the test passes.