### PR TITLE
Inline mixed int/float arithmetic and fast-array reads in the interpreter

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -1545,6 +1545,21 @@ static JSValue js_number(double d)
         return js_float64(d);
 }
 
+/* If v is a number (int or float64), store it as a double and return true.
+   Used by the interpreter arithmetic fast paths to handle mixed int/float
+   operands inline instead of falling back to the slow path. */
+static inline bool js_arith_to_float64(JSValue v, double *pd)
+{
+    uint32_t tag = JS_VALUE_GET_TAG(v);
+    if (JS_TAG_IS_FLOAT64(tag))
+        *pd = JS_VALUE_GET_FLOAT64(v);
+    else if (tag == JS_TAG_INT)
+        *pd = JS_VALUE_GET_INT(v);
+    else
+        return false;
+    return true;
+}
+
 static JSValue __JS_NewShortBigInt(JSContext *ctx, int32_t d)
 {
     (void)&ctx;
@@ -19399,6 +19414,26 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
             {
                 JSValue val;
 
+                /* fast path: regular/typed array element by int index */
+                if (likely(JS_VALUE_GET_TAG(sp[-2]) == JS_TAG_OBJECT &&
+                           JS_VALUE_GET_TAG(sp[-1]) == JS_TAG_INT)) {
+                    JSObject *p = JS_VALUE_GET_OBJ(sp[-2]);
+                    uint32_t idx = JS_VALUE_GET_INT(sp[-1]);
+                    if (likely(p->class_id == JS_CLASS_ARRAY &&
+                               idx < p->u.array.count)) {
+                        val = js_dup(p->u.array.u.values[idx]);
+                        JS_FreeValue(ctx, sp[-2]);
+                        sp[-2] = val;
+                        sp--;
+                        BREAK;
+                    }
+                    if (js_get_fast_array_element(ctx, p, idx, &val)) {
+                        JS_FreeValue(ctx, sp[-2]);
+                        sp[-2] = val;
+                        sp--;
+                        BREAK;
+                    }
+                }
                 sf->cur_pc = pc;
                 val = JS_GetPropertyValue(ctx, sp[-2], sp[-1]);
                 JS_FreeValue(ctx, sp[-2]);
@@ -19413,6 +19448,21 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
             {
                 JSValue val;
 
+                /* fast path: regular/typed array element by int index */
+                if (likely(JS_VALUE_GET_TAG(sp[-2]) == JS_TAG_OBJECT &&
+                           JS_VALUE_GET_TAG(sp[-1]) == JS_TAG_INT)) {
+                    JSObject *p = JS_VALUE_GET_OBJ(sp[-2]);
+                    uint32_t idx = JS_VALUE_GET_INT(sp[-1]);
+                    if (likely(p->class_id == JS_CLASS_ARRAY &&
+                               idx < p->u.array.count)) {
+                        sp[-1] = js_dup(p->u.array.u.values[idx]);
+                        BREAK;
+                    }
+                    if (js_get_fast_array_element(ctx, p, idx, &val)) {
+                        sp[-1] = val;
+                        BREAK;
+                    }
+                }
                 sf->cur_pc = pc;
                 val = JS_GetPropertyValue(ctx, sp[-2], sp[-1]);
                 sp[-1] = val;
@@ -19624,7 +19674,19 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                                         JS_VALUE_GET_FLOAT64(op2));
                     JS_X87_FPCW_RESTORE(fpcw);
                     sp--;
+                } else if (JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op1)) ||
+                           JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op2))) {
+                    /* mixed int/float; the BOTH_FLOAT fast path above is unchanged */
+                    double d1, d2;
+                    if (!js_arith_to_float64(op1, &d1) ||
+                        !js_arith_to_float64(op2, &d2))
+                        goto add_slow_case;
+                    JS_X87_FPCW_SAVE_AND_ADJUST(fpcw);
+                    sp[-2] = js_float64(d1 + d2);
+                    JS_X87_FPCW_RESTORE(fpcw);
+                    sp--;
                 } else {
+                add_slow_case:
                     sf->cur_pc = pc;
                     if (js_add_slow(ctx, sp))
                         goto exception;
@@ -19694,6 +19756,17 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                                         JS_VALUE_GET_FLOAT64(op2));
                     JS_X87_FPCW_RESTORE(fpcw);
                     sp--;
+                } else if (JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op1)) ||
+                           JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op2))) {
+                    /* mixed int/float; the BOTH_FLOAT fast path above is unchanged */
+                    double d1, d2;
+                    if (!js_arith_to_float64(op1, &d1) ||
+                        !js_arith_to_float64(op2, &d2))
+                        goto binary_arith_slow;
+                    JS_X87_FPCW_SAVE_AND_ADJUST(fpcw);
+                    sp[-2] = js_float64(d1 - d2);
+                    JS_X87_FPCW_RESTORE(fpcw);
+                    sp--;
                 } else {
                     goto binary_arith_slow;
                 }
@@ -19729,6 +19802,17 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                 mul_fp_res:
                     sp[-2] = js_float64(d);
                     sp--;
+                } else if (JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op1)) ||
+                           JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op2))) {
+                    /* mixed int/float; the BOTH_FLOAT fast path above is unchanged */
+                    double d1, d2;
+                    if (!js_arith_to_float64(op1, &d1) ||
+                        !js_arith_to_float64(op2, &d2))
+                        goto binary_arith_slow;
+                    JS_X87_FPCW_SAVE_AND_ADJUST(fpcw);
+                    d = d1 * d2;
+                    JS_X87_FPCW_RESTORE(fpcw);
+                    goto mul_fp_res;
                 } else {
                     goto binary_arith_slow;
                 }
@@ -19744,6 +19828,23 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
                     v1 = JS_VALUE_GET_INT(op1);
                     v2 = JS_VALUE_GET_INT(op2);
                     sp[-2] = js_number((double)v1 / (double)v2);
+                    sp--;
+                } else if (JS_VALUE_IS_BOTH_FLOAT(op1, op2)) {
+                    JS_X87_FPCW_SAVE_AND_ADJUST(fpcw);
+                    sp[-2] = js_number(JS_VALUE_GET_FLOAT64(op1) /
+                                       JS_VALUE_GET_FLOAT64(op2));
+                    JS_X87_FPCW_RESTORE(fpcw);
+                    sp--;
+                } else if (JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op1)) ||
+                           JS_TAG_IS_FLOAT64(JS_VALUE_GET_TAG(op2))) {
+                    /* mixed int/float; the BOTH_FLOAT fast path above is unchanged */
+                    double d1, d2;
+                    if (!js_arith_to_float64(op1, &d1) ||
+                        !js_arith_to_float64(op2, &d2))
+                        goto binary_arith_slow;
+                    JS_X87_FPCW_SAVE_AND_ADJUST(fpcw);
+                    sp[-2] = js_number(d1 / d2);
+                    JS_X87_FPCW_RESTORE(fpcw);
                     sp--;
                 } else {
                     goto binary_arith_slow;


### PR DESCRIPTION

    Ported from bellard/quickjs:
    - 8e97f24044102b5793524ab22b037ca75f536319 "faster add, sub and mul for mixed
      integer floating point operands" (extended here to OP_div; kept NG's direct
      BOTH_FLOAT fast path instead of replacing it).
    - 8e8eefb922b205bb56de14e0279b4e42b5f3f460 "optimized array access by inlining
      get_array_el, get_array_el2, get_array_el3 and put_array_el" (applied to
      get_array_el/el2; NG already inlines put_array_el).

    Octane (Release + static mimalloc, median of 3): overall score +6%,
    NavierStokes +33%.