### PR TITLE
Fix missing module exports for array destructuring

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -26800,6 +26800,11 @@ static int js_parse_destructuring_element(JSParseState *s, int tok,
                         goto var_error;
                     if (js_define_var(s, var_name, tok))
                         goto var_error;
+                    if (export_flag) {
+                        if (!add_export_entry(s, s->cur_func->module, var_name, var_name,
+                                              JS_EXPORT_TYPE_LOCAL))
+                            goto var_error;
+                    }
                     opcode = OP_scope_get_var;
                     scope = s->cur_func->scope_level;
                 } else {

--- a/tests/destructured-export.js
+++ b/tests/destructured-export.js
@@ -4,5 +4,17 @@ import * as mod from "./destructured-export.js";
 export const { a, b, c } = { a: 1, b: 2, c: 3 };
 export const d = 4;
 
+/* array destructuring targets must be exported too */
+export const [e, f] = [5, 6];
+export const [g, ...h] = [7, 8, 9];
+export let [{ i }, [j]] = [{ i: 10 }, [11]];
+
 assert(typeof mod === 'object');
-assertArrayEquals(Object.keys(mod), ["a", "b", "c", "d"]);
+assertArrayEquals(Object.keys(mod),
+                  ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]);
+assert(mod.e, 5);
+assert(mod.f, 6);
+assert(mod.g, 7);
+assertArrayEquals(mod.h, [8, 9]);
+assert(mod.i, 10);
+assert(mod.j, 11);


### PR DESCRIPTION
`export const [a, b] = [1, 2]` (and `let`/`var`) did not register the destructured names as module exports, so importing them failed with `SyntaxError: Could not find export 'a'`. Object destructuring already worked because only the object-property branch of `js_parse_destructuring_element()` emitted an export entry; the array-element branch did not.

The fix adds the same `add_export_entry()` call to that branch, guarded by `export_flag`, mirroring the object case.

| syntax | before | after |
|---|---|---|
| `export const { a } = ...` | exported | exported |
| `export const [a] = ...` | not exported | exported |
| `export const [a, ...r] = ...` | not exported | exported |
| `export let [{ i }, [j]] = ...` | not exported | exported |

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*
