### PR TITLE
Fix CMake config installation path to match exported target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(NOT SUNOS)
 xcheck_add_c_compiler_flag(-funsigned-char)
 endif()
 
-# Clang on Windows without MSVC command line fails because the codebase uses 
+# Clang on Windows without MSVC command line fails because the codebase uses
 # functions like strcpy over strcpy_s
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND WIN32 AND NOT MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
@@ -555,11 +555,11 @@ if (QJS_ENABLE_INSTALL)
         install(TARGETS qjs_exe RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
         install(TARGETS qjsc RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
-    install(TARGETS qjs EXPORT quickjsConfig
+    install(TARGETS qjs EXPORT qjsConfig
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(EXPORT quickjsConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/quickjs)
+    install(EXPORT qjsConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/qjs)
     install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
     install(DIRECTORY examples DESTINATION ${CMAKE_INSTALL_DOCDIR})
 endif()


### PR DESCRIPTION
Fixes 32eb2ce217d08be4ba68e7bb32f3ddb478392dac