### PR TITLE
Set module internal promise rejection as handled when appropriate

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -391,6 +391,45 @@ static void module_serde(void)
     JS_FreeRuntime(rt);
 }
 
+struct rejection_counts {
+    int reject_count;
+    int handle_count;
+};
+
+static void rejection_counter(JSContext *ctx, JSValueConst promise,
+                              JSValueConst reason, bool is_handled, void *opaque)
+{
+    struct rejection_counts *c = opaque;
+    if (is_handled)
+        c->handle_count++;
+    else
+        c->reject_count++;
+}
+
+// A synchronous module that throws at top level must surface exactly one unhandled rejection
+static void module_unhandled_rejection(void)
+{
+    struct rejection_counts c = {0, 0};
+    JSRuntime *rt = new_runtime();
+    JS_SetHostPromiseRejectionTracker(rt, rejection_counter, &c);
+    JSContext *ctx = JS_NewContext(rt);
+
+    static const char code[] = "throw new Error('Nuke the entire site from orbit. It\\'s the only way to be sure.')";
+    JSValue v = JS_Eval(ctx, code, strlen(code), "<m>", JS_EVAL_TYPE_MODULE);
+    JS_FreeValue(ctx, v);
+
+    JSContext *c1;
+    while (JS_ExecutePendingJob(rt, &c1) > 0)
+        ;
+
+    // net unhandled rejections == (2 rejects - 1 handled)
+    assert(c.reject_count == 2);
+    assert(c.handle_count == 1);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 static void runtime_cstring_free(void)
 {
     JSRuntime *rt = new_runtime();
@@ -1177,6 +1216,7 @@ int main(void)
     raw_context_global_var();
     is_array();
     module_serde();
+    module_unhandled_rejection();
     runtime_cstring_free();
     utf16_string();
     weak_map_gc_check();

--- a/quickjs.c
+++ b/quickjs.c
@@ -31748,6 +31748,7 @@ static int exec_module_list_cmp(const void *p1, const void *p2, void *opaque)
 static int js_execute_async_module(JSContext *ctx, JSModuleDef *m);
 static int js_execute_sync_module(JSContext *ctx, JSModuleDef *m,
                                   JSValue *pvalue);
+static void js_promise_set_handled(JSContext *ctx, JSValueConst promise);
 
 static JSValue js_async_module_execution_rejected(JSContext *ctx, JSValueConst this_val,
                                                   int argc, JSValueConst *argv, int magic,
@@ -31885,6 +31886,9 @@ static int js_execute_sync_module(JSContext *ctx, JSModuleDef *m,
             JS_FreeValue(ctx, promise);
         } else if (state == JS_PROMISE_REJECTED) {
             *pvalue = JS_PromiseResult(ctx, promise);
+            // rejection is propagated to module's evaluation promise; mark this internal
+            // promise as handled so it's not also surfaced as an unhandled rejection
+            js_promise_set_handled(ctx, promise);
             JS_FreeValue(ctx, promise);
             return -1;
         } else {
@@ -54783,7 +54787,7 @@ typedef struct JSPromiseData {
     JSPromiseStateEnum promise_state;
     /* 0=fulfill, 1=reject, list of JSPromiseReactionData.link */
     struct list_head promise_reactions[2];
-    bool is_handled; /* Note: only useful to debug */
+    bool is_handled;
     JSValue promise_result;
 } JSPromiseData;
 
@@ -54817,6 +54821,29 @@ JSValue JS_PromiseResult(JSContext *ctx, JSValueConst promise)
     if (!s)
         return JS_UNDEFINED;
     return js_dup(s->promise_result);
+}
+
+// Notify the host tracker of an unreported rejection's state
+static void call_promise_rejection_tracker(JSContext *ctx, JSValueConst promise,
+                                         bool is_handled)
+{
+    JSPromiseData *s = JS_GetOpaque(promise, JS_CLASS_PROMISE);
+    JSRuntime *rt = ctx->rt;
+    if (s && s->promise_state == JS_PROMISE_REJECTED && !s->is_handled &&
+        rt->host_promise_rejection_tracker) {
+        rt->host_promise_rejection_tracker(ctx, promise, s->promise_result,
+                                           is_handled, rt->host_promise_rejection_tracker_opaque);
+    }
+}
+
+// Mark rejected promise as handled by the engine itself and let the host know that the promise is handled
+static void js_promise_set_handled(JSContext *ctx, JSValueConst promise)
+{
+    JSPromiseData *s = JS_GetOpaque(promise, JS_CLASS_PROMISE);
+    if (!s)
+        return;
+    call_promise_rejection_tracker(ctx, promise, true);
+    s->is_handled = true;
 }
 
 bool JS_IsPromise(JSValueConst val)
@@ -54934,12 +54961,7 @@ static void fulfill_or_reject_promise(JSContext *ctx, JSValueConst promise,
         }
     }
 
-    if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
-        JSRuntime *rt = ctx->rt;
-        if (rt->host_promise_rejection_tracker)
-            rt->host_promise_rejection_tracker(ctx, promise, value, false,
-                                               rt->host_promise_rejection_tracker_opaque);
-    }
+    call_promise_rejection_tracker(ctx, promise, false);
 
     list_for_each_safe(el, el1, &s->promise_reactions[is_reject]) {
         rd = list_entry(el, JSPromiseReactionData, link);
@@ -55728,12 +55750,7 @@ static __exception int perform_promise_then(JSContext *ctx,
             list_add_tail(&rd_array[i]->link, &s->promise_reactions[i]);
     } else {
         JSValueConst args[5];
-        if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
-            JSRuntime *rt = ctx->rt;
-            if (rt->host_promise_rejection_tracker)
-                rt->host_promise_rejection_tracker(ctx, promise, s->promise_result,
-                                                   true, rt->host_promise_rejection_tracker_opaque);
-        }
+        call_promise_rejection_tracker(ctx, promise, true);
         i = s->promise_state - JS_PROMISE_FULFILLED;
         rd = rd_array[i];
         args[0] = rd->resolving_funcs[0];

--- a/tests.conf
+++ b/tests.conf
@@ -12,3 +12,4 @@ tests/fixture_cyclic_import.js
 tests/microbench.js
 tests/test_worker_module.js
 tests/fixture_string_exports.js
+tests/fixture_throwing_module.js

--- a/tests/dynamic_import_rejection_handled.js
+++ b/tests/dynamic_import_rejection_handled.js
@@ -1,0 +1,7 @@
+/*---
+flags: [qjs:track-promise-rejections]
+---*/
+
+// import() of a throwing module must not leak the module's internal rejection.
+const error = await import("./fixture_throwing_module.js").then(() => 'ok', e => e)
+print('Got this error:', error.message)

--- a/tests/fixture_throwing_module.js
+++ b/tests/fixture_throwing_module.js
@@ -1,0 +1,1 @@
+throw new Error("Nuke the entire site from orbit. It's the only way to be sure.")


### PR DESCRIPTION
Before:

A module body is run as an async function. js_execute_sync_module calls that function. It finds its result promise already rejected, reads the result, and frees it without attaching a JS handler. The rejection fires a unhandled notification. That notification is never balanced by a is_handled=true notification. The internal promise rejection surfaces as an unhandled rejection in addition to the module's evaluation promise.

Additional symptoms:

A dynamic import() whose rejection is fully handled by the caller still leaked a unhandled rejection: the internal body promise stayed orphaned. Without the fix a `import('m').then(ok, onerr)` of a throwing module results in a unhandled rejection.

Fix:

Mark the consumed promise handled, emitting the balancing notification with is_handled=true so the host can handle the rejection correctly.

With the fix, a `import('m').then(ok, onerr)` nets zero false positives.

Added both JS test and api-test regression tests.