### PR TITLE
Fix object leak in JS_NewCConstructor

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -1849,6 +1849,17 @@ void object_from(void)
     JS_FreeRuntime(rt);
 }
 
+void add_intrinsic_bigint(void)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContextRaw(rt);
+    JS_AddIntrinsicBaseObjects(ctx);
+    JS_AddIntrinsicBigInt(ctx);
+    assert(!JS_HasException(ctx));
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     cfunctions();
@@ -1883,5 +1894,6 @@ int main(void)
     resize_external_array_buffer();
     transfer_default_managed_array_buffer();
     object_from();
+    add_intrinsic_bigint();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -40920,7 +40920,7 @@ static JSValue JS_NewCConstructor(JSContext *ctx, int class_id, const char *name
                                   const JSCFunctionListEntry *proto_fields, int n_proto_fields,
                                   int flags)
 {
-    JSValue ctor = JS_UNDEFINED, proto, parent_proto;
+    JSValue ctor = JS_UNDEFINED, proto, parent_proto, *class_proto;
     int proto_class_id, proto_flags, ctor_flags;
 
     proto_flags = 0;
@@ -40951,8 +40951,12 @@ static JSValue JS_NewCConstructor(JSContext *ctx, int class_id, const char *name
                                             n_proto_fields + 1);
         if (JS_IsException(proto))
             goto fail;
-        if (class_id >= 0)
-            ctx->class_proto[class_id] = js_dup(proto);
+        if (class_id >= 0) {
+            class_proto = &ctx->class_proto[class_id];
+            if (!JS_IsNull(*class_proto))
+                JS_FreeValue(ctx, *class_proto);
+            *class_proto = js_dup(proto);
+        }
     }
     if (JS_SetPropertyFunctionList(ctx, proto, proto_fields, n_proto_fields))
         goto fail;


### PR DESCRIPTION
Calling JS_NewCConstructor twice with the same class id resulted in a leak of the class prototype.

Manifested as a downstream regression in nginx/njs where it calls JS_AddIntrinsicBigInt after JS_AddIntrinsicBaseObjects, both which add the BigInt intrinsic.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1669