### PR TITLE
Fix column reporting for invalid number literals

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -22677,6 +22677,7 @@ static __exception int next_token(JSParseState *s)
             if (JS_VALUE_IS_NAN(ret) ||
                 lre_js_is_ident_next(utf8_decode(p, &p1))) {
                 JS_FreeValue(s->ctx, ret);
+                s->col_num = max_int(1, s->mark - s->eol);
                 js_parse_error(s, "invalid number literal");
                 goto fail;
             }

--- a/tests/bug1498.js
+++ b/tests/bug1498.js
@@ -1,0 +1,30 @@
+import { assert } from "./assert.js";
+
+function test_invalid_number_literal_location()
+{
+    let error;
+    const source =
+        "function fun() {\n" +
+        "    let a = 123bcd;\n" +
+        "}\n";
+
+    try {
+        eval(source);
+    } catch (e) {
+        error = e;
+    }
+
+    assert(error instanceof SyntaxError);
+    assert(error.message, "invalid number literal");
+    assert(error.stack.length >= 1);
+    assert(error.stack[0].getFileName(), "<input>");
+    assert(error.stack[0].getLineNumber(), 2);
+    assert(error.stack[0].getColumnNumber(), 13);
+}
+
+Error.prepareStackTrace = (_, frames) => frames;
+try {
+    test_invalid_number_literal_location();
+} finally {
+    Error.prepareStackTrace = undefined;
+}


### PR DESCRIPTION
`next_token()` reports invalid number literals before it reaches the common token finalization path, where the token column is normally computed. Because `js_parse_error()` uses `s->col_num` for the error backtrace, these syntax errors could point to a stale column instead of the start of the current numeric token.

This updates `s->col_num` before throwing the invalid number literal error, using the same column calculation as the normal token path.