### PR TITLE
Fix Iterator Helper close when the source iterator has no `return`

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -45493,13 +45493,9 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
     case JS_ITERATOR_HELPER_KIND_DROP:
         {
             JSValue item, method;
-            if (magic == GEN_MAGIC_NEXT) {
-                method = js_dup(it->next);
-            } else {
-                method = JS_GetProperty(ctx, it->obj, JS_ATOM_return);
-                if (JS_IsException(method))
-                    goto fail;
-            }
+            if (magic == GEN_MAGIC_RETURN)
+                goto close;
+            method = js_dup(it->next);
             while (it->count > 0) {
                 it->count--;
                 item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
@@ -45508,8 +45504,6 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
                     goto fail;
                 }
                 JS_FreeValue(ctx, item);
-                if (magic == GEN_MAGIC_RETURN)
-                    *pdone = true;
                 if (*pdone) {
                     JS_FreeValue(ctx, method);
                     ret = JS_UNDEFINED;
@@ -45529,20 +45523,16 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
         {
             JSValue item, method, selected, index_val;
             JSValueConst args[2];
-            if (magic == GEN_MAGIC_NEXT) {
-                method = js_dup(it->next);
-            } else {
-                method = JS_GetProperty(ctx, it->obj, JS_ATOM_return);
-                if (JS_IsException(method))
-                    goto fail;
-            }
+            if (magic == GEN_MAGIC_RETURN)
+                goto close;
+            method = js_dup(it->next);
         filter_again:
             item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
             if (JS_IsException(item)) {
                 JS_FreeValue(ctx, method);
                 goto fail;
             }
-            if (*pdone || magic == GEN_MAGIC_RETURN) {
+            if (*pdone) {
                 JS_FreeValue(ctx, method);
                 ret = item;
                 goto done;
@@ -45570,20 +45560,16 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
         {
             JSValue item, method, index_val, iter;
             JSValueConst args[2];
+            if (magic == GEN_MAGIC_RETURN)
+                goto close;
         flat_map_again:
             if (JS_IsUndefined(it->inner)) {
-                if (magic == GEN_MAGIC_NEXT) {
-                    method = js_dup(it->next);
-                } else {
-                    method = JS_GetProperty(ctx, it->obj, JS_ATOM_return);
-                    if (JS_IsException(method))
-                        goto fail;
-                }
+                method = js_dup(it->next);
                 item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
                 JS_FreeValue(ctx, method);
                 if (JS_IsException(item))
                     goto fail;
-                if (*pdone || magic == GEN_MAGIC_RETURN) {
+                if (*pdone) {
                     ret = item;
                     goto done;
                 }
@@ -45619,10 +45605,7 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
                 it->inner = iter;
             }
 
-            if (magic == GEN_MAGIC_NEXT)
-                method = JS_GetProperty(ctx, it->inner, JS_ATOM_next);
-            else
-                method = JS_GetProperty(ctx, it->inner, JS_ATOM_return);
+            method = JS_GetProperty(ctx, it->inner, JS_ATOM_next);
             if (JS_IsException(method)) {
             inner_fail:
                 JS_IteratorClose(ctx, it->inner, false);
@@ -45630,16 +45613,11 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
                 it->inner = JS_UNDEFINED;
                 goto fail;
             }
-            if (magic == GEN_MAGIC_RETURN && (JS_IsUndefined(method) || JS_IsNull(method))) {
-                goto inner_end;
-            } else {
-                item = JS_IteratorNext(ctx, it->inner, method, 0, NULL, pdone);
-                JS_FreeValue(ctx, method);
-                if (JS_IsException(item))
-                    goto inner_fail;
-            }
+            item = JS_IteratorNext(ctx, it->inner, method, 0, NULL, pdone);
+            JS_FreeValue(ctx, method);
+            if (JS_IsException(item))
+                goto inner_fail;
             if (*pdone) {
-            inner_end:
                 *pdone = false; // The outer iterator must continue.
                 JS_IteratorClose(ctx, it->inner, false);
                 JS_FreeValue(ctx, it->inner);
@@ -45654,18 +45632,14 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
         {
             JSValue item, method, index_val;
             JSValueConst args[2];
-            if (magic == GEN_MAGIC_NEXT) {
-                method = js_dup(it->next);
-            } else {
-                method = JS_GetProperty(ctx, it->obj, JS_ATOM_return);
-                if (JS_IsException(method))
-                    goto fail;
-            }
+            if (magic == GEN_MAGIC_RETURN)
+                goto close;
+            method = js_dup(it->next);
             item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
             JS_FreeValue(ctx, method);
             if (JS_IsException(item))
                 goto fail;
-            if (*pdone || magic == GEN_MAGIC_RETURN) {
+            if (*pdone) {
                 ret = item;
                 goto done;
             }
@@ -45683,34 +45657,41 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
     case JS_ITERATOR_HELPER_KIND_TAKE:
         {
             JSValue item, method;
-            if (it->count > 0) {
-                if (magic == GEN_MAGIC_NEXT) {
-                    method = js_dup(it->next);
-                } else {
-                    method = JS_GetProperty(ctx, it->obj, JS_ATOM_return);
-                    if (JS_IsException(method))
-                        goto fail;
-                }
-                it->count--;
-                item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-                JS_FreeValue(ctx, method);
-                if (JS_IsException(item))
-                    goto fail;
-                ret = item;
-                goto done;
-            }
-
-            *pdone = true;
-            if (JS_IteratorClose(ctx, it->obj, false))
-                ret = JS_EXCEPTION;
-            else
-                ret = JS_UNDEFINED;
+            if (magic == GEN_MAGIC_RETURN || it->count == 0)
+                goto close;
+            method = js_dup(it->next);
+            it->count--;
+            item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
+            JS_FreeValue(ctx, method);
+            if (JS_IsException(item))
+                goto fail;
+            ret = item;
             goto done;
         }
         break;
     default:
         abort();
     }
+
+close:
+    /* Close the underlying iterator(s) and report completion. Used both when
+       the helper's own `return` is invoked and when a `take` reaches its
+       limit. JS_IteratorClose is a no-op when the iterator has no `return`
+       method, so this must not assume one exists. */
+    *pdone = true;
+    ret = JS_UNDEFINED;
+    if (!JS_IsUndefined(it->inner)) {
+        // flatMap: close the active inner iterator first.
+        if (JS_IteratorClose(ctx, it->inner, false))
+            ret = JS_EXCEPTION;
+        JS_FreeValue(ctx, it->inner);
+        it->inner = JS_UNDEFINED;
+    }
+    if (JS_IsException(ret))
+        JS_IteratorClose(ctx, it->obj, true); // preserve the pending exception
+    else if (JS_IteratorClose(ctx, it->obj, false))
+        ret = JS_EXCEPTION;
+    goto done;
 
 done:
     it->done = magic == GEN_MAGIC_NEXT ? *pdone : 1;

--- a/quickjs.c
+++ b/quickjs.c
@@ -45667,7 +45667,6 @@ close:
     }
     if (JS_IteratorClose(ctx, it->obj, JS_IsException(ret)))
         ret = JS_EXCEPTION;
-    goto done;
 
 done:
     it->done = magic == GEN_MAGIC_NEXT ? *pdone : 1;

--- a/quickjs.c
+++ b/quickjs.c
@@ -45492,27 +45492,22 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
     switch (it->kind) {
     case JS_ITERATOR_HELPER_KIND_DROP:
         {
-            JSValue item, method;
+            JSValue item;
             if (magic == GEN_MAGIC_RETURN)
                 goto close;
-            method = js_dup(it->next);
             while (it->count > 0) {
                 it->count--;
-                item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-                if (JS_IsException(item)) {
-                    JS_FreeValue(ctx, method);
+                item = JS_IteratorNext(ctx, it->obj, it->next, 0, NULL, pdone);
+                if (JS_IsException(item))
                     goto fail;
-                }
                 JS_FreeValue(ctx, item);
                 if (*pdone) {
-                    JS_FreeValue(ctx, method);
                     ret = JS_UNDEFINED;
                     goto done;
                 }
             }
 
-            item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-            JS_FreeValue(ctx, method);
+            item = JS_IteratorNext(ctx, it->obj, it->next, 0, NULL, pdone);
             if (JS_IsException(item))
                 goto fail;
             ret = item;
@@ -45521,19 +45516,15 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
         break;
     case JS_ITERATOR_HELPER_KIND_FILTER:
         {
-            JSValue item, method, selected, index_val;
+            JSValue item, selected, index_val;
             JSValueConst args[2];
             if (magic == GEN_MAGIC_RETURN)
                 goto close;
-            method = js_dup(it->next);
         filter_again:
-            item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-            if (JS_IsException(item)) {
-                JS_FreeValue(ctx, method);
+            item = JS_IteratorNext(ctx, it->obj, it->next, 0, NULL, pdone);
+            if (JS_IsException(item))
                 goto fail;
-            }
             if (*pdone) {
-                JS_FreeValue(ctx, method);
                 ret = item;
                 goto done;
             }
@@ -45544,11 +45535,9 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
             JS_FreeValue(ctx, index_val);
             if (JS_IsException(selected)) {
                 JS_FreeValue(ctx, item);
-                JS_FreeValue(ctx, method);
                 goto fail;
             }
             if (JS_ToBoolFree(ctx, selected)) {
-                JS_FreeValue(ctx, method);
                 ret = item;
                 goto done;
             }
@@ -45564,9 +45553,7 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
                 goto close;
         flat_map_again:
             if (JS_IsUndefined(it->inner)) {
-                method = js_dup(it->next);
-                item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-                JS_FreeValue(ctx, method);
+                item = JS_IteratorNext(ctx, it->obj, it->next, 0, NULL, pdone);
                 if (JS_IsException(item))
                     goto fail;
                 if (*pdone) {
@@ -45630,13 +45617,11 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
         break;
     case JS_ITERATOR_HELPER_KIND_MAP:
         {
-            JSValue item, method, index_val;
+            JSValue item, index_val;
             JSValueConst args[2];
             if (magic == GEN_MAGIC_RETURN)
                 goto close;
-            method = js_dup(it->next);
-            item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-            JS_FreeValue(ctx, method);
+            item = JS_IteratorNext(ctx, it->obj, it->next, 0, NULL, pdone);
             if (JS_IsException(item))
                 goto fail;
             if (*pdone) {
@@ -45656,13 +45641,11 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
         break;
     case JS_ITERATOR_HELPER_KIND_TAKE:
         {
-            JSValue item, method;
+            JSValue item;
             if (magic == GEN_MAGIC_RETURN || it->count == 0)
                 goto close;
-            method = js_dup(it->next);
             it->count--;
-            item = JS_IteratorNext(ctx, it->obj, method, 0, NULL, pdone);
-            JS_FreeValue(ctx, method);
+            item = JS_IteratorNext(ctx, it->obj, it->next, 0, NULL, pdone);
             if (JS_IsException(item))
                 goto fail;
             ret = item;
@@ -45674,22 +45657,15 @@ static JSValue js_iterator_helper_next(JSContext *ctx, JSValueConst this_val,
     }
 
 close:
-    /* Close the underlying iterator(s) and report completion. Used both when
-       the helper's own `return` is invoked and when a `take` reaches its
-       limit. JS_IteratorClose is a no-op when the iterator has no `return`
-       method, so this must not assume one exists. */
     *pdone = true;
     ret = JS_UNDEFINED;
     if (!JS_IsUndefined(it->inner)) {
-        // flatMap: close the active inner iterator first.
         if (JS_IteratorClose(ctx, it->inner, false))
             ret = JS_EXCEPTION;
         JS_FreeValue(ctx, it->inner);
         it->inner = JS_UNDEFINED;
     }
-    if (JS_IsException(ret))
-        JS_IteratorClose(ctx, it->obj, true); // preserve the pending exception
-    else if (JS_IteratorClose(ctx, it->obj, false))
+    if (JS_IteratorClose(ctx, it->obj, JS_IsException(ret)))
         ret = JS_EXCEPTION;
     goto done;
 

--- a/tests/bug1557.js
+++ b/tests/bug1557.js
@@ -1,0 +1,55 @@
+// https://github.com/quickjs-ng/quickjs/issues/1557
+import { assert, assertArrayEquals } from "./assert.js";
+
+assertArrayEquals(
+    Iterator.from([1, 2, 3, 4]).filter(x => x > 1).take(1).toArray(),
+    [2]
+);
+
+assertArrayEquals(Iterator.from([1, 2, 3, 4]).map(x => x * 2).take(2).toArray(), [2, 4]);
+assertArrayEquals(Iterator.from([1, 2, 3, 4, 5]).drop(1).take(2).toArray(), [2, 3]);
+assertArrayEquals(Iterator.from([1, 2, 3]).flatMap(x => [x, x * 10]).take(3).toArray(), [1, 10, 2]);
+assertArrayEquals(Iterator.from([1, 2, 3, 4, 5, 6]).filter(x => x % 2 === 0).map(x => x + 1).take(2).toArray(), [3, 5]);
+
+// Calling `.return()` explicitly on a helper over a `return`-less source must
+// not throw and must report completion with an undefined value.
+for (const make of [
+    it => it.map(x => x),
+    it => it.filter(() => true),
+    it => it.take(5),
+    it => it.drop(0),
+    it => it.flatMap(x => [x]),
+]) {
+    // `[][Symbol.iterator]()` is a plain array iterator: it has no `return`.
+    const helper = make([1, 2, 3][Symbol.iterator]());
+    const r1 = helper.return();
+    assert(r1.done, true);
+    assert(r1.value, undefined);
+    // A second `.return()` is a no-op and also reports done.
+    const r2 = helper.return();
+    assert(r2.done, true);
+    assert(r2.value, undefined);
+}
+
+// When the source *does* have a `return`, closing the helper must still
+// forward to it exactly once.
+for (const make of [
+    it => it.map(x => x),
+    it => it.filter(() => true),
+    it => it.take(5),
+    it => it.drop(0),
+    it => it.flatMap(x => [x]),
+]) {
+    let returnCount = 0;
+    class Src extends Iterator {
+        next() { return { done: false, value: 1 }; }
+        return(value) { returnCount++; return { done: true, value }; }
+    }
+    const helper = make(new Src());
+    helper.next();
+    assert(returnCount, 0);
+    helper.return();
+    assert(returnCount, 1);
+    helper.return(); // already closed: not forwarded again
+    assert(returnCount, 1);
+}


### PR DESCRIPTION
Fixes #1557
