### PR TITLE
JS_Free*: public vararg macros

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1131,6 +1131,43 @@ static void new_symbol(void)
     JS_FreeRuntime(rt);
 }
 
+static void bulk_free_macros(void) {
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+
+    JSValue val0 = JS_NewObject(ctx);
+    JSValue val1 = JS_NewArray(ctx);
+    JSValue val2 = JS_NewDate(ctx, 0.0);
+    
+    JSMemoryUsage mem_usage;
+    JS_ComputeMemoryUsage(rt, &mem_usage);
+    int obj_count = mem_usage.obj_count;
+
+    JS_FreeValues(ctx, val0, val1);
+    JS_FreeValuesRT(rt, val2);
+
+    // silly atoms to ensure qjs doesn't find built-ins that match
+    JSAtom atom0 = JS_NewAtom(ctx, "ALL!!");
+    JSAtom atom1 = JS_NewAtom(ctx, "YOUR!!");
+    JSAtom atom2 = JS_NewAtom(ctx, "AROMS!!");
+    JSAtom atom3 = JS_NewAtom(ctx, "ARE!!");
+    JSAtom atom4 = JS_NewAtom(ctx, "BELONG!!");
+    JSAtom atom5 = JS_NewAtom(ctx, "TO US!!");
+
+    JS_ComputeMemoryUsage(rt, &mem_usage);
+    assert((obj_count - 3) == mem_usage.obj_count);
+    int atom_count = mem_usage.atom_count;
+
+    JS_FreeAtoms(ctx, atom1, atom3, atom4);
+    JS_FreeAtomsRT(rt, atom0, atom2, atom5);
+
+    JS_ComputeMemoryUsage(rt, &mem_usage);
+    assert((atom_count - 6) == mem_usage.atom_count);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     cfunctions();
@@ -1153,5 +1190,6 @@ int main(void)
     shared_array_buffer_growth();
     get_uint8array();
     new_symbol();
+    bulk_free_macros();
     return 0;
 }

--- a/api-test.c
+++ b/api-test.c
@@ -1149,7 +1149,7 @@ static void bulk_free_macros(void) {
     // silly atoms to ensure qjs doesn't find built-ins that match
     JSAtom atom0 = JS_NewAtom(ctx, "ALL!!");
     JSAtom atom1 = JS_NewAtom(ctx, "YOUR!!");
-    JSAtom atom2 = JS_NewAtom(ctx, "AROMS!!");
+    JSAtom atom2 = JS_NewAtom(ctx, "ATOMS!!");
     JSAtom atom3 = JS_NewAtom(ctx, "ARE!!");
     JSAtom atom4 = JS_NewAtom(ctx, "BELONG!!");
     JSAtom atom5 = JS_NewAtom(ctx, "TO US!!");

--- a/quickjs.c
+++ b/quickjs.c
@@ -6811,6 +6811,24 @@ void JS_FreeValue(JSContext *ctx, JSValue v)
     JS_FreeValueRT(ctx->rt, v);
 }
 
+void js_freevalue_rt_v(JSRuntime *rt, int num, ...)
+{
+    va_list va;
+    va_start(va, num);
+    while (num--)
+        JS_FreeValueRT(rt, va_arg(va, JSValue));
+    va_end(va);
+}
+
+void js_freevalue_v(JSContext *ctx, int num, ...)
+{
+    va_list va;
+    va_start(va, num);
+    while (num--)
+        JS_FreeValueRT(ctx->rt, va_arg(va, JSValue));
+    va_end(va);
+}
+
 /* garbage collection */
 
 static void add_gc_object(JSRuntime *rt, JSGCObjectHeader *h,

--- a/quickjs.c
+++ b/quickjs.c
@@ -3659,24 +3659,6 @@ void JS_FreeAtomRT(JSRuntime *rt, JSAtom v)
         __JS_FreeAtom(rt, v);
 }
 
