### PR TITLE
fix(bytecode): bounds-check opcode operands in JS_ReadFunctionBytecode

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1027,8 +1027,50 @@ static void new_symbol(void)
     JS_FreeRuntime(rt);
 }
 
+/* Feeds JS_ReadObject a hand-crafted bytecode-function blob whose body
+   is a single byte: an atom-format opcode (OP_push_atom_value = 4,
+   declared size 5 in quickjs-opcode.h) with no operand bytes following.
+   Before the fix the reader's loop unconditionally read 4 operand bytes
+   past the end of bc_buf via get_u32(), then wrote the resolved atom
+   back via put_u32(), corrupting the adjacent heap chunk. After the fix
+   the reader checks pos + len > bc_len before reading and rejects the
+   blob cleanly. */
+static void bc_function_opcode_bounds(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+
+    const uint8_t blob[] = {
+        /* BC_VERSION   */ 26,
+        /* checksum     */ 0xFF, 0xFF, 0xFF, 0xFF,
+        /* atom_count=0 */ 0x00,
+        /* tag = BC_TAG_FUNCTION_BYTECODE (12) */ 0x0C,
+        /* flags (u16)  */ 0x00, 0x00,
+        /* is_strict    */ 0x00,
+        /* func_name = builtin atom 1 */ 0x02,
+        /* arg_count    */ 0x00,
+        /* var_count    */ 0x00,
+        /* defined_arg  */ 0x00,
+        /* stack_size   */ 0x00,
+        /* var_ref_count*/ 0x00,
+        /* closure_var  */ 0x00,
+        /* cpool_count  */ 0x00,
+        /* byte_code_len=1 */ 0x01,
+        /* local_count  */ 0x00,
+        /* byte_code: just the opcode byte, no operand */
+        /* OP_push_atom_value (= 4) */ 0x04,
+    };
+    JSValue v = JS_ReadObject(ctx, blob, sizeof(blob), JS_READ_OBJ_BYTECODE);
+    assert(JS_IsException(v));
+    JS_FreeValue(ctx, JS_GetException(ctx));
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
+    bc_function_opcode_bounds();
     cfunctions();
     sync_call();
     async_call();

--- a/quickjs.c
+++ b/quickjs.c
@@ -38725,9 +38725,17 @@ static int JS_ReadFunctionBytecode(BCReaderState *s, JSFunctionBytecode *b,
     b->byte_code_buf = bc_buf;
 
     pos = 0;
-    while (pos < bc_len) {
+    while ((uint32_t)pos < bc_len) {
         op = bc_buf[pos];
         len = short_opcode_info(op).size;
+        /* Refuse zero-length opcodes (would loop forever) and opcodes whose
+           operand bytes would run off the end of bc_buf. Without this the
+           OP_FMT_atom* arms below read 4 bytes past the buffer (and then
+           write the resolved atom back), corrupting the adjacent heap chunk. */
+        if (len <= 0 || (uint32_t)pos + (uint32_t)len > bc_len) {
+            b->byte_code_len = pos;
+            return -1;
+        }
         switch(short_opcode_info(op).fmt) {
         case OP_FMT_atom:
         case OP_FMT_atom_u8:


### PR DESCRIPTION
The OP_FMT_atom* arms in JS_ReadFunctionBytecode's loop did get_u32(bc_buf + pos + 1) and put_u32(bc_buf + pos + 1, atom) without verifying that the operand bytes fit inside bc_buf. A bytecode blob ending in an atom-format opcode (declared size 5) with only the opcode byte present made the loop read and write four bytes past the allocated bc_buf, corrupting the adjacent heap chunk.

Add a `len <= 0 || pos + len > bc_len` check at the top of the loop, before the switch dispatches. Zero-length opcodes are also rejected so a future opcode table can't loop forever.

Test: api-test now hands JS_ReadObject a one-byte byte_code body of OP_push_atom_value (= 4, size 5). Before the fix the reader silently corrupts the heap and still returns a function — the assertion `JS_IsException(v)` fails. After the fix the reader rejects the blob and the test passes.