### PR TITLE
Install manpages to the correct location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,8 +561,8 @@ if (QJS_ENABLE_INSTALL)
     if(NOT IOS AND NOT TVOS AND NOT WATCHOS)
         install(TARGETS qjs_exe RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
         install(TARGETS qjsc RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-        install(FILES qjs.man DESTINATION ${CMAKE_INSTALL_DATADIR}/man/man1/qjs.1)
-        install(FILES qjsc.man DESTINATION ${CMAKE_INSTALL_DATADIR}/man/man1/qjsc.1)
+        install(FILES qjs.man DESTINATION ${CMAKE_INSTALL_DATADIR}/man/man1 RENAME qjs.1)
+        install(FILES qjsc.man DESTINATION ${CMAKE_INSTALL_DATADIR}/man/man1 RENAME qjsc.1)
     endif()
     install(TARGETS qjs EXPORT qjsConfig
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/53173/ GPT 5.6 Sol observes:

>Upstream's [`CMakeLists.txt`](https://github.com/quickjs-ng/quickjs/blob/10b99693cdc3f37cdf05114bc2d5225de495c4a3/CMakeLists.txt#L561-L562) installs `qjs.man` and `qjsc.man` beneath directories named `qjs.1` and `qjsc.1`, yielding malformed manual-page paths.