### PR TITLE
Fix build on i386 with older GCC: label followed by a declaration

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -15572,7 +15572,10 @@ static no_inline __exception int js_binary_arith_slow(JSContext *ctx, JSValue *s
         }
         if (JS_ToFloat64Free(ctx, &d2, op2))
             goto exception;
-    handle_float64:
+    handle_float64: ;
+        /* The empty statement is load-bearing: on i386
+           JS_X87_FPCW_SAVE_AND_ADJUST expands to a declaration, and a label
+           may not be followed directly by a declaration before C23. */
         JS_X87_FPCW_SAVE_AND_ADJUST(fpcw);
         switch(op) {
         case OP_sub:


### PR DESCRIPTION
﻿`JS_BinaryArithSlowPath` has `handle_float64:` immediately followed by
`JS_X87_FPCW_SAVE_AND_ADJUST(fpcw)`. On i386 that macro expands to a
declaration (`unsigned short cw;`, `cutils.h:671`), and before C23 a label may
not be followed by a declaration.

Modern GCC accepts this as an extension, so the tree builds fine on CI вЂ” but
older compilers reject it. Building for i386 with gcc 5.4 (a KolibriOS cross
toolchain) fails at the default `-std=gnu11`, no `-pedantic` involved:

```
cutils.h:671:5: error: a label can only be part of a statement and a declaration is not a statement
```

Other targets never see it: there `JS_X87_FPCW_SAVE_AND_ADJUST` expands to
nothing (`cutils.h:680`) and the label attaches to the following `switch`.

The fix is an empty statement after the label, so it has a statement to attach
to. The other `handle_float64:` (in `JS_PostOrIncDec`) is already followed by a
block and is left alone.

Verified by compiling `quickjs.c` for i386 with gcc 5.4 before and after the
change: the error above disappears and the translation unit builds clean.
Behaviour is unchanged on every other target вЂ” the empty statement generates no
code.
