### PR TITLE
Build release binaries with static mimalloc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,19 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jirutka/setup-alpine@v1
         with:
+          # mimalloc v3 (mimalloc3-dev) lives in the edge testing repo; enable it.
+          # riscv64 has no v3 build there, so it falls back to mimalloc2-dev.
+          branch: edge
           arch: ${{matrix.arch}}
-          packages: "build-base make cmake"
+          extra-repositories: |
+            http://dl-cdn.alpinelinux.org/alpine/edge/testing
+          packages: "build-base make cmake ${{ matrix.arch == 'riscv64' && 'mimalloc2-dev' || 'mimalloc3-dev' }}"
       - name: build
         shell: alpine.sh {0}
         run: |
           mkdir build
           cd build
-          cmake -DQJS_BUILD_WERROR=ON -DQJS_BUILD_CLI_STATIC=ON ..
+          cmake -DQJS_BUILD_WERROR=ON -DQJS_BUILD_CLI_STATIC=ON -DQJS_BUILD_CLI_WITH_STATIC_MIMALLOC=ON ..
           cd ..
           cmake --build build --target qjs_exe -j$(getconf _NPROCESSORS_ONLN)
           cmake --build build --target qjsc -j$(getconf _NPROCESSORS_ONLN)
@@ -55,21 +60,33 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x86_64]
     steps:
       - uses: actions/checkout@v7
+      - name: install mimalloc
+        if: ${{ matrix.arch == 'arm64' }}
+        run: brew install mimalloc
       - name: build
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DQJS_BUILD_WERROR=ON ..
+          cmake -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}} -DQJS_BUILD_WERROR=ON ${{ matrix.arch == 'arm64' && '-DQJS_BUILD_CLI_WITH_STATIC_MIMALLOC=ON -DCMAKE_PREFIX_PATH=/opt/homebrew' || '' }} ..
           make -j$(getconf _NPROCESSORS_ONLN)
-          make -C .. amalgam # writes build/quickjs-amalgam.zip
-          mv qjs qjs-darwin
-          mv qjsc qjsc-darwin
+      - name: build amalgamation
+        if: ${{ matrix.arch == 'arm64' }}
+        run: make amalgam # writes build/quickjs-amalgam.zip; runs qjs natively on arm64
+      - name: rename
+        run: |
+          mv build/qjs build/qjs-darwin-${{matrix.arch}}
+          mv build/qjsc build/qjsc-darwin-${{matrix.arch}}
       - name: check
         run: |
-          lipo -info build/qjs-darwin build/qjsc-darwin
+          lipo -info build/qjs-darwin-${{matrix.arch}} build/qjsc-darwin-${{matrix.arch}}
       - name: upload amalgamation
+        if: ${{ matrix.arch == 'arm64' }}
         uses: actions/upload-artifact@v7
         with:
           name: quickjs-amalgam.zip
@@ -78,8 +95,8 @@ jobs:
       - name: upload
         uses: actions/upload-artifact@v7
         with:
-          name: qjs-darwin
-          path: build/*-darwin
+          name: qjs-darwin-${{matrix.arch}}
+          path: build/*-darwin-${{matrix.arch}}
 
   windows:
     runs-on: windows-latest
@@ -103,7 +120,10 @@ jobs:
             cmake:p
             ninja:p
             toolchain:p
+            ${{ matrix.arch == 'x86_64' && 'mimalloc:p' || '' }}
       - name: build
+        env:
+          QJS_BUILD_CLI_WITH_STATIC_MIMALLOC: ${{ matrix.arch == 'x86_64' && 'ON' || 'OFF' }}
         run: |
           make
           mv build/qjs.exe build/qjs-windows-${{matrix.arch}}.exe


### PR DESCRIPTION
- Linux: use Alpine Edge mimalloc3-dev (riscv64 has no package, keeps system
  malloc)
- macOS: split into per-arch builds; arm64 links Homebrew mimalloc, x86_64
  ships without it (no more universal binary)
- Windows: MSYS2 mimalloc for x86_64 (no 32-bit package)
