### PR TITLE
Fix BigInt.asUintN of negatives when width is limb-aligned

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -57810,28 +57810,62 @@ static JSValue js_bigint_asUintN(JSContext *ctx,
         res = __JS_NewShortBigInt(ctx, 0);
     } else if (JS_VALUE_GET_TAG(a) == JS_TAG_SHORT_BIG_INT) {
         /* fast case */
-        if (bits >= JS_SHORT_BIG_INT_BITS) {
+        js_slimb_t sv = JS_VALUE_GET_SHORT_BIG_INT(a);
+        if (bits >= JS_SHORT_BIG_INT_BITS && (asIntN || sv >= 0)) {
             res = a;
-        } else {
+        } else if (bits < JS_SHORT_BIG_INT_BITS) {
             uint64_t v;
             int shift;
             shift = 64 - bits;
-            v = JS_VALUE_GET_SHORT_BIG_INT(a);
+            v = sv;
             v = v << shift;
             if (asIntN)
                 v = (int64_t)v >> shift;
             else
                 v = v >> shift;
             res = __JS_NewShortBigInt(ctx, v);
+        } else {
+            JSBigInt *r;
+            uint64_t len64 = (bits + JS_LIMB_BITS - 1) / JS_LIMB_BITS;
+            int len, shift, i;
+
+            if (len64 > JS_BIGINT_MAX_SIZE) {
+                JS_FreeValue(ctx, a);
+                return JS_ThrowRangeError(ctx, "BigInt is too large to allocate");
+            }
+            len = len64;
+            r = js_bigint_new(ctx, len);
+            if (!r) {
+                JS_FreeValue(ctx, a);
+                return JS_EXCEPTION;
+            }
+            r->len = len;
+            r->tab[0] = sv;
+            for(i = 1; i < len; i++)
+                r->tab[i] = -1;
+            shift = (-bits) & (JS_LIMB_BITS - 1);
+            r->tab[len - 1] = (r->tab[len - 1] << shift) >> shift;
+            r = js_bigint_extend(ctx, r, 0);
+            JS_FreeValue(ctx, a);
+            if (!r)
+                return JS_EXCEPTION;
+            res = JS_CompactBigInt(ctx, r);
         }
     } else {
         JSBigInt *r, *p = JS_VALUE_GET_PTR(a);
-        if (bits >= p->len * JS_LIMB_BITS) {
+        int is_neg = js_bigint_sign(p);
+        if (bits >= (uint64_t)p->len * JS_LIMB_BITS &&
+            (asIntN || !is_neg)) {
             res = a;
         } else {
+            uint64_t len64 = (bits + JS_LIMB_BITS - 1) / JS_LIMB_BITS;
             int len, shift, i;
             js_limb_t v;
-            len = (bits + JS_LIMB_BITS - 1) / JS_LIMB_BITS;
+            if (len64 > JS_BIGINT_MAX_SIZE) {
+                JS_FreeValue(ctx, a);
+                return JS_ThrowRangeError(ctx, "BigInt is too large to allocate");
+            }
+            len = len64;
             r = js_bigint_new(ctx, len);
             if (!r) {
                 JS_FreeValue(ctx, a);
@@ -57839,15 +57873,21 @@ static JSValue js_bigint_asUintN(JSContext *ctx,
             }
             r->len = len;
             for(i = 0; i < len - 1; i++)
-                r->tab[i] = p->tab[i];
+                r->tab[i] = i < p->len ? p->tab[i] : -is_neg;
             shift = (-bits) & (JS_LIMB_BITS - 1);
             /* 0 <= shift <= JS_LIMB_BITS - 1 */
-            v = p->tab[len - 1] << shift;
+            v = (len - 1 < p->len ? p->tab[len - 1] : -is_neg) << shift;
             if (asIntN)
                 v = (js_slimb_t)v >> shift;
             else
                 v = v >> shift;
             r->tab[len - 1] = v;
+            if (!asIntN)
+                r = js_bigint_extend(ctx, r, 0);
+            if (!r) {
+                JS_FreeValue(ctx, a);
+                return JS_EXCEPTION;
+            }
             r = js_bigint_normalize(ctx, r);
             JS_FreeValue(ctx, a);
             res = JS_CompactBigInt(ctx, r);

--- a/tests/test_bigint.js
+++ b/tests/test_bigint.js
@@ -102,6 +102,36 @@ function test_bigint_map()
     assert(m.size, 0);
 }
 
+function test_bigint_asintn()
+{
+    /* BigInt.asIntN */
+    assert(BigInt.asIntN(0, -1n), 0n);
+    assert(BigInt.asIntN(1, -1n), -1n);
+    assert(BigInt.asIntN(8, 128n), -128n);
+    assert(BigInt.asIntN(8, 127n), 127n);
+    assert(BigInt.asIntN(64, -1n), -1n);
+    assert(BigInt.asIntN(64, 0x8000000000000000n), -0x8000000000000000n);
+    assert(BigInt.asIntN(128, -1n), -1n);
+
+    /* BigInt.asUintN: wrapping a negative value when the requested width is a
+       multiple of the internal limb size used to return the value unchanged. */
+    assert(BigInt.asUintN(0, -1n), 0n);
+    assert(BigInt.asUintN(1, -1n), 1n);
+    assert(BigInt.asUintN(8, -1n), 0xffn);
+    assert(BigInt.asUintN(64, -1n), 0xffffffffffffffffn);
+    assert(BigInt.asUintN(64, -2n), 0xfffffffffffffffen);
+    assert(BigInt.asUintN(64, 0x8000000000000000n), 0x8000000000000000n);
+    assert(BigInt.asUintN(128, -1n), (1n << 128n) - 1n);
+    assert(BigInt.asUintN(192, -1n), (1n << 192n) - 1n);
+    assert(BigInt.asUintN(64, -(1n << 64n)), 0n);
+    assert(BigInt.asUintN(64, 1n << 64n), 0n);
+
+    /* non-negative values are returned unchanged */
+    assert(BigInt.asUintN(64, 123n), 123n);
+    assert(BigInt.asIntN(64, 123n), 123n);
+}
+
 test_bigint1();
 test_bigint2();
 test_bigint_map();
+test_bigint_asintn();


### PR DESCRIPTION
`js_bigint_asUintN()` returned the argument unchanged whenever the requested width was at least as wide as the value's internal representation. That is correct for `asIntN`, but for `asUintN` of a negative value the result must be reinterpreted as unsigned (wrapped modulo `2**bits`).

So `BigInt.asUintN(64, -1n)` returned `-1n` instead of `18446744073709551615n`, for any width that is a whole number of internal limbs (64, 128, 192, ...). Non-negative values and `asIntN` are unaffected.

| call | before | after |
|---|---|---|
| `BigInt.asUintN(64, -1n)` | `-1n` | `18446744073709551615n` |
| `BigInt.asUintN(64, -2n)` | `-2n` | `18446744073709551614n` |
| `BigInt.asUintN(128, -1n)` | `-1n` | `2**128 - 1` |
| `BigInt.asUintN(192, -1n)` | `-1n` | `2**192 - 1` |
| `BigInt.asIntN(64, -1n)` | `-1n` | `-1n` (unchanged) |

The fix guards the sign-extension path for both the short and heap BigInt representations, and extends the result with a leading zero limb so the unsigned value stays positive.

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*
