### PR TITLE
Fix integer multiplication result cast to unsigned long in js_realloc_array()

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -2186,7 +2186,8 @@ static no_inline int js_realloc_array(JSContext *ctx, void **parray,
     void *new_array;
     /* XXX: potential arithmetic overflow */
     new_size = max_int(req_size, *psize * 3 / 2);
-    new_array = js_realloc2(ctx, *parray, new_size * elem_size, &slack);
+    assert(elem_size > 0 && new_size > 0);
+    new_array = js_realloc2(ctx, *parray, (size_t)new_size * (size_t)elem_size, &slack);
     if (!new_array)
         return -1;
     new_size += slack / elem_size;


### PR DESCRIPTION
Both `new_size` and `elem_size` are **signed integers** of type `int` (4-bytes on most 64-bit systems).
`js_realloc2` function's `size` parameter is of type `size_t` (**unsigned long**, 8-bytes on most 64-bit systems).

The two int factors are multiplied first. The multiplication in C is always performed in the type of the factor variables, co casting it to `size_t` **_afterwards_** is ineffective and opens the way for potential int overflows.
This commit mitigates the potential probability of overflows by casting the factors before the arithmetic multiplication is performed.

So, basically we have:
`(size_t)(int * int)`
While it should have been:
`(size_t)int * int`, or better showing the intent: `(size_t)int * (size_t)int`

Reference:
https://codeql.github.com/codeql-query-help/cpp/cpp-integer-multiplication-cast-to-long/
https://cwe.mitre.org/data/definitions/681.html