### PR TITLE
Harden against hash collisions

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -52792,10 +52792,10 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
         h = JS_VALUE_GET_INT(key);
         break;
     case JS_TAG_STRING:
-        h = hash_string(JS_VALUE_GET_STRING(key), ctx->hash_seed);
+        h = hash_string(JS_VALUE_GET_STRING(key), 0);
         break;
     case JS_TAG_STRING_ROPE:
-        h = hash_string_rope(key, ctx->hash_seed);
+        h = hash_string_rope(key, 0);
         break;
     case JS_TAG_OBJECT:
     case JS_TAG_SYMBOL:
@@ -52809,8 +52809,7 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
         goto hash_float64;
     case JS_TAG_BIG_INT:
         r = JS_VALUE_GET_PTR(key);
-        h = hash_string8((void *)r->tab, r->len * sizeof(*r->tab),
-                         ctx->hash_seed);
+        h = hash_string8((void *)r->tab, r->len * sizeof(*r->tab), 0);
         break;
     case JS_TAG_FLOAT64:
         d = JS_VALUE_GET_FLOAT64(key);
@@ -52820,13 +52819,13 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
     hash_float64:
         u.d = d;
         h = (u.u32[0] ^ u.u32[1]) * 3163;
-        return h ^= JS_TAG_FLOAT64;
+        tag = JS_TAG_FLOAT64;
+        break;
     default:
         h = 0;
         break;
     }
-    h ^= tag;
-    return h;
+    return h ^ ctx->hash_seed ^ hash32(tag);
 }
 
 static JSMapRecord *map_find_record(JSContext *ctx, JSMapState *s,

--- a/quickjs.c
+++ b/quickjs.c
@@ -582,6 +582,7 @@ struct JSContext {
     double time_origin;
 
     uint64_t random_state;
+    uint32_t hash_seed;
 
     /* when the counter reaches zero, JSRutime.interrupt_handler is called */
     int interrupt_counter;
@@ -1365,6 +1366,7 @@ static JSValue js_error_constructor(JSContext *ctx, JSValueConst new_target,
                                     int argc, JSValueConst *argv, int magic);
 static JSValue js_object_defineProperty(JSContext *ctx, JSValueConst this_val,
                                         int argc, JSValueConst *argv, int magic);
+static uint64_t xorshift64star(uint64_t *pstate);
 
 typedef enum JSStrictEqModeEnum {
     JS_EQ_STRICT,
@@ -2863,6 +2865,12 @@ JSContext *JS_NewContextRaw(JSRuntime *rt)
     ctx->error_prepare_stack = JS_UNDEFINED;
     ctx->error_stack_trace_limit = js_int32(10);
     init_list_head(&ctx->loaded_modules);
+    // TODO(bnoordhuis) use getrandom() etc.
+    ctx->random_state = js__gettimeofday_us();
+    // the state must be non zero
+    if (ctx->random_state == 0)
+        ctx->random_state = 1;
+    ctx->hash_seed = xorshift64star(&ctx->random_state);
 
     if (JS_AddIntrinsicBasicObjects(ctx)) {
         JS_FreeContext(ctx);
@@ -3204,7 +3212,7 @@ static inline uint32_t hash_string8(const uint8_t *str, size_t len, uint32_t h)
 
     for(i = 0; i < len; i++)
         h = h * 263 + str[i];
-    return h;
+    return h ^ hash32(len);
 }
 
 static inline uint32_t hash_string16(const uint16_t *str,
@@ -3214,7 +3222,7 @@ static inline uint32_t hash_string16(const uint16_t *str,
 
     for(i = 0; i < len; i++)
         h = h * 263 + str[i];
-    return h;
+    return h ^ hash32(len);
 }
 
 static uint32_t hash_string(JSString *str, uint32_t h)
@@ -48470,14 +48478,6 @@ static uint64_t xorshift64star(uint64_t *pstate)
     return x * 0x2545F4914F6CDD1D;
 }
 
-static void js_random_init(JSContext *ctx)
-{
-    ctx->random_state = js__gettimeofday_us();
-    /* the state must be non zero */
-    if (ctx->random_state == 0)
-        ctx->random_state = 1;
-}
-
 static JSValue js_math_random(JSContext *ctx, JSValueConst this_val,
                               int argc, JSValueConst *argv)
 {
@@ -52792,10 +52792,10 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
         h = JS_VALUE_GET_INT(key);
         break;
     case JS_TAG_STRING:
-        h = hash_string(JS_VALUE_GET_STRING(key), 0);
+        h = hash_string(JS_VALUE_GET_STRING(key), ctx->hash_seed);
         break;
     case JS_TAG_STRING_ROPE:
-        h = hash_string_rope(key, 0);
+        h = hash_string_rope(key, ctx->hash_seed);
         break;
     case JS_TAG_OBJECT:
     case JS_TAG_SYMBOL:
@@ -52809,7 +52809,8 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
         goto hash_float64;
     case JS_TAG_BIG_INT:
         r = JS_VALUE_GET_PTR(key);
-        h = hash_string8((void *)r->tab, r->len * sizeof(*r->tab), 0);
+        h = hash_string8((void *)r->tab, r->len * sizeof(*r->tab),
+                         ctx->hash_seed);
         break;
     case JS_TAG_FLOAT64:
         d = JS_VALUE_GET_FLOAT64(key);
@@ -58392,7 +58393,6 @@ int JS_AddIntrinsicBaseObjects(JSContext *ctx)
         return -1;
 
     /* Math: create as autoinit object */
-    js_random_init(ctx);
     if (JS_SetPropertyFunctionList(ctx, ctx->global_obj, js_math_obj, countof(js_math_obj)))
         return -1;
 


### PR DESCRIPTION
Make it harder to cause collisions in hash tables.

1. Use a per-context random hash seed

2. Mix in the string length (to make it harder for attackers that control the string prefix)

No test because any test depends on observing timing patterns and that's impossible to make flake free when run as part of the test suite.

Fixes: https://github.com/quickjs-ng/quickjs/issues/205

<hr>

To eyeball-verify that the change is correct, here is the test from #205 amended to display the standard deviation. On my system it's all over the place with master but fairly restricted (normally < 2,000) with the changes from this PR.
```js
import * as os from "qjs:os"
function go(a) {
    const s = new Set()
    const t0 = os.now()
    for (let i = a.length; i-- > 0; s.add(a[i]));
    const t1 = os.now()
    return t1-t0
}
function fmt(x) {
    return ("       " + x).slice(-7)
}
function bench(c) {
    const p = ("0000" + c.charCodeAt(0).toString(16)).slice(-4)
    const k = c.repeat(0x1000) + "k"
    const a = []
    for (let i = k.length; i-- > 0;) a.push(k.slice(i))
    let b = []
    for (let i = 0; i < 20; i++) b.push(go(a))
    b.sort((x, y) => x-y)
    const avg = b.reduce((a, v) => a + v) / b.length
    const sd = Math.sqrt(b.reduce((a, v) => a + (v - avg) ** 2) / (b.length - 1))
    b = b.map(fmt)
    print(p, b[0], b[9], b[19], sd.toFixed(2)); // min, median, max, sd
}
for (let i = 0; i < 128; i++) bench(String.fromCharCode(i))
```