### PR TITLE
Add JS_PromiseMarkAsHandled

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -430,6 +430,49 @@ static void module_unhandled_rejection(void)
     JS_FreeRuntime(rt);
 }
 
+static void promise_mark_as_handled(void)
+{
+    struct rejection_counts c = {0, 0};
+    JSRuntime *rt = new_runtime();
+    JS_SetHostPromiseRejectionTracker(rt, rejection_counter, &c);
+    JSContext *ctx = JS_NewContext(rt);
+    JSContext *c1;
+
+    // marking an already-rejected promise notifies the tracker exactly once
+    static const char code[] = "Promise.reject('kaboom')";
+    JSValue promise = JS_Eval(ctx, code, strlen(code), "<t>", JS_EVAL_TYPE_GLOBAL);
+    assert(JS_IsPromise(promise));
+    while (JS_ExecutePendingJob(rt, &c1) > 0)
+        ;
+    assert(c.reject_count == 1);
+    assert(c.handle_count == 0);
+    JS_PromiseMarkAsHandled(ctx, promise);
+    assert(c.handle_count == 1);
+    JS_PromiseMarkAsHandled(ctx, promise);
+    assert(c.handle_count == 1);
+    JS_FreeValue(ctx, promise);
+
+    // marking a pending promise suppresses the report when it later rejects
+    JSValue resolving_funcs[2];
+    JSValue promise2 = JS_NewPromiseCapability(ctx, resolving_funcs);
+    JS_PromiseMarkAsHandled(ctx, promise2);
+    JSValue reason = JS_NewString(ctx, "unseen");
+    JSValue ret = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1,
+                          (JSValueConst *)&reason);
+    while (JS_ExecutePendingJob(rt, &c1) > 0)
+        ;
+    assert(c.reject_count == 1);
+    assert(c.handle_count == 1);
+    JS_FreeValue(ctx, ret);
+    JS_FreeValue(ctx, reason);
+    JS_FreeValue(ctx, resolving_funcs[0]);
+    JS_FreeValue(ctx, resolving_funcs[1]);
+    JS_FreeValue(ctx, promise2);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 static void runtime_cstring_free(void)
 {
     JSRuntime *rt = new_runtime();
@@ -1250,6 +1293,7 @@ int main(void)
     is_array();
     module_serde();
     module_unhandled_rejection();
+    promise_mark_as_handled();
     runtime_cstring_free();
     utf16_string();
     weak_map_gc_check();

--- a/quickjs.c
+++ b/quickjs.c
@@ -54968,6 +54968,11 @@ bool JS_IsPromise(JSValueConst val)
     return JS_VALUE_GET_OBJ(val)->class_id == JS_CLASS_PROMISE;
 }
 
+void JS_PromiseMarkAsHandled(JSContext *ctx, JSValueConst promise)
+{
+    js_promise_set_handled(ctx, promise);
+}
+
 JSValue JS_NewSettledPromise(JSContext *ctx, bool is_reject, JSValueConst value)
 {
     return js_promise_resolve(ctx, ctx->promise_ctor, 1, &value, is_reject);

--- a/quickjs.h
+++ b/quickjs.h
@@ -1132,6 +1132,7 @@ JS_EXTERN JSPromiseStateEnum JS_PromiseState(JSContext *ctx,
                                              JSValueConst promise);
 JS_EXTERN JSValue JS_PromiseResult(JSContext *ctx, JSValueConst promise);
 JS_EXTERN bool JS_IsPromise(JSValueConst val);
+JS_EXTERN void JS_PromiseMarkAsHandled(JSContext *ctx, JSValueConst promise);
 JS_EXTERN JSValue JS_NewSettledPromise(JSContext *ctx, bool is_reject, JSValueConst value);
 
 JS_EXTERN JSValue JS_NewSymbol(JSContext *ctx, const char *description, bool is_global);


### PR DESCRIPTION
Embedders that consume a rejected promise through the C API (for example `JS_Eval` returning a promise whose rejection the host reports itself) have no way to tell the engine the rejection was handled, so the host promise rejection tracker still reports it as unhandled. The internal `js_promise_set_handled` already implements the right semantics; this exposes it as `JS_PromiseMarkAsHandled`.

Behavior:

| promise state when marked | effect |
|---|---|
| rejected | tracker notified once with `is_handled == true` |
| pending | no callback; a later rejection is not reported |
| already handled | no-op |

V8 exposes the same operation as `v8::Promise::MarkAsHandled`. Covered in api-test.c with the existing rejection tracker harness.

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*
