### PR TITLE
Improve error message for illegal yield in classic mode

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -27715,6 +27715,25 @@ static __exception int js_parse_assign_expr2(JSParseState *s, int parse_flags)
             emit_label(s, label_next);
         }
         return 0;
+    } else if (s->token.val == TOK_IDENT &&
+               s->token.u.ident.atom == JS_ATOM_yield &&
+               !(s->cur_func->func_kind & JS_FUNC_GENERATOR)) {
+        /* In a non-generator function `yield` is a plain identifier, so
+           `yield <expr>` would otherwise fail with the generic "expecting ';'".
+           When a value-producing token follows `yield` on the same line, the
+           user almost certainly meant the generator keyword, so emit a clearer
+           message. peek_token() uses the lightweight scanner, which reports an
+           identifier or keyword such as `true`/`null`/`this` as TOK_IDENT and a
+           literal as its leading character; we only fire on the start of a
+           primary expression (identifier/keyword, number, or string/template),
+           which can never legally follow a bare identifier. This leaves
+           identifier uses of `yield` such as `var yield = 1; yield;`,
+           `yield + 1`, `yield()`, `yield[0]`, or `yield.foo` untouched.
+           See https://github.com/quickjs-ng/quickjs/issues/833 */
+        int tok = peek_token(s, true);
+        if (tok == TOK_IDENT || (tok >= '0' && tok <= '9') ||
+            tok == '"' || tok == '\'' || tok == '`')
+            return js_parse_error(s, "'yield' is only valid inside a generator function");
     } else if (s->token.val == '(' &&
                js_parse_skip_parens_token(s, NULL, true) == TOK_ARROW) {
         return js_parse_function_decl(s, JS_PARSE_FUNC_ARROW,

--- a/quickjs.c
+++ b/quickjs.c
@@ -28354,6 +28354,25 @@ static __exception int js_parse_assign_expr2(JSParseState *s, int parse_flags)
             emit_label(s, label_next);
         }
         return 0;
+    } else if (s->token.val == TOK_IDENT &&
+               s->token.u.ident.atom == JS_ATOM_yield &&
+               !(s->cur_func->func_kind & JS_FUNC_GENERATOR)) {
+        /* In a non-generator function `yield` is a plain identifier, so
+           `yield <expr>` would otherwise fail with the generic "expecting ';'".
+           When a value-producing token follows `yield` on the same line, the
+           user almost certainly meant the generator keyword, so emit a clearer
+           message. peek_token() uses the lightweight scanner, which reports an
+           identifier or keyword such as `true`/`null`/`this` as TOK_IDENT and a
+           literal as its leading character; we only fire on the start of a
+           primary expression (identifier/keyword, number, or string/template),
+           which can never legally follow a bare identifier. This leaves
+           identifier uses of `yield` such as `var yield = 1; yield;`,
+           `yield + 1`, `yield()`, `yield[0]`, or `yield.foo` untouched.
+           See https://github.com/quickjs-ng/quickjs/issues/833 */
+        int tok = peek_token(s, true);
+        if (tok == TOK_IDENT || (tok >= '0' && tok <= '9') ||
+            tok == '"' || tok == '\'' || tok == '`')
+            return js_parse_error(s, "'yield' is only valid inside a generator function");
     } else if (s->token.val == '(' &&
                js_parse_skip_parens_token(s, NULL, true) == TOK_ARROW) {
         return js_parse_function_decl(s, JS_PARSE_FUNC_ARROW,

--- a/tests/bug833.js
+++ b/tests/bug833.js
@@ -1,0 +1,52 @@
+import { assert } from "./assert.js";
+
+// https://github.com/quickjs-ng/quickjs/issues/833
+// In a classic (non-generator) function `yield` is a plain identifier. When it
+// is followed by a value, the user almost certainly meant the generator
+// keyword, so the parser now emits a clearer error than the generic
+// "expecting ';'".
+
+function compileError(src) {
+    try {
+        // eslint-disable-next-line no-eval
+        (0, eval)(src);
+    } catch (e) {
+        return e;
+    }
+    return null;
+}
+
+// `yield <value>` in a non-generator function reports the improved message.
+for (const src of [
+    "(function g(){ yield 42; })",
+    "(async function g(){ yield 42; })",
+    "(function g(){ yield foo; })",
+    "(function g(){ yield \"x\"; })",
+    "(function g(){ yield true; })",
+]) {
+    const e = compileError(src);
+    assert(e instanceof SyntaxError, true, src);
+    assert(e.message.includes("generator"), true,
+           "expected clearer message for: " + src + " (got: " + e.message + ")");
+    assert(e.message.includes("expecting ';'"), false,
+           "should no longer emit generic message for: " + src);
+}
+
+// Negative: `yield` used as a plain identifier in sloppy mode still parses.
+for (const src of [
+    "var yield = 1; yield;",
+    "var yield = 1; yield + 1;",
+    "var yield = function(){ return 1; }; yield();",
+    "var yield = [1]; yield[0];",
+    "var yield = { a: 1 }; yield.a;",
+    "var yield; yield = 5;",
+    "var yield = 1; yield++;",
+]) {
+    assert(compileError(src), null, "yield-as-identifier should parse: " + src);
+}
+
+// Sanity: a real generator still compiles and runs.
+assert(compileError("(function* g(){ yield 42; })"), null,
+       "generator function should still compile");
+function* g() { yield 42; }
+assert(g().next().value, 42, "generator still yields");


### PR DESCRIPTION
## Summary

In a classic (non-generator) function, `yield` is a plain identifier, so source like

```js
async function g() { // not a generator
    yield 42;
}
```

previously failed with the generic `SyntaxError: expecting ';'`, which gives no hint about the real problem.

This adds a targeted branch in `js_parse_assign_expr2` (quickjs.c) that, when the current token is the identifier `yield` inside a non-generator function and a value-producing token follows it on the same line, emits:

```
SyntaxError: 'yield' is only valid inside a generator function
```

The trigger is intentionally narrow. It uses `peek_token()` and only fires when the following token starts a primary expression that can never legally follow a bare identifier (another identifier/keyword, a number, or a string/template). That means genuine identifier uses of `yield` in sloppy mode are left untouched: `var yield = 1; yield;`, `yield + 1`, `yield()`, `yield[0]`, `yield.foo`, and `yield = 5` all still parse. Strict/module mode keeps its existing `unexpected 'yield' keyword` message, and real generators are unaffected.

## Why this matters

`yield` is a reserved word that users almost always intend as the generator keyword, so the generic `expecting ';'` is confusing in exactly the case the maintainer flagged. The new wording mirrors the existing `unexpected 'yield' keyword` message and points the user at the actual fix. https://github.com/quickjs-ng/quickjs/issues/833

## Testing

- Added `tests/bug833.js` (auto-discovered via `tests.conf` `testdir=tests`), covering the improved message for `yield <value>` forms, the negative cases where `yield` remains a valid identifier, and a real-generator sanity check.
- `cmake -B build && cmake --build build` then `./build/run-test262 -c tests.conf` -> `Result: 0/64 errors, 5 excluded` (the new test is included in the 64).
- `./build/qjs -m tests/bug833.js` passes.

Fixes #833
