### PR TITLE
Add per-context interrupt budget

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1075,6 +1075,34 @@ static void get_uint8array(void)
     JS_FreeRuntime(rt);
 }
 
+static void context_interrupt_limit(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx1 = JS_NewContext(rt);
+    JSContext *ctx2 = JS_NewContext(rt);
+    JSValue ret;
+
+    assert(JS_GetContextInterruptCount(ctx1) == 0);
+    JS_SetContextInterruptLimit(ctx1, 1);
+
+    ret = eval(ctx1, "for (;;) {}\n");
+    assert(JS_IsException(ret));
+    JS_FreeValue(ctx1, JS_GetException(ctx1));
+    assert(JS_GetContextInterruptCount(ctx1) >= 1);
+
+    JS_ResetContextInterruptCount(ctx1);
+    assert(JS_GetContextInterruptCount(ctx1) == 0);
+
+    ret = eval(ctx2, "1 + 1");
+    assert(!JS_IsException(ret));
+    JS_FreeValue(ctx2, ret);
+    assert(JS_GetContextInterruptCount(ctx2) >= 1);
+
+    JS_FreeContext(ctx2);
+    JS_FreeContext(ctx1);
+    JS_FreeRuntime(rt);
+}
+
 static void new_symbol(void)
 {
     JSRuntime *rt = new_runtime();
@@ -1152,6 +1180,7 @@ int main(void)
     immutable_array_buffer();
     shared_array_buffer_growth();
     get_uint8array();
+    context_interrupt_limit();
     new_symbol();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -526,8 +526,10 @@ struct JSContext {
 
     uint64_t random_state;
 
-    /* when the counter reaches zero, JSRutime.interrupt_handler is called */
+    /* when the counter reaches zero, JSRuntime.interrupt_handler is called */
     int interrupt_counter;
+    uint64_t interrupt_count;
+    uint64_t interrupt_limit; /* 0 = unlimited */
 
     struct list_head loaded_modules; /* list of JSModuleDef.link */
 
@@ -2123,6 +2125,21 @@ void JS_SetInterruptHandler(JSRuntime *rt, JSInterruptHandler *cb, void *opaque)
     rt->interrupt_opaque = opaque;
 }
 
+void JS_SetContextInterruptLimit(JSContext *ctx, uint64_t limit)
+{
+    ctx->interrupt_limit = limit;
+}
+
+uint64_t JS_GetContextInterruptCount(JSContext *ctx)
+{
+    return ctx->interrupt_count;
+}
+
+void JS_ResetContextInterruptCount(JSContext *ctx)
+{
+    ctx->interrupt_count = 0;
+}
+
 void JS_SetCanBlock(JSRuntime *rt, bool can_block)
 {
     rt->can_block = can_block;
@@ -2521,6 +2538,8 @@ JSContext *JS_NewContextRaw(JSRuntime *rt)
     ctx->error_back_trace = JS_UNDEFINED;
     ctx->error_prepare_stack = JS_UNDEFINED;
     ctx->error_stack_trace_limit = js_int32(10);
+    ctx->interrupt_count = 0;
+    ctx->interrupt_limit = 0;
     init_list_head(&ctx->loaded_modules);
 
     if (JS_AddIntrinsicBasicObjects(ctx)) {
@@ -8222,6 +8241,11 @@ static no_inline __exception int __js_poll_interrupts(JSContext *ctx)
 {
     JSRuntime *rt = ctx->rt;
     ctx->interrupt_counter = JS_INTERRUPT_COUNTER_INIT;
+    ctx->interrupt_count++;
+    if (ctx->interrupt_limit > 0 && ctx->interrupt_count >= ctx->interrupt_limit) {
+        JS_ThrowInterrupted(ctx);
+        return -1;
+    }
     if (rt->interrupt_handler) {
         if (rt->interrupt_handler(rt, rt->interrupt_opaque)) {
             JS_ThrowInterrupted(ctx);

--- a/quickjs.h
+++ b/quickjs.h
@@ -1139,6 +1139,10 @@ JS_EXTERN void JS_SetHostPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRej
 /* return != 0 if the JS code needs to be interrupted */
 typedef int JSInterruptHandler(JSRuntime *rt, void *opaque);
 JS_EXTERN void JS_SetInterruptHandler(JSRuntime *rt, JSInterruptHandler *cb, void *opaque);
+/* count interrupt polls per context; use 0 to disable the limit */
+JS_EXTERN void JS_SetContextInterruptLimit(JSContext *ctx, uint64_t limit);
+JS_EXTERN uint64_t JS_GetContextInterruptCount(JSContext *ctx);
+JS_EXTERN void JS_ResetContextInterruptCount(JSContext *ctx);
 /* if can_block is true, Atomics.wait() can be used */
 JS_EXTERN void JS_SetCanBlock(JSRuntime *rt, bool can_block);
 /* set the [IsHTMLDDA] internal slot */


### PR DESCRIPTION
Add a context-local interrupt counter and optional limit.

The counter increments when the interpreter reaches the existing interrupt polling path. If a context limit is set and the counter reaches it, that context throws `interrupted` before consulting the runtime-level interrupt handler. A limit of `0` keeps the feature disabled.

This is useful for embedders that host multiple `JSContext` instances inside one `JSRuntime` and need each context to have an independent execution budget. In [QuickBEAM](https://github.com/elixir-volt/quickbeam), a pool worker owns [one `JSRuntime`](https://github.com/elixir-volt/quickbeam/blob/9adf0ca34d5dab493f0e12b1ba32fe8103f52be0/lib/quickbeam/context_worker.zig#L105-L122) and creates many contexts with [`JS_NewContext(rt)`](https://github.com/elixir-volt/quickbeam/blob/9adf0ca34d5dab493f0e12b1ba32fe8103f52be0/lib/quickbeam/context_worker.zig#L186-L193). A runtime-level interrupt handler remains useful as a global guard, but it cannot express a per-context budget for that pooled model.

Tested:

```sh
cmake --build build --target api-test -j2
./build/api-test
```
