### PR TITLE
Fix SIGBUS on strict-alignment platforms: align cpool_offset to 8 bytes

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -37024,8 +37024,8 @@ static JSValue js_create_function(JSContext *ctx, JSFunctionDef *fd)
         goto fail;
 
     function_size = sizeof(*b);
-    cpool_offset = function_size;
-    function_size += fd->cpool_count * sizeof(*fd->cpool);
+    cpool_offset = (function_size + 7) & ~7;
+    function_size = cpool_offset + fd->cpool_count * sizeof(*fd->cpool);
     vardefs_offset = function_size;
     function_size += (fd->arg_count + fd->var_count) * sizeof(*b->vardefs);
     closure_var_offset = function_size;
@@ -39726,8 +39726,8 @@ static JSValue JS_ReadFunctionTag(BCReaderState *s)
         goto fail;
 
     function_size = sizeof(*b);
-    cpool_offset = function_size;
-    function_size += bc.cpool_count * sizeof(*bc.cpool);
+    cpool_offset = (function_size + 7) & ~7;
+    function_size = cpool_offset + bc.cpool_count * sizeof(*bc.cpool);
     vardefs_offset = function_size;
     function_size += local_count * sizeof(*bc.vardefs);
     closure_var_offset = function_size;


### PR DESCRIPTION
JSValue can hold a double/int64_t and needs 8-byte alignment, but cpool_offset was computed with no rounding, so on strict-alignment architectures (e.g. 32-bit SPARC) the constant pool array can land on a 4-but-not-8 byte boundary, causing SIGBUS on the first access.