### PR TITLE
Preserve host interrupt handlers in evalScript

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,7 @@ endif()
 add_executable(api-test
     api-test.c
 )
+add_qjs_libc_if_needed(api-test)
 target_compile_definitions(api-test PRIVATE ${qjs_defines})
 target_link_libraries(api-test PRIVATE qjs)
 

--- a/api-test.c
+++ b/api-test.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "quickjs.h"
+#include "quickjs-libc.h"
 #include "cutils.h"
 
 static JSRuntime *new_runtime(void)
@@ -236,6 +237,49 @@ static void async_call(void)
     JS_FreeValue(ctx, e);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
+}
+
+static void eval_script_interrupt_test(const char *code)
+{
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+    JSValue ret, exception;
+    int time = 0;
+
+    js_std_init_handlers(rt);
+    JS_SetModuleLoaderFunc2(rt, NULL, js_module_loader,
+                            js_module_check_attributes, NULL);
+    js_init_module_std(ctx, "qjs:std");
+    JS_SetInterruptHandler(rt, timeout_interrupt_handler, &time);
+
+    ret = JS_Eval(ctx, code, strlen(code), "<input>",
+                  JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+    assert(!JS_IsException(ret));
+    assert(0 == js_module_set_import_meta(ctx, ret, false, false));
+    ret = JS_EvalFunction(ctx, ret);
+    ret = js_std_await(ctx, ret);
+    assert(time > MAX_TIME);
+    assert(JS_IsException(ret));
+    JS_FreeValue(ctx, ret);
+    assert(JS_HasException(ctx));
+    exception = JS_GetException(ctx);
+    assert(JS_IsError(exception));
+    JS_FreeValue(ctx, exception);
+
+    js_std_free_handlers(rt);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
+static void eval_script_preserves_interrupt_handler(void)
+{
+    eval_script_interrupt_test(
+        "import * as std from 'qjs:std';\n"
+        "std.evalScript('while (true) {}');\n");
+    eval_script_interrupt_test(
+        "import * as std from 'qjs:std';\n"
+        "std.evalScript('1');\n"
+        "while (true) {}\n");
 }
 
 static JSValue save_value(JSContext *ctx, JSValueConst this_val,
@@ -2057,6 +2101,7 @@ int main(void)
     cfunctions();
     sync_call();
     async_call();
+    eval_script_preserves_interrupt_handler();
     async_call_stack_overflow();
     raw_context_global_var();
     is_array();

--- a/meson.build
+++ b/meson.build
@@ -518,7 +518,7 @@ if tests.allowed()
       'api-test.c',
 
       c_args: qjs_c_args,
-      dependencies: qjs_dep,
+      dependencies: [qjs_dep, qjs_libc_dep],
       build_by_default: false,
     ),
   )

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -187,6 +187,8 @@ typedef struct JSThreadState {
     struct list_head port_list; /* list of JSWorkerMessageHandler.link */
     struct list_head rejected_promise_list; /* list of JSRejectedPromiseEntry.link */
     int eval_script_recurse; /* only used in the main thread */
+    JSInterruptHandler *saved_interrupt_handler;
+    void *saved_interrupt_opaque;
     int64_t next_timer_id; /* for setTimeout / setInterval */
     bool can_js_os_poll;
     /* not used in the main thread */
@@ -1085,7 +1087,13 @@ static JSValue js_std_gc(JSContext *ctx, JSValueConst this_val,
 
 static int interrupt_handler(JSRuntime *rt, void *opaque)
 {
-    return (os_pending_signals >> SIGINT) & 1;
+    JSThreadState *ts = opaque;
+
+    if ((os_pending_signals >> SIGINT) & 1)
+        return 1;
+    if (ts->saved_interrupt_handler)
+        return ts->saved_interrupt_handler(rt, ts->saved_interrupt_opaque);
+    return 0;
 }
 
 static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val,
@@ -1147,8 +1155,9 @@ static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val,
             return JS_EXCEPTION;
     }
     if (!ts->recv_pipe && ++ts->eval_script_recurse == 1) {
-        /* install the interrupt handler */
-        JS_SetInterruptHandler(JS_GetRuntime(ctx), interrupt_handler, NULL);
+        ts->saved_interrupt_handler =
+            JS_GetInterruptHandler(rt, &ts->saved_interrupt_opaque);
+        JS_SetInterruptHandler(rt, interrupt_handler, ts);
     }
     flags = compile_module ? JS_EVAL_TYPE_MODULE : JS_EVAL_TYPE_GLOBAL;
     if (backtrace_barrier)
@@ -1165,8 +1174,10 @@ static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val,
     }
     JS_FreeCString(ctx, str);
     if (!ts->recv_pipe && --ts->eval_script_recurse == 0) {
-        /* remove the interrupt handler */
-        JS_SetInterruptHandler(JS_GetRuntime(ctx), NULL, NULL);
+        JS_SetInterruptHandler(rt, ts->saved_interrupt_handler,
+                               ts->saved_interrupt_opaque);
+        ts->saved_interrupt_handler = NULL;
+        ts->saved_interrupt_opaque = NULL;
         os_pending_signals &= ~((uint64_t)1 << SIGINT);
         /* convert the uncatchable "interrupted" error into a normal error
            so that it can be caught by the REPL */

--- a/quickjs.c
+++ b/quickjs.c
@@ -2473,6 +2473,13 @@ void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold)
 #define free(p) free_is_forbidden(p)
 #define realloc(p,s) realloc_is_forbidden(p,s)
 
+JSInterruptHandler *JS_GetInterruptHandler(JSRuntime *rt, void **opaque)
+{
+    if (opaque)
+        *opaque = rt->interrupt_opaque;
+    return rt->interrupt_handler;
+}
+
 void JS_SetInterruptHandler(JSRuntime *rt, JSInterruptHandler *cb, void *opaque)
 {
     rt->interrupt_handler = cb;

--- a/quickjs.h
+++ b/quickjs.h
@@ -1178,6 +1178,7 @@ JS_EXTERN void JS_SetHostPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRej
 
 /* return != 0 if the JS code needs to be interrupted */
 typedef int JSInterruptHandler(JSRuntime *rt, void *opaque);
+JS_EXTERN JSInterruptHandler *JS_GetInterruptHandler(JSRuntime *rt, void **opaque);
 JS_EXTERN void JS_SetInterruptHandler(JSRuntime *rt, JSInterruptHandler *cb, void *opaque);
 /* if can_block is true, Atomics.wait() can be used */
 JS_EXTERN void JS_SetCanBlock(JSRuntime *rt, bool can_block);


### PR DESCRIPTION
## Summary

- preserve an embedder's interrupt handler across `std.evalScript()` calls
- chain the embedder handler while the standard library's SIGINT handler is active
- add native regressions for timeouts both inside and after `evalScript()`

Fixes #1673.

## Testing

- `api-test` in release and ASan/UBSan builds
- `api-test` with `QJS_BUILD_LIBC` both on and off
- `run-test262 -c tests.conf` (0/110 errors, 9 excluded)
- `make jscheck ctest cxxtest`
- supplied A/B reproducer: the `evalScript()` case hangs on untouched master and exits normally after this patch
