### PR TITLE
Only export API symbols for shared builds

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -68,7 +68,7 @@ extern "C" {
 #  define JS_EXTERN /* nothing */
 # endif
 #else
-# ifdef QUICKJS_NG_CC_GNULIKE
+# if defined(BUILDING_QJS_SHARED) && defined(QUICKJS_NG_CC_GNULIKE)
 #  define JS_EXTERN __attribute__((visibility("default")))
 # else
 #  define JS_EXTERN /* nothing */
@@ -109,7 +109,7 @@ extern "C" {
 #  define JS_MODULE_EXTERN __declspec(dllimport)
 # endif
 #else
-# ifdef QUICKJS_NG_CC_GNULIKE
+# if defined(QUICKJS_NG_MODULE_BUILD) && defined(QUICKJS_NG_CC_GNULIKE)
 #  define JS_MODULE_EXTERN __attribute__((visibility("default")))
 # else
 #  define JS_MODULE_EXTERN /* nothing */


### PR DESCRIPTION
Related to #940.

Public API symbols currently get default visibility on GNU-like compilers whenever `QUICKJS_NG_CC_GNULIKE` is defined. For static/vendored builds, that can bypass an embedder’s `-fvisibility=hidden` setup and export QuickJS symbols from the embedding shared object.

Gate default visibility on the build modes that actually need exported symbols:

- `JS_EXTERN`: `BUILDING_QJS_SHARED`
- `JS_MODULE_EXTERN`: `QUICKJS_NG_MODULE_BUILD`

Windows import/export handling is unchanged.

Tested:

```sh
make -j2 build/qjs
```
