### PR TITLE
docs: add RongJS to projects

### DIFF
--- a/docs/docs/projects.md
+++ b/docs/docs/projects.md
@@ -91,4 +91,7 @@ Header only library for quickjs-ng with modern C++ interface (Archived).
 
 A lightweight proxy client, empowered by sing-box and thrift.
 
+## [RongJS](https://github.com/LingXia-Dev/Rong)
+
+A multi-engine JavaScript runtime and Rust embedding API with first-class QuickJS-NG support.
 


### PR DESCRIPTION
## Summary

Add [RongJS](https://github.com/LingXia-Dev/Rong) to the list of projects using QuickJS-NG.

RongJS is a multi-engine JavaScript runtime and Rust embedding API with first-class QuickJS-NG support.