### PR TITLE
fix: accessor descriptors from Proxy getOwnPropertyDescriptor trap

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -52495,6 +52495,19 @@ static int js_proxy_get_own_property(JSContext *ctx, JSPropertyDescriptor *pdesc
         }
         ret = true;
         if (pdesc) {
+            /* js_obj_to_desc() returns defineProperty-style flags; convert to
+               an own-property descriptor (CompletePropertyDescriptor) so
+               consumers relying on JS_PROP_GETSET see the accessor. */
+            if (result_desc.flags & (JS_PROP_HAS_GET | JS_PROP_HAS_SET)) {
+                result_desc.flags =
+                    (result_desc.flags &
+                     (JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE)) |
+                    JS_PROP_GETSET;
+            } else {
+                result_desc.flags &=
+                    (JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE |
+                     JS_PROP_WRITABLE);
+            }
             *pdesc = result_desc;
         } else {
             js_free_desc(ctx, &result_desc);

--- a/tests/proxy-getownpropertydescriptor-accessor.js
+++ b/tests/proxy-getownpropertydescriptor-accessor.js
@@ -1,0 +1,59 @@
+// Proxy [[GetOwnProperty]] must return CompletePropertyDescriptor(resultDesc):
+// an accessor descriptor produced by a getOwnPropertyDescriptor trap must
+// surface as an accessor (get/set), not degrade to
+// { value: undefined, writable: false }.
+// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
+import { assert } from "./assert.js";
+
+const getX = function() { return 42; };
+const target = {};
+Object.defineProperty(target, "x", {
+    configurable: true,
+    enumerable: true,
+    get: getX,
+});
+
+// accessor descriptor through the trap
+{
+    const p = new Proxy(target, {
+        getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+    });
+    const d = Object.getOwnPropertyDescriptor(p, "x");
+    assert(d.get, getX);
+    assert(d.set, undefined);
+    assert("value" in d, false);
+    assert("writable" in d, false);
+    assert(d.enumerable, true);
+    assert(d.configurable, true);
+    assert(p.x, 42);
+}
+
+// incomplete accessor descriptor from the trap: absent fields default
+// per CompletePropertyDescriptor
+{
+    const p = new Proxy(target, {
+        getOwnPropertyDescriptor() {
+            return { configurable: true, get: getX };
+        },
+    });
+    const d = Object.getOwnPropertyDescriptor(p, "x");
+    assert(d.get, getX);
+    assert(d.set, undefined);
+    assert(d.enumerable, false);
+    assert(d.configurable, true);
+}
+
+// data descriptor through the trap is unaffected
+{
+    const t = { y: 7 };
+    const p = new Proxy(t, {
+        getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+    });
+    const d = Object.getOwnPropertyDescriptor(p, "y");
+    assert(d.value, 7);
+    assert(d.writable, true);
+    assert(d.enumerable, true);
+    assert(d.configurable, true);
+    assert("get" in d, false);
+    assert("set" in d, false);
+}


### PR DESCRIPTION
js_obj_to_desc() returns defineProperty-style flags (JS_PROP_HAS_GET / JS_PROP_HAS_SET, never JS_PROP_GETSET), but js_proxy_get_own_property() published the parsed trap result unconverted. Descriptor consumers test JS_PROP_GETSET, so any accessor descriptor returned by a getOwnPropertyDescriptor trap degraded to a data descriptor { value: undefined, writable: false }.

Convert the flags to own-property form before publishing, per the CompletePropertyDescriptor(resultDesc) step of Proxy [[GetOwnProperty]]:

```
    const t = {};
    Object.defineProperty(t, 'x', { configurable: true, get() { return 42; } });
    const p = new Proxy(t, { getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor });
    Object.getOwnPropertyDescriptor(p, 'x');
    // before: { value: undefined, writable: false, ... }
    // after:  { get: [Function], set: undefined, ... }
```

Embedders exposing host objects through descriptor-trap proxies hit this in practice (eg, NativeScript's iOS runtime did).