### PR TITLE
Fix double free of a detached ArrayBuffer's backing store

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1207,6 +1207,39 @@ static void bulk_free_macros(void) {
     JS_FreeRuntime(rt);
 }
 
+static int detach_free_count;
+
+static void detach_free_func(JSRuntime *rt, void *opaque, void *ptr)
+{
+    detach_free_count++;
+    free(ptr);
+}
+
+static void detach_array_buffer_free_once(void)
+{
+    JSValue obj;
+    uint8_t *buf;
+
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+
+    detach_free_count = 0;
+    buf = malloc(8);
+    obj = JS_NewArrayBuffer(ctx, buf, 8, detach_free_func, NULL, false);
+    assert(JS_IsArrayBuffer(obj));
+
+    /* detaching releases the backing store exactly once */
+    JS_DetachArrayBuffer(ctx, obj);
+    assert(detach_free_count == 1);
+
+    /* finalizing the detached buffer must not release it a second time */
+    JS_FreeValue(ctx, obj);
+    assert(detach_free_count == 1);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     cfunctions();
@@ -1231,5 +1264,6 @@ int main(void)
     get_uint8array();
     new_symbol();
     bulk_free_macros();
+    detach_array_buffer_free_once();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -58610,8 +58610,13 @@ void JS_DetachArrayBuffer(JSContext *ctx, JSValueConst obj)
 
     if (!abuf || abuf->detached)
         return;
-    if (abuf->free_func)
+    if (abuf->free_func) {
         abuf->free_func(ctx->rt, abuf->opaque, abuf->data);
+        /* The backing data has been released. Do not release it again when
+           the detached ArrayBuffer object is later finalized. */
+        abuf->free_func = NULL;
+        abuf->opaque = NULL;
+    }
     abuf->data = NULL;
     abuf->byte_length = 0;
     abuf->detached = true;


### PR DESCRIPTION
`JS_DetachArrayBuffer()` calls `abuf->free_func()` to release the backing store but left `free_func` and `opaque` set on the buffer. When the detached ArrayBuffer was later finalized, `js_array_buffer_finalizer()` called `free_func()` a second time.

For the default allocator this was a harmless `free(NULL)`, but a custom `free_func` passed to `JS_NewArrayBuffer()` that manages an external resource via `opaque` was invoked twice.

| free_func | before | after |
|---|---|---|
| default allocator | called twice (`free(NULL)`, harmless) | called once |
| custom, resource keyed on `opaque` | called twice (double free) | called once |

The fix clears `free_func` and `opaque` after detaching so the finalizer does not run it again.

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*