-void js_freeatom_v(JSContext *ctx, int num, ...)
-{
-    va_list va;
-    va_start(va, num);
-    while (num--)
-        JS_FreeAtom(ctx, va_arg(va, JSAtom));
-    va_end(va);
-}
-
-void js_freeatom_rt_v(JSRuntime *rt, int num, ...)
-{
-    va_list va;
-    va_start(va, num);
-    while (num--)
-        JS_FreeAtomRT(rt, va_arg(va, JSAtom));
-    va_end(va);
-}
-
 /* return true if 'v' is a symbol with a string description */
 static bool JS_AtomSymbolHasDescription(JSContext *ctx, JSAtom v)
 {
@@ -6827,24 +6809,6 @@ void JS_FreeValueRT(JSRuntime *rt, JSValue v)
 void JS_FreeValue(JSContext *ctx, JSValue v)
 {
     JS_FreeValueRT(ctx->rt, v);
-}
-
-void js_freevalue_rt_v(JSRuntime *rt, int num, ...)
-{
-    va_list va;
-    va_start(va, num);
-    while (num--)
-        JS_FreeValueRT(rt, va_arg(va, JSValue));
-    va_end(va);
-}
-
-void js_freevalue_v(JSContext *ctx, int num, ...)
-{
-    va_list va;
-    va_start(va, num);
-    while (num--)
-        JS_FreeValueRT(ctx->rt, va_arg(va, JSValue));
-    va_end(va);
 }
 
 /* garbage collection */

--- a/quickjs.c
+++ b/quickjs.c
@@ -3659,6 +3659,24 @@ void JS_FreeAtomRT(JSRuntime *rt, JSAtom v)
         __JS_FreeAtom(rt, v);
 }
 
