### PR TITLE
Fix ArrayBuffer immutable-method semantics

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -58167,13 +58167,14 @@ static JSValue js_array_buffer_transfer(JSContext *ctx, JSValueConst this_val,
         return JS_EXCEPTION;
     if (abuf->shared)
         return JS_ThrowTypeError(ctx, "cannot transfer a SharedArrayBuffer");
-    if (magic == JS_ARRAY_BUFFER_TRANSFER_TO_IMMUTABLE && abuf->immutable)
-        return JS_ThrowTypeErrorImmutableArrayBuffer(ctx);
+    // Spec (ArrayBufferCopyAndDetach): the newLength argument must be
+    // coerced (its valueOf observed) before the buffer's detachability /
+    // immutability is checked, so side effects of coercion are visible.
     if (argc < 1 || JS_IsUndefined(argv[0]))
         new_len = abuf->byte_length;
     else if (JS_ToIndex(ctx, &new_len, argv[0]))
         return JS_EXCEPTION;
-    if (magic != JS_ARRAY_BUFFER_TRANSFER_TO_IMMUTABLE && abuf->immutable)
+    if (abuf->immutable)
         return JS_ThrowTypeErrorImmutableArrayBuffer(ctx);
     if (abuf->detached)
         return JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
@@ -58350,8 +58351,15 @@ static JSValue js_array_buffer_slice(JSContext *ctx,
         goto fail;
     }
     /* must test again because of side effects */
-    if (abuf->detached || abuf->byte_length < start + new_len) {
+    if (abuf->detached) {
         JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
+        goto fail;
+    }
+    if (abuf->byte_length < start + new_len) {
+        if (immutable)
+            JS_ThrowRangeError(ctx, "invalid array buffer length");
+        else
+            JS_ThrowTypeErrorDetachedArrayBuffer(ctx);
         goto fail;
     }
     memcpy(new_abuf->data, abuf->data + start, new_len);

--- a/test262_errors.txt
+++ b/test262_errors.txt
@@ -5,10 +5,6 @@ test262/test/annexB/language/expressions/assignmenttargettype/callexpression-in-
 test262/test/annexB/language/expressions/assignmenttargettype/callexpression-in-prefix-update.js:27: SyntaxError: invalid increment/decrement operand
 test262/test/annexB/language/expressions/assignmenttargettype/callexpression.js:33: SyntaxError: invalid assignment left-hand side
 test262/test/annexB/language/expressions/assignmenttargettype/cover-callexpression-and-asyncarrowhead.js:20: SyntaxError: invalid assignment left-hand side
-test262/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/this-shrinks.js:40: Test262Error: resize below resolved end Expected a RangeError but got a TypeError
-test262/test/built-ins/ArrayBuffer/prototype/sliceToImmutable/this-shrinks.js:40: strict mode: Test262Error: resize below resolved end Expected a RangeError but got a TypeError
-test262/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-not-detachable.js:35: Test262Error: Actual [] and expected [newLength.valueOf] should have the same contents. [immutable ArrayBuffer] Must read arguments before verifying detachability.
-test262/test/built-ins/ArrayBuffer/prototype/transferToImmutable/this-is-not-detachable.js:35: strict mode: Test262Error: Actual [] and expected [newLength.valueOf] should have the same contents. [immutable ArrayBuffer] Must read arguments before verifying detachability.
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-poisoned-wrapper.js:64: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-poisoned-wrapper.js:64: strict mode: TypeError: $DONE() not called
 test262/test/built-ins/AsyncFromSyncIteratorPrototype/next/next-result-poisoned-wrapper.js:69: TypeError: $DONE() not called


### PR DESCRIPTION
sliceToImmutable throws RangeError (not TypeError) when a resizable source
shrinks below the resolved end during argument coercion; transferToImmutable
coerces newLength before checking detachability so valueOf side effects are observed.
