### PR TITLE
Fix `set Iterator.prototype.constructor` for non-object values

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -45089,7 +45089,7 @@ static JSValue js_iterator_proto_set_toStringTag(JSContext *ctx, JSValueConst th
         if (JS_SetProperty(ctx, this_val, JS_ATOM_Symbol_toStringTag, js_dup(val)) < 0)
             return JS_EXCEPTION;
     } else {
-        if (JS_DefinePropertyValueConst(ctx, this_val, JS_ATOM_Symbol_toStringTag, val, JS_PROP_C_W_E) < 0)
+        if (JS_DefinePropertyValueConst(ctx, this_val, JS_ATOM_Symbol_toStringTag, val, JS_PROP_C_W_E | JS_PROP_THROW) < 0)
             return JS_EXCEPTION;
     }
     return JS_UNDEFINED;

--- a/quickjs.c
+++ b/quickjs.c
@@ -44349,6 +44349,8 @@ static const JSCFunctionListEntry js_iterator_wrap_proto_funcs[] = {
     JS_ITERATOR_NEXT_DEF("return", 0, js_iterator_wrap_next, GEN_MAGIC_RETURN ),
 };
 
+static int check_iterator(JSContext *ctx, JSValueConst obj);
+
 static JSValue js_iterator_constructor_getset(JSContext *ctx,
                                               JSValueConst this_val,
                                               int argc, JSValueConst *argv,
@@ -44357,14 +44359,27 @@ static JSValue js_iterator_constructor_getset(JSContext *ctx,
 {
     int ret;
 
-    if (argc > 0) { // if setter
-        if (!JS_IsObject(argv[0]))
-            return JS_ThrowTypeErrorNotAnObject(ctx);
-        ret = JS_DefinePropertyValue(ctx, this_val, JS_ATOM_constructor,
-                                     js_dup(argv[0]),
-                                     JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
+    if (magic) { // setter (the getter is registered with magic == 0)
+        // SetterThatIgnoresPrototypeProperties(%Iterator.prototype%, "constructor", v)
+        // argv[0] is the assigned value; it defaults to undefined because the
+        // setter is registered with length 1 (see JS_AddIntrinsicBaseObjects).
+        if (check_iterator(ctx, this_val) < 0)
+            return JS_EXCEPTION;
+        if (js_same_value(ctx, this_val, ctx->class_proto[JS_CLASS_ITERATOR]))
+            return JS_ThrowTypeError(ctx, "Cannot assign to read only property");
+        ret = JS_GetOwnProperty(ctx, NULL, this_val, JS_ATOM_constructor);
         if (ret < 0)
             return JS_EXCEPTION;
+        if (ret) {
+            if (JS_SetProperty(ctx, this_val, JS_ATOM_constructor, js_dup(argv[0])) < 0)
+                return JS_EXCEPTION;
+        } else {
+            if (JS_DefinePropertyValue(ctx, this_val, JS_ATOM_constructor,
+                                       js_dup(argv[0]),
+                                       JS_PROP_C_W_E | JS_PROP_THROW) < 0)
+                return JS_EXCEPTION;
+        }
+        return JS_UNDEFINED;
     }
     return js_dup(func_data[0]);
 }
@@ -57712,26 +57727,41 @@ int JS_AddIntrinsicBaseObjects(JSContext *ctx)
                               0);
     if (JS_IsException(obj2))
         return -1;
-    // quirk: Iterator.prototype.constructor is an accessor property
+    // quirk: Iterator.prototype.constructor is an accessor property. The getter
+    // (magic == 0) returns %Iterator%; the setter (magic == 1, length 1)
+    // implements SetterThatIgnoresPrototypeProperties. They must be separate
+    // function objects so that magic, not argc, distinguishes get from set.
     // TODO(bnoordhuis) mildly inefficient because JS_NewCConstructor
     // first creates a .constructor value property that we then replace with
     // an accessor
-    obj1 = JS_NewCFunctionData(ctx, js_iterator_constructor_getset,
-                               0, 0, 1, vc(&obj2));
-    if (JS_IsException(obj1)) {
-        JS_FreeValue(ctx, obj2);
-        return -1;
+    {
+        JSValue getter, setter;
+        getter = JS_NewCFunctionData(ctx, js_iterator_constructor_getset,
+                                     0, 0, 1, vc(&obj2));
+        if (JS_IsException(getter)) {
+            JS_FreeValue(ctx, obj2);
+            return -1;
+        }
+        setter = JS_NewCFunctionData(ctx, js_iterator_constructor_getset,
+                                     1, 1, 1, vc(&obj2));
+        if (JS_IsException(setter)) {
+            JS_FreeValue(ctx, getter);
+            JS_FreeValue(ctx, obj2);
+            return -1;
+        }
+        ctx->iterator_ctor_getset = js_dup(getter);
+        if (JS_DefineProperty(ctx, ctx->class_proto[JS_CLASS_ITERATOR],
+                              JS_ATOM_constructor, JS_UNDEFINED,
+                              getter, setter,
+                              JS_PROP_HAS_GET | JS_PROP_HAS_SET | JS_PROP_CONFIGURABLE) < 0) {
+            JS_FreeValue(ctx, getter);
+            JS_FreeValue(ctx, setter);
+            JS_FreeValue(ctx, obj2);
+            return -1;
+        }
+        JS_FreeValue(ctx, getter);
+        JS_FreeValue(ctx, setter);
     }
-    ctx->iterator_ctor_getset = js_dup(obj1);
-    if (JS_DefineProperty(ctx, ctx->class_proto[JS_CLASS_ITERATOR],
-                          JS_ATOM_constructor, JS_UNDEFINED,
-                          obj1, obj1,
-                          JS_PROP_HAS_GET | JS_PROP_HAS_SET | JS_PROP_CONFIGURABLE) < 0) {
-        JS_FreeValue(ctx, obj2);
-        JS_FreeValue(ctx, obj1);
-        return -1;
-    }
-    JS_FreeValue(ctx, obj1);
     ctx->iterator_ctor = obj2;
     JS_DefineAutoInitProperty(ctx, obj2, JS_ATOM_zip, JS_AUTOINIT_ID_BYTECODE,
                               (void *)(uintptr_t)JS_BUILTIN_ITERATOR_ZIP,

--- a/tests/bug1552.js
+++ b/tests/bug1552.js
@@ -1,0 +1,87 @@
+// `set Iterator.prototype.constructor` must implement
+// SetterThatIgnoresPrototypeProperties(%Iterator.prototype%, "constructor", v):
+// it operates on `this` (the receiver), not on the value being assigned.
+// https://tc39.es/ecma262/#sec-set-iterator.prototype.constructor
+// https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties
+import { assert, assertThrows } from "./assert.js";
+
+const desc = Object.getOwnPropertyDescriptor(Iterator.prototype, "constructor");
+const get = desc.get;
+const set = desc.set;
+
+assert(typeof get, "function");
+assert(typeof set, "function");
+assert(get !== set, true);
+assert(get.length, 0);
+assert(set.length, 1);
+
+assert(get.call({}), Iterator);
+assert(get.call(undefined), Iterator);
+assert(Iterator.prototype.constructor, Iterator);
+{
+    const o = {};
+    assert(get.call(o, 123), Iterator);
+    assert(Object.prototype.hasOwnProperty.call(o, "constructor"), false);
+}
+
+{
+    const o = {};
+    assert(set.call(o), undefined);
+    const d = Object.getOwnPropertyDescriptor(o, "constructor");
+    assert(d.value, undefined);
+    assert(d.writable, true);
+    assert(d.enumerable, true);
+    assert(d.configurable, true);
+}
+
+{
+    const o = {};
+    assert(set.call(o, 0), undefined);
+    // The value `v` need not be an object; a fresh data property is created.
+    const d = Object.getOwnPropertyDescriptor(o, "constructor");
+    assert(d.value, 0);
+    assert(d.writable, true);
+    assert(d.enumerable, true);
+    assert(d.configurable, true);
+}
+
+assertThrows(TypeError, () => set.call(undefined, 0));
+assertThrows(TypeError, () => set.call(null, 0));
+assertThrows(TypeError, () => set.call(1, 0));
+assertThrows(TypeError, () => set.call("s", 0));
+
+assertThrows(TypeError, () => set.call(Iterator.prototype, 0));
+assert(Iterator.prototype.constructor, Iterator);
+
+{
+    const o = {};
+    Object.defineProperty(o, "constructor", {
+        value: 1, writable: false, enumerable: true, configurable: true,
+    });
+    assertThrows(TypeError, () => set.call(o, 2));
+    assert(o.constructor, 1); // unchanged
+}
+
+{
+    const o = { constructor: 1 };
+    assert(set.call(o, 2), undefined);
+    assert(o.constructor, 2);
+}
+
+{
+    const o = Object.preventExtensions({});
+    assertThrows(TypeError, () => set.call(o, 0));
+    assert(Object.prototype.hasOwnProperty.call(o, "constructor"), false);
+}
+
+{
+    const it = Object.create(Iterator.prototype);
+    it.constructor = 42;
+    const d = Object.getOwnPropertyDescriptor(it, "constructor");
+    assert(d.value, 42);
+    assert(d.writable, true);
+    assert(d.enumerable, true);
+    assert(d.configurable, true);
+    assert(Iterator.prototype.constructor, Iterator);
+}
+

--- a/tests/iterator-tostringtag-setter.js
+++ b/tests/iterator-tostringtag-setter.js
@@ -1,0 +1,44 @@
+// `set Iterator.prototype[Symbol.toStringTag]` implements
+// SetterThatIgnoresPrototypeProperties(%Iterator.prototype%, @@toStringTag, v).
+// In particular the CreateDataPropertyOrThrow step must throw on a
+// non-extensible receiver rather than silently doing nothing.
+// https://tc39.es/ecma262/#sec-set-iterator.prototype-%symbol.tostringtag%
+// https://tc39.es/ecma262/#sec-SetterThatIgnoresPrototypeProperties
+import { assert, assertThrows } from "./assert.js";
+
+const desc = Object.getOwnPropertyDescriptor(Iterator.prototype, Symbol.toStringTag);
+const set = desc.set;
+
+assert(Iterator.prototype[Symbol.toStringTag], "Iterator");
+
+assertThrows(TypeError, () => set.call(undefined, "x"));
+assertThrows(TypeError, () => set.call(null, "x"));
+assertThrows(TypeError, () => set.call(1, "x"));
+
+assertThrows(TypeError, () => set.call(Iterator.prototype, "x"));
+assert(Iterator.prototype[Symbol.toStringTag], "Iterator");
+
+{
+    const o = {};
+    assert(set.call(o, "x"), undefined);
+    const d = Object.getOwnPropertyDescriptor(o, Symbol.toStringTag);
+    assert(d.value, "x");
+    assert(d.writable, true);
+    assert(d.enumerable, true);
+    assert(d.configurable, true);
+}
+
+{
+    const o = {};
+    Object.defineProperty(o, Symbol.toStringTag, {
+        value: "a", writable: false, enumerable: true, configurable: true,
+    });
+    assertThrows(TypeError, () => set.call(o, "b"));
+    assert(o[Symbol.toStringTag], "a");
+}
+
+{
+    const o = Object.preventExtensions({});
+    assertThrows(TypeError, () => set.call(o, "x"));
+    assert(Object.prototype.hasOwnProperty.call(o, Symbol.toStringTag), false);
+}


### PR DESCRIPTION
Fixes #1552
