### PR TITLE
Add JS_PromiseThen

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -473,6 +473,76 @@ static void promise_mark_as_handled(void)
     JS_FreeRuntime(rt);
 }
 
+static void promise_then(void)
+{
+    const char *s;
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+    JSContext *c1;
+    JSValue got = JS_UNDEFINED;
+    JS_SetContextOpaque(ctx, &got);
+
+    // the result promise is intrinsic: neither an overridden then() nor
+    // Symbol.species is consulted
+    static const char code[] =
+        "class P extends Promise {"
+        "  static get [Symbol.species]() { throw new Error('species'); }"
+        "  then() { throw new Error('then'); }"
+        "}"
+        "P.resolve('ok')";
+    JSValue promise = eval(ctx, code);
+    assert(JS_IsPromise(promise));
+    JSValue on_fulfilled = JS_NewCFunction(ctx, save_value, "onFulfilled", 1);
+    JSValue result = JS_PromiseThen(ctx, promise, on_fulfilled, JS_UNDEFINED);
+    assert(JS_IsPromise(result));
+    while (JS_ExecutePendingJob(rt, &c1) > 0)
+        ;
+    s = JS_ToCString(ctx, got);
+    assert(s);
+    assert(!strcmp(s, "ok"));
+    JS_FreeCString(ctx, s);
+    JS_FreeValue(ctx, got);
+    assert(JS_PromiseState(ctx, result) == JS_PROMISE_FULFILLED);
+    JS_FreeValue(ctx, result);
+    JS_FreeValue(ctx, on_fulfilled);
+    JS_FreeValue(ctx, promise);
+
+    // rejection handler receives the reason when the promise rejects later
+    JSValue resolving_funcs[2];
+    JSValue promise2 = JS_NewPromiseCapability(ctx, resolving_funcs);
+    JSValue on_rejected = JS_NewCFunction(ctx, save_value, "onRejected", 1);
+    JSValue result2 = JS_PromiseThen(ctx, promise2, JS_UNDEFINED, on_rejected);
+    assert(JS_IsPromise(result2));
+    got = JS_UNDEFINED;
+    JSValue reason = JS_NewString(ctx, "boom");
+    JSValue ret = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1,
+                          (JSValueConst *)&reason);
+    while (JS_ExecutePendingJob(rt, &c1) > 0)
+        ;
+    s = JS_ToCString(ctx, got);
+    assert(s);
+    assert(!strcmp(s, "boom"));
+    JS_FreeCString(ctx, s);
+    JS_FreeValue(ctx, got);
+    assert(JS_PromiseState(ctx, result2) == JS_PROMISE_FULFILLED);
+    JS_FreeValue(ctx, ret);
+    JS_FreeValue(ctx, reason);
+    JS_FreeValue(ctx, result2);
+    JS_FreeValue(ctx, on_rejected);
+    JS_FreeValue(ctx, resolving_funcs[0]);
+    JS_FreeValue(ctx, resolving_funcs[1]);
+    JS_FreeValue(ctx, promise2);
+
+    // a non-promise argument is a TypeError
+    JSValue bad = JS_PromiseThen(ctx, JS_UNDEFINED, JS_UNDEFINED, JS_UNDEFINED);
+    assert(JS_IsException(bad));
+    JSValue exc = JS_GetException(ctx);
+    JS_FreeValue(ctx, exc);
+
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 static void runtime_cstring_free(void)
 {
     JSRuntime *rt = new_runtime();
@@ -1294,6 +1364,7 @@ int main(void)
     module_serde();
     module_unhandled_rejection();
     promise_mark_as_handled();
+    promise_then();
     runtime_cstring_free();
     utf16_string();
     weak_map_gc_check();

--- a/quickjs.c
+++ b/quickjs.c
@@ -55560,6 +55560,43 @@ JSValue JS_NewPromiseCapability(JSContext *ctx, JSValue *resolving_funcs)
     return js_new_promise_capability(ctx, resolving_funcs, JS_UNDEFINED);
 }
 
+JSValue JS_PromiseThen(JSContext *ctx, JSValueConst promise,
+                       JSValueConst on_fulfilled,
+                       JSValueConst on_rejected)
+{
+    JSValue result_promise, resolving_funcs[2];
+    JSValueConst handlers[2] = { on_fulfilled, on_rejected };
+    JSRuntime *rt = ctx->rt;
+    JSValueLink link;
+    bool have_promise_hook;
+    int i, ret;
+
+    if (!JS_GetOpaque2(ctx, promise, JS_CLASS_PROMISE))
+        return JS_EXCEPTION;
+
+    /* Match the embedding API: create an intrinsic promise and do not consult
+       Promise.prototype.then or Symbol.species. */
+    have_promise_hook = (rt->promise_hook != NULL);
+    if (have_promise_hook) {
+        link = (JSValueLink){rt->parent_promise, promise};
+        rt->parent_promise = &link;
+    }
+    result_promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+    if (have_promise_hook)
+        rt->parent_promise = link.next;
+    if (JS_IsException(result_promise))
+        return result_promise;
+
+    ret = perform_promise_then(ctx, promise, handlers, vc(resolving_funcs));
+    for (i = 0; i < 2; i++)
+        JS_FreeValue(ctx, resolving_funcs[i]);
+    if (ret) {
+        JS_FreeValue(ctx, result_promise);
+        return JS_EXCEPTION;
+    }
+    return result_promise;
+}
+
 static JSValue js_promise_resolve(JSContext *ctx, JSValueConst this_val,
                                   int argc, JSValueConst *argv, int magic)
 {

--- a/quickjs.h
+++ b/quickjs.h
@@ -1128,6 +1128,9 @@ typedef enum JSPromiseStateEnum {
 } JSPromiseStateEnum;
 
 JS_EXTERN JSValue JS_NewPromiseCapability(JSContext *ctx, JSValue *resolving_funcs);
+JS_EXTERN JSValue JS_PromiseThen(JSContext *ctx, JSValueConst promise,
+                                JSValueConst on_fulfilled,
+                                JSValueConst on_rejected);
 JS_EXTERN JSPromiseStateEnum JS_PromiseState(JSContext *ctx,
                                              JSValueConst promise);
 JS_EXTERN JSValue JS_PromiseResult(JSContext *ctx, JSValueConst promise);


### PR DESCRIPTION
Embedders chaining on a promise internally (module loaders, host APIs that observe a promise's settlement) currently have to call the `then` property, which user code can override, or hand-roll reactions with `JS_NewPromiseCapability` plus JS glue. This adds `JS_PromiseThen`, which performs PerformPromiseThen directly: the result promise is created with the intrinsic constructor, so an overridden `then()` or `Symbol.species` is never consulted and cannot interfere.

Handlers may be `undefined` (identity/thrower per spec). A non-promise argument throws a TypeError. V8 exposes the same operation as `v8::Promise::Then`.

Covered in api-test.c, including a subclass with poisoned `then`/`Symbol.species` that JS_PromiseThen must not invoke.

*Disclaimer: This is an AI-assisted patch from the [v8x](https://github.com/littledivy/v8x) project.*
