### PR TITLE
Fix for-await-of calling return() on normal completion

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -17188,6 +17188,16 @@ static __exception int js_iterator_get_value_done(JSContext *ctx, JSValue *sp)
     JS_FreeValue(ctx, obj);
     sp[-1] = value;
     sp[0] = js_bool(done);
+    if (done) {
+        /* Iterator exhausted via {done:true}: drop the iterator object (stack
+           layout at the for-await `next` call is iter_obj,next,catch_offset,result
+           so iter_obj is sp[-4]) so the trailing OP_iterator_close skips calling
+           return(). Mirrors js_for_of_next, which nulls the iterator on done.
+           Per spec AsyncIteratorClose must NOT run on normal completion. This op
+           is emitted only by the for-await-of loop, so the layout is fixed. */
+        JS_FreeValue(ctx, sp[-4]);
+        sp[-4] = JS_UNDEFINED;
+    }
     return 0;
 }
 

--- a/tests/for-await-normal-close.js
+++ b/tests/for-await-normal-close.js
@@ -1,0 +1,35 @@
+import { assert } from "./assert.js";
+
+function makeAsyncIter(log) {
+    let i = 0;
+    return { [Symbol.asyncIterator]() { return {
+        next() {
+            return Promise.resolve(i < 2 ? { value: i++, done: false }
+                                          : { value: undefined, done: true });
+        },
+        return() { log.returned++; return Promise.resolve({ done: true }); },
+    }; } };
+}
+
+/* normal completion must NOT call return() */
+{
+    const log = { returned: 0 };
+    for await (const x of makeAsyncIter(log)) {}
+    assert(log.returned, 0);
+}
+
+/* break is an abrupt completion and must call return() */
+{
+    const log = { returned: 0 };
+    for await (const x of makeAsyncIter(log)) break;
+    assert(log.returned, 1);
+}
+
+/* throw is an abrupt completion and must call return() */
+{
+    const log = { returned: 0 };
+    try {
+        for await (const x of makeAsyncIter(log)) throw new Error("stop");
+    } catch (e) {}
+    assert(log.returned, 1);
+}


### PR DESCRIPTION
A `for await` loop that ran to completion normally still called the async iterator's `return()` method. Per spec, `AsyncIteratorClose` only runs on an abrupt completion (break, throw, return), not on normal exhaustion. Sync `for..of` already behaves correctly; only `for await` was affected.

| completion | before | after |
|---|---|---|
| normal (iterator returns `done: true`) | `return()` called | not called |
| `break` | `return()` called | `return()` called |
| `throw` | `return()` called | `return()` called |

`js_iterator_get_value_done()` now clears the iterator slot on exhaustion so the trailing close is skipped.

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*
