### PR TITLE
Fix build with strict C compilers on x86-32

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -668,6 +668,7 @@ static inline int js_thread_join(js_thread_t thrd);
 // Note that `*&cw` in the asm constraints looks redundant but isn't.
 #if defined(__i386__) && !defined(_MSC_VER)
 #define JS_X87_FPCW_SAVE_AND_ADJUST(cw)                                     \
+    (void)0;                                                                \
     unsigned short cw;                                                      \
     __asm__ __volatile__("fnstcw %0" : "=m"(*&cw));                         \
     do {                                                                    \


### PR DESCRIPTION
This macro is used in several places in quickjs.c.. and some of them are right after a label statement, this is illegal in C, and despite most modern compilers have an extension to handle this, strict compiler flags and C compliant compilers will refuse to compile this thing.

I reproduced this bug when building quickjs in iSH for iOS, here's the proof:

<img width="590" height="1278" alt="IMG_7536" src="https://github.com/user-attachments/assets/968c17f0-bbc9-43cc-868a-157c4d4d2749" />

It will be nice also to have a define to disable the use of asm inline, we will lose some floating point precission here but its just a 1 line change i can also include in this PR if needed.