### PR TITLE
Fix JS_NewObjectFrom

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1822,6 +1822,33 @@ static void transfer_default_managed_array_buffer(void)
     JS_FreeRuntime(rt);
 }
 
+void object_from(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+    JSValue t0 = JS_NewObject(ctx);
+    assert(!JS_IsException(t0));
+    assert(JS_IsObject(t0));
+    JSAtom prop = JS_NewAtomLen(ctx, "prop", 4);
+    assert(prop != JS_ATOM_NULL);
+    JSValue val = JS_NULL;
+    JSValue t1 = JS_NewObjectFrom(ctx, 1, &prop, &val);
+    assert(!JS_IsException(t1));
+    assert(JS_IsObject(t1));
+    uint32_t old_shape_hash_count = js_std_cmd(/*GetShapeHashCount*/4, rt);
+    JSValue t2 = JS_NewObjectFrom(ctx, 1, &prop, &val);
+    assert(!JS_IsException(t2));
+    assert(JS_IsObject(t2));
+    uint32_t new_shape_hash_count = js_std_cmd(/*GetShapeHashCount*/4, rt);
+    assert(old_shape_hash_count == new_shape_hash_count);
+    JS_FreeAtom(ctx, prop);
+    JS_FreeValue(ctx, t2);
+    JS_FreeValue(ctx, t1);
+    JS_FreeValue(ctx, t0);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     cfunctions();
@@ -1855,5 +1882,6 @@ int main(void)
     transfer_external_array_buffer();
     resize_external_array_buffer();
     transfer_default_managed_array_buffer();
+    object_from();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -6324,48 +6324,21 @@ JSValue JS_NewObjectProto(JSContext *ctx, JSValueConst proto)
 JSValue JS_NewObjectFrom(JSContext *ctx, int count, const JSAtom *props,
                          const JSValue *values)
 {
-    JSShapeProperty *pr;
-    uint32_t *hash;
-    JSRuntime *rt;
-    JSObject *p;
-    JSShape *sh;
     JSValue obj;
-    JSAtom atom;
-    intptr_t h;
     int i;
 
-    rt = ctx->rt;
     obj = JS_NewObject(ctx);
     if (JS_IsException(obj))
         return JS_EXCEPTION;
-    if (count > 0) {
-        p = JS_VALUE_GET_OBJ(obj);
-        sh = p->shape;
-        assert(sh->is_hashed);
-        assert(JS_REF_COUNT(sh) == 1);
-        js_shape_hash_unlink(rt, sh);
-        if (resize_properties(ctx, &sh, p, count)) {
-            js_shape_hash_link(rt, sh);
-            JS_FreeValue(ctx, obj);
-            return JS_EXCEPTION;
-        }
-        p->shape = sh;
-        for (i = 0; i < count; i++) {
-            atom = props[i];
-            pr = &get_shape_prop(sh)[i];
-            sh->hash = shape_hash(shape_hash(sh->hash, atom), JS_PROP_C_W_E);
-            h = atom & sh->prop_hash_mask;
-            hash = &prop_hash_end(sh)[-h - 1];
-            pr->hash_next = *hash;
-            *hash = i + 1;
-            pr->atom = JS_DupAtom(ctx, atom);
-            pr->flags = JS_PROP_C_W_E;
-            p->prop[i].u.value = values[i];
-        }
-        js_shape_hash_link(rt, sh);
-        sh->prop_count = count;
-    }
+    for (i = 0; i < count; i++)
+        if (JS_SetProperty(ctx, obj, props[i], values[i]) < 0)
+            goto fail;
     return obj;
+fail:
+    for (/*empty*/; i < count; i++)
+        JS_FreeValue(ctx, values[i]);
+    JS_FreeValue(ctx, obj);
+    return JS_EXCEPTION;
 }
 
 JSValue JS_NewObjectFromStr(JSContext *ctx, int count, const char **props,
@@ -64824,6 +64797,10 @@ uintptr_t js_std_cmd(int cmd, ...) {
         rv = -1;
         if (JS_IsString(*pv))
             rv = JS_VALUE_GET_STRING(*pv)->kind;
+        break;
+    case 4: // GetShapeHashCount
+        rt = va_arg(ap, JSRuntime *);
+        rv = rt->shape_hash_count;
         break;
     default:
         rv = -1;


### PR DESCRIPTION
Replace it with a simple implementation for now. The idea of the old implementation was to compute the final JSShape + storage for the properties in one step but the reference counting gets tricky.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1640