### PR TITLE
Fixes segfault from #1661

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -55197,7 +55197,7 @@ static JSValue js_async_dispose_step(JSContext *ctx, JSValueConst this_val,
             return JS_EXCEPTION;
         resolve_fn = JS_NewCFunctionData(ctx, js_async_dispose_rethrow, 0, 0,
                                          1, &prev_err);
-        reject_fn = JS_NewCFunctionData(ctx, js_async_dispose_rethrow, 0, 1,
+        reject_fn = JS_NewCFunctionData(ctx, js_async_dispose_rethrow, 1, 1,
                                         1, &prev_err);
         then_args[0] = resolve_fn;
         then_args[1] = reject_fn;
@@ -55308,7 +55308,7 @@ static JSValue js_disposable_stack_dispose(JSContext *ctx,
             data[2] = hint_val;
             resolve_fn = JS_NewCFunctionData(ctx, js_async_dispose_step, 0, 0,
                                              3, data);
-            reject_fn = JS_NewCFunctionData(ctx, js_async_dispose_step, 0, 1,
+            reject_fn = JS_NewCFunctionData(ctx, js_async_dispose_step, 1, 1,
                                             3, data);
             JS_FreeValue(ctx, hint_val);
             JS_FreeValue(ctx, res->value);

--- a/tests/bug1661.js
+++ b/tests/bug1661.js
@@ -1,0 +1,42 @@
+import { assert, assertThrows } from "./assert.js";
+
+// Adapted from @mschwarzl's repros
+
+// Test js_async_dispose_step path
+
+let saved;
+Promise.prototype.then = function (f, r) {if (typeof r === "function") saved = r;return Promise.resolve();};
+let s = new AsyncDisposableStack();
+
+s.use(undefined);
+s.defer(() => {});
+s.disposeAsync();
+try { saved(); } catch {}
+gc();
+assert(saved !== undefined, true, "saved is undefined");
+
+// Test js_async_dispose_rethrow path
+
+let callCount = 0;
+let saved2;
+
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    callCount++;
+    if (callCount === 1)
+        return onRejected({ previous: 1 });   // drives step() into the rethrow branch
+    if (callCount === 2) {
+        saved2 = onRejected;                   // this is the js_async_dispose_rethrow reject_fn
+        return Promise.resolve();
+    }
+    return Promise.resolve();
+};
+
+const stack = new AsyncDisposableStack();
+stack.defer(() => undefined);
+stack.defer(() => { throw { first: 1 }; });
+stack.disposeAsync();
+
+try { saved2(); } catch {}
+
+gc();
+assert(saved2 !== undefined, true, "saved2 is undefined");


### PR DESCRIPTION
Fixes #1661 by configuring reject functions to take an argument. This way, instead of reading stale data at argv[0], it will read undefined when no parameters are passed. Both the js_async_dispose_rethrow and js_async_dispose_step paths were patched, but I still need to test js_async_dispose_rethrow, so I’m leaving this as a draft until I or someone else figures out how to trigger that issue.