### PR TITLE
Fix TypedArray.prototype.with() value conversion order

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -60081,10 +60081,13 @@ static JSValue js_typed_array_with(JSContext *ctx, JSValueConst this_val,
     if (idx < 0)
         idx = len + idx;
 
-    val = JS_ToPrimitive(ctx, argv[1], HINT_NUMBER);
+    if (p->class_id == JS_CLASS_BIG_INT64_ARRAY || p->class_id == JS_CLASS_BIG_UINT64_ARRAY) {
+        val = JS_ToBigInt(ctx, argv[1]);
+    } else {
+        val = JS_ToNumber(ctx, argv[1]);
+    }
     if (JS_IsException(val))
         return JS_EXCEPTION;
-
     /* re-validate after user code (spec step 9: IsValidIntegerIndex) */
     if (typed_array_is_oob(p)) {
         JS_FreeValue(ctx, val);

--- a/tests/bug1625.js
+++ b/tests/bug1625.js
@@ -1,0 +1,6 @@
+import { assertThrows } from "./assert.js";
+
+
+assertThrows(TypeError, () => new BigInt64Array().with());
+assertThrows(TypeError, () => new BigInt64Array().with(0, 1));
+assertThrows(RangeError, () => new BigInt64Array().with(0, BigInt(10)));


### PR DESCRIPTION
Fixes #1625.

The `with` method must convert value with `ToBigInt` or `ToNumber` before validating the index. The current implementation in master uses `ToPrimitive`, which allows an invalid value to sneak by and throw a `RangeError` instead of the correct `TypeError`.

I added some tests to confirm that the issue is fixed without causing regressions. All tests passed when I ran `make test`.