### PR TITLE
Fix part of speech in test262 suite reference

### DIFF
--- a/docs/docs/diff.md
+++ b/docs/docs/diff.md
@@ -23,7 +23,7 @@ average of a new release every 2 months.
 Since its inception testing has been a focus. Each PR is tested in over 50 configurations,
 involving different operating systems, build types and sanitizers.
 
-The `test262` suite is also ran for every change.
+The `test262` suite is also run for every change.
 
 ## Cross-platform support
 


### PR DESCRIPTION
In a sentence "The `test262` suite is also ran," 'run' should be used instead of 'ran'. It is the past participle in the sentence, despite 'is' being in the present tense. 'run' is irregular, but if you substitute a regular verb like 'execute', it becomes more clear:

"The `test262` suite is also executed." If the present participle were used, it would be 'executing'.

It's a common mistake in English, even amongst native speakers and linguistic drift may eventually put this in free variation, but for now 'run' is correct.

It's crazy how much of a difference one letter can make. This is why English is one of the two most difficult languages to learn, the other being Mandarin. (source: I think I heard this once)