### PR TITLE
Fix -Wmaybe-uninitialized warning in js_binary_logic_slow

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -15324,6 +15324,11 @@ static no_inline __exception int js_binary_logic_slow(JSContext *ctx,
         JSBigInt *p1, *p2, *r;
         JSBigIntBuf buf1, buf2;
     slow_big_int:
+        /* buf2 is zero-initialized here (after the label, so it also runs on
+           the goto slow_big_int paths) to silence a -Wmaybe-uninitialized
+           false positive: GCC cannot prove buf2 is initialized through the
+           inlined js_bigint_get_si_sat() -> js_bigint_sign() read below. */
+        memset(&buf2, 0, sizeof(buf2));
         if (JS_VALUE_GET_TAG(op1) == JS_TAG_SHORT_BIG_INT)
             p1 = js_bigint_set_short(&buf1, op1);
         else


### PR DESCRIPTION
Fix -Wmaybe-uninitialized warning in js_binary_logic_slow (quickjs.c).

GCC (seen with 16.1.1, Release/-O2) warns that buf2 may be used
uninitialized on the BigInt logic/shift path. js_bigint_get_si_sat(p2)
is inlined and reads buf2.tab via js_bigint_sign(), and GCC can't
correlate that with the earlier js_bigint_set_short(&buf2, op2) store.
The read is in fact always safe.

A declaration initializer (JSBigIntBuf buf2 = {0};) does not help,
because the slow_big_int: label is reached via goto, which jumps over
the initializer. The fix zero-initializes buf2 with memset() right
after the label so it runs on every entry path.

Verified on master with GCC 16.1.1: warning gone, tests.conf suite
passes (0/63 errors), api-test passes, and BigInt ops are correct
(123n<<4n=1968, -5n>>1n=-3, 6n&3n=2).

buf1 in the same function could be initialized the same way for
symmetry, though it does not currently trigger a warning. Happy to add
that if preferred.

Disclosure: prepared with AI assistance. I reviewed the code path,
reproduced the warning on master, verified the fix, and ran the test
suite myself.