### PR TITLE
Return null from CallSite position getters for native frames

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -62896,6 +62896,9 @@ static JSValue js_callsite_getnumber(JSContext *ctx, JSValueConst this_val, int 
     if (!csd)
         return JS_EXCEPTION;
     int *field = (void *)((char *)csd + magic);
+    /* V8 returns null when the frame has no source position (native frames) */
+    if (*field < 0)
+        return JS_NULL;
     return js_int32(*field);
 }
 

--- a/tests/callsite-native-position.js
+++ b/tests/callsite-native-position.js
@@ -1,0 +1,19 @@
+import { assert } from "./assert.js";
+
+/* CallSite position getters return null for frames with no source position
+   (native frames), matching V8, instead of leaking the internal -1. */
+
+Error.prepareStackTrace = (_, frames) => frames;
+const frames = [1].map(function m() { return new Error().stack; })[0];
+Error.prepareStackTrace = undefined;
+
+const native = frames.find((f) => f.isNative());
+assert(native !== undefined, true);
+assert(native.getLineNumber(), null);
+assert(native.getColumnNumber(), null);
+assert(native.getFileName(), null);
+
+/* frames with a real position still report numbers */
+const scripted = frames.find((f) => !f.isNative());
+assert(typeof scripted.getLineNumber(), "number");
+assert(typeof scripted.getColumnNumber(), "number");


### PR DESCRIPTION
`getLineNumber()` and `getColumnNumber()` returned the internal `-1` sentinel for frames without a source position, such as native frames. V8 returns `null` there, like `getFileName()` already does for the missing file name.

```js
Error.prepareStackTrace = (_, frames) => frames;
const frames = [1].map(function m() { return new Error().stack; })[0];
const native = frames.find((f) => f.isNative());
native.getLineNumber();    // before: -1   after: null
native.getColumnNumber();  // before: -1   after: null
native.getFileName();      // null (already)
```

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*