+void js_freeatom_v(JSContext *ctx, int num, ...)
+{
+    va_list va;
+    va_start(va, num);
+    while (num--)
+        JS_FreeAtom(ctx, va_arg(va, JSAtom));
+    va_end(va);
+}
+
+void js_freeatom_rt_v(JSRuntime *rt, int num, ...)
+{
+    va_list va;
+    va_start(va, num);
+    while (num--)
+        JS_FreeAtomRT(rt, va_arg(va, JSAtom));
+    va_end(va);
+}
+
 /* return true if 'v' is a symbol with a string description */
 static bool JS_AtomSymbolHasDescription(JSContext *ctx, JSAtom v)
 {

--- a/quickjs.h
+++ b/quickjs.h
@@ -843,6 +843,11 @@ JS_EXTERN JSValue JS_PRINTF_FORMAT_ATTR(3, 4) JS_ThrowDOMException(JSContext *ct
 JS_EXTERN JSValue JS_ThrowOutOfMemory(JSContext *ctx);
 JS_EXTERN void JS_FreeValue(JSContext *ctx, JSValue v);
 JS_EXTERN void JS_FreeValueRT(JSRuntime *rt, JSValue v);
+JS_EXTERN void js_freevalue_v(JSContext *ctx, int num, ...);
+JS_EXTERN void js_freevalue_rt_v(JSRuntime *ctx, int num, ...);
+#define JS_FVV_NUMARGS(...) (sizeof((JSValue[]){__VA_ARGS__}) / sizeof(JSValue))
+#define JS_FreeValue_V(ctx, ...) js_freevalue_v(ctx, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeValueRT_V(rt, ...) js_freevalue_rt_v(rt, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
 JS_EXTERN JSValue JS_DupValue(JSContext *ctx, JSValueConst v);
 JS_EXTERN JSValue JS_DupValueRT(JSRuntime *rt, JSValueConst v);
 JS_EXTERN int JS_ToBool(JSContext *ctx, JSValueConst val); /* return -1 for JS_EXCEPTION */

--- a/quickjs.h
+++ b/quickjs.h
@@ -599,6 +599,9 @@ JS_EXTERN JSAtom JS_DupAtom(JSContext *ctx, JSAtom v);
 JS_EXTERN JSAtom JS_DupAtomRT(JSRuntime *rt, JSAtom v);
 JS_EXTERN void JS_FreeAtom(JSContext *ctx, JSAtom v);
 JS_EXTERN void JS_FreeAtomRT(JSRuntime *rt, JSAtom v);
+#define JS_FAV_NUMARGS(...) (sizeof((JSAtom[]){__VA_ARGS__}) / sizeof(JSAtom))
+#define JS_FreeAtoms(ctx, ...) js_freeatom_v(ctx, JS_FAV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeAtomsRT(rt, ...) js_freeatom_rt_v(rt, JS_FAV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
 JS_EXTERN JSValue JS_AtomToValue(JSContext *ctx, JSAtom atom);
 JS_EXTERN JSValue JS_AtomToString(JSContext *ctx, JSAtom atom);
 JS_EXTERN const char *JS_AtomToCStringLen(JSContext *ctx, size_t *plen, JSAtom atom);

--- a/quickjs.h
+++ b/quickjs.h
@@ -846,8 +846,8 @@ JS_EXTERN void JS_FreeValueRT(JSRuntime *rt, JSValue v);
 JS_EXTERN void js_freevalue_v(JSContext *ctx, int num, ...);
 JS_EXTERN void js_freevalue_rt_v(JSRuntime *ctx, int num, ...);
 #define JS_FVV_NUMARGS(...) (sizeof((JSValue[]){__VA_ARGS__}) / sizeof(JSValue))
-#define JS_FreeValue_V(ctx, ...) js_freevalue_v(ctx, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
-#define JS_FreeValueRT_V(rt, ...) js_freevalue_rt_v(rt, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeValues(ctx, ...) js_freevalue_v(ctx, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeValuesRT(rt, ...) js_freevalue_rt_v(rt, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
 JS_EXTERN JSValue JS_DupValue(JSContext *ctx, JSValueConst v);
 JS_EXTERN JSValue JS_DupValueRT(JSRuntime *rt, JSValueConst v);
 JS_EXTERN int JS_ToBool(JSContext *ctx, JSValueConst val); /* return -1 for JS_EXCEPTION */

--- a/quickjs.h
+++ b/quickjs.h
@@ -135,6 +135,25 @@ extern "C" {
 #endif
 #endif
 
+/*
+ * `JS_CALL_X` -- macro tree for calling a function with a variable number of arguments.
+ * This is used for bulk operations such as freeing values or atoms.
+ */
+#define JS_COUNT_ARGS_(_0, _8, _7, _6, _5, _4, _3, _2, _1, N, ...) N
+#define JS_COUNT_ARGS(...) JS_COUNT_ARGS_(0, __VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+#define JS_CALLX1(F,X,a)               do { F(X,a); } while (0)
+#define JS_CALLX2(F,X,a,b)             do { F(X,a); F(X,b); } while (0)
+#define JS_CALLX3(F,X,a,b,c)           do { F(X,a); F(X,b); F(X,c); } while (0)
+#define JS_CALLX4(F,X,a,b,c,d)         do { F(X,a); F(X,b); F(X,c); F(X,d); } while (0)
+#define JS_CALLX5(F,X,a,b,c,d,e)       do { F(X,a); F(X,b); F(X,c); F(X,d); F(X,e); } while (0)
+#define JS_CALLX6(F,X,a,b,c,d,e,f)     do { F(X,a); F(X,b); F(X,c); F(X,d); F(X,e); F(X,f); } while (0)
+#define JS_CALLX7(F,X,a,b,c,d,e,f,g)   do { F(X,a); F(X,b); F(X,c); F(X,d); F(X,e); F(X,f); F(X,g); } while (0)
+#define JS_CALLX8(F,X,a,b,c,d,e,f,g,h) do { F(X,a); F(X,b); F(X,c); F(X,d); F(X,e); F(X,f); F(X,g); F(X,h); } while (0)
+
+#define JS_CALLX__(F, X, N, ...) JS_CALLX##N(F, X, __VA_ARGS__)
+#define JS_CALLX_(F, X, N, ...) JS_CALLX__(F, X, N, __VA_ARGS__)
+
 #undef QUICKJS_NG_CC_GNULIKE
 #undef QUICKJS_NG_PLAT_WIN32
 
@@ -599,9 +618,8 @@ JS_EXTERN JSAtom JS_DupAtom(JSContext *ctx, JSAtom v);
 JS_EXTERN JSAtom JS_DupAtomRT(JSRuntime *rt, JSAtom v);
 JS_EXTERN void JS_FreeAtom(JSContext *ctx, JSAtom v);
 JS_EXTERN void JS_FreeAtomRT(JSRuntime *rt, JSAtom v);
-#define JS_FAV_NUMARGS(...) (sizeof((JSAtom[]){__VA_ARGS__}) / sizeof(JSAtom))
-#define JS_FreeAtoms(ctx, ...) js_freeatom_v(ctx, JS_FAV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
-#define JS_FreeAtomsRT(rt, ...) js_freeatom_rt_v(rt, JS_FAV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeAtoms(ctx, ...) JS_CALLX_(JS_FreeAtom, ctx, JS_COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeAtomsRT(rt, ...) JS_CALLX_(JS_FreeAtomRT, rt, JS_COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
 JS_EXTERN JSValue JS_AtomToValue(JSContext *ctx, JSAtom atom);
 JS_EXTERN JSValue JS_AtomToString(JSContext *ctx, JSAtom atom);
 JS_EXTERN const char *JS_AtomToCStringLen(JSContext *ctx, size_t *plen, JSAtom atom);
@@ -846,11 +864,8 @@ JS_EXTERN JSValue JS_PRINTF_FORMAT_ATTR(3, 4) JS_ThrowDOMException(JSContext *ct
 JS_EXTERN JSValue JS_ThrowOutOfMemory(JSContext *ctx);
 JS_EXTERN void JS_FreeValue(JSContext *ctx, JSValue v);
 JS_EXTERN void JS_FreeValueRT(JSRuntime *rt, JSValue v);
-JS_EXTERN void js_freevalue_v(JSContext *ctx, int num, ...);
-JS_EXTERN void js_freevalue_rt_v(JSRuntime *ctx, int num, ...);
-#define JS_FVV_NUMARGS(...) (sizeof((JSValue[]){__VA_ARGS__}) / sizeof(JSValue))
-#define JS_FreeValues(ctx, ...) js_freevalue_v(ctx, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
-#define JS_FreeValuesRT(rt, ...) js_freevalue_rt_v(rt, JS_FVV_NUMARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeValues(ctx, ...) JS_CALLX_(JS_FreeValue, ctx, JS_COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
+#define JS_FreeValuesRT(rt, ...) JS_CALLX_(JS_FreeValueRT, rt, JS_COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
 JS_EXTERN JSValue JS_DupValue(JSContext *ctx, JSValueConst v);
 JS_EXTERN JSValue JS_DupValueRT(JSRuntime *rt, JSValueConst v);
 JS_EXTERN int JS_ToBool(JSContext *ctx, JSValueConst val); /* return -1 for JS_EXCEPTION */


### PR DESCRIPTION
This introduces 4 new public macros based on a set of generic vararg macros that could also be used for other convenience macros.

The functions to use directly are
* `JS_FreeValues`
* `JS_FreeValuesRT`
* `JS_FreeAtoms`
* `JS_FreeAtomsRT`

*note the "s"*

**Example usage**
`JS_FreeValues(ctx, myval1, myval2, someotherval3);`

**Why?**
I am editing dense code with tight interop with QJS and i've noticed an annoying pattern of FreeValue/Atom accumulating, especially when dup'ing for calls when the JSValue layout isn't initially linear, or when going down object chains with atoms. I also feel like this could benefit more users than me.