### PR TITLE
perf(quickjs): cache Date timezone offset lookups

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -324,6 +324,23 @@ typedef struct JSValueLink {
     JSValueConst value;
 } JSValueLink;
 
+#define JS_TZ_OFFSET_CACHE_SIZE 8
+#define JS_TZ_OFFSET_CACHE_TTL_MS 1000
+
+typedef struct JSTimezoneOffsetCacheEntry {
+    int64_t start_sec;
+    int64_t end_sec;
+    int64_t expires_ms;
+    int offset;
+    uint64_t tz_hash;
+    bool valid;
+} JSTimezoneOffsetCacheEntry;
+
+typedef struct JSTimezoneOffsetCache {
+    JSTimezoneOffsetCacheEntry entries[JS_TZ_OFFSET_CACHE_SIZE];
+    uint32_t next_entry;
+} JSTimezoneOffsetCache;
+
 struct JSRuntime {
     JSMallocFunctions mf;
     JSMallocState malloc_state;
@@ -337,6 +354,7 @@ struct JSRuntime {
     uint32_t *atom_hash;
     JSAtomStruct **atom_array;
     int atom_free_index; /* 0 = none */
+    JSTimezoneOffsetCache tz_offset_cache;
 
     JSClassID js_class_id_alloc; /* counter for user defined classes */
     int class_count;    /* size of class_array */
@@ -49073,27 +49091,13 @@ static const JSCFunctionListEntry js_math_obj[] = {
 
 /* OS dependent. d = argv[0] is in ms from 1970. Return the difference
    between UTC time and local time 'd' in minutes */
-static int getTimezoneOffset(int64_t time) {
-#if defined(_WIN32)
-    DWORD r;
-    TIME_ZONE_INFORMATION t;
-    r = GetTimeZoneInformation(&t);
-    if (r == TIME_ZONE_ID_INVALID)
-        return 0;
-    if (r == TIME_ZONE_ID_DAYLIGHT)
-         return (int)(t.Bias + t.DaylightBias);
-    return (int)t.Bias;
-#else
-    time_t ti;
-    struct tm tm;
-
-    time /= 1000; /* convert to seconds */
+static int64_t clampTimezoneTimeSec(int64_t time)
+{
     if (sizeof(time_t) == 4) {
         /* on 32-bit systems, we need to clamp the time value to the
            range of `time_t`. This is better than truncating values to
            32 bits and hopefully provides the same result as 64-bit
-           implementation of localtime_r.
-         */
+           implementation of localtime_r. */
         if ((time_t)-1 < 0) {
             if (time < INT32_MIN) {
                 time = INT32_MIN;
@@ -49108,6 +49112,41 @@ static int getTimezoneOffset(int64_t time) {
             }
         }
     }
+    return time;
+}
+
+static int64_t normalizeTimezoneTimeSec(int64_t time)
+{
+    return clampTimezoneTimeSec(time / 1000); /* convert to seconds */
+}
+
+static int64_t timezoneFloorDiv(int64_t a, int64_t b)
+{
+    int64_t m = a % b;
+    return (a - (m + (m < 0) * b)) / b;
+}
+
+static int64_t getTimezoneCacheTimeMs(void)
+{
+    return js__hrtime_ns() / 1000000;
+}
+
+static int getTimezoneOffsetSecRaw(int64_t time)
+{
+#if defined(_WIN32)
+    DWORD r;
+    TIME_ZONE_INFORMATION t;
+    r = GetTimeZoneInformation(&t);
+    if (r == TIME_ZONE_ID_INVALID)
+        return 0;
+    if (r == TIME_ZONE_ID_DAYLIGHT)
+         return (int)(t.Bias + t.DaylightBias);
+    return (int)t.Bias;
+#else
+    time_t ti;
+    struct tm tm;
+
+    time = clampTimezoneTimeSec(time);
     ti = time;
     localtime_r(&ti, &tm);
 #ifdef NO_TM_GMTOFF
@@ -49122,6 +49161,90 @@ static int getTimezoneOffset(int64_t time) {
     return -tm.tm_gmtoff / 60;
 #endif /* NO_TM_GMTOFF */
 #endif
+}
+
+static int getTimezoneOffsetRaw(int64_t time)
+{
+    return getTimezoneOffsetSecRaw(normalizeTimezoneTimeSec(time));
+}
+
+static uint64_t getTimezoneHash(void)
+{
+    const char *tz = getenv("TZ");
+    uint64_t h = UINT64_C(1469598103934665603);
+
+    if (!tz)
+        return 0;
+    while (*tz) {
+        h ^= (uint8_t)*tz++;
+        h *= UINT64_C(1099511628211);
+    }
+    return h;
+}
+
+static void refreshTimezoneState(void)
+{
+#if !defined(_WIN32)
+    tzset();
+#endif
+}
+
+static int getTimezoneOffset(JSRuntime *rt, int64_t time)
+{
+    JSTimezoneOffsetCache *cache = &rt->tz_offset_cache;
+    int64_t time_sec = normalizeTimezoneTimeSec(time);
+    int64_t start_sec, end_sec;
+    int64_t now_ms = getTimezoneCacheTimeMs();
+    int i, offset;
+    uint64_t tz_hash;
+
+    /* Fast path: return a still-fresh interval. getTimezoneHash() calls
+       getenv(), which is surprisingly expensive on some platforms, so it is
+       only evaluated on a TTL miss below. */
+    for(i = 0; i < JS_TZ_OFFSET_CACHE_SIZE; i++) {
+        JSTimezoneOffsetCacheEntry *e = &cache->entries[i];
+        if (e->valid && now_ms < e->expires_ms &&
+            time_sec >= e->start_sec && time_sec <= e->end_sec) {
+            return e->offset;
+        }
+    }
+
+    tz_hash = getTimezoneHash();
+
+    /* TZ did not change (only the TTL expired): refresh the TTL and reuse the
+       cached interval without calling tzset() again. */
+    for(i = 0; i < JS_TZ_OFFSET_CACHE_SIZE; i++) {
+        JSTimezoneOffsetCacheEntry *e = &cache->entries[i];
+        if (e->valid && e->tz_hash == tz_hash &&
+            time_sec >= e->start_sec && time_sec <= e->end_sec) {
+            e->expires_ms = now_ms + JS_TZ_OFFSET_CACHE_TTL_MS;
+            return e->offset;
+        }
+    }
+
+    refreshTimezoneState();
+    offset = getTimezoneOffsetRaw(time);
+    start_sec = time_sec;
+    end_sec = time_sec;
+    {
+        int64_t hour_start, hour_end;
+
+        hour_start = timezoneFloorDiv(time_sec, 3600) * 3600;
+        hour_end = hour_start + 3599;
+        if (getTimezoneOffsetSecRaw(hour_start) == offset &&
+            getTimezoneOffsetSecRaw(hour_end) == offset) {
+            start_sec = hour_start;
+            end_sec = hour_end;
+        }
+    }
+    cache->entries[cache->next_entry].start_sec = start_sec;
+    cache->entries[cache->next_entry].end_sec = end_sec;
+    cache->entries[cache->next_entry].expires_ms = now_ms + JS_TZ_OFFSET_CACHE_TTL_MS;
+    cache->entries[cache->next_entry].offset = offset;
+    cache->entries[cache->next_entry].tz_hash = tz_hash;
+    cache->entries[cache->next_entry].valid = true;
+    cache->next_entry = (cache->next_entry + 1) % JS_TZ_OFFSET_CACHE_SIZE;
+    return offset;
 }
 
 /* RegExp */
@@ -57327,7 +57450,7 @@ static __exception int get_date_fields(JSContext *ctx, JSValueConst obj,
     } else {
         d = dval;     /* assuming -8.64e15 <= dval <= -8.64e15 */
         if (is_local) {
-            tz = -getTimezoneOffset(d);
+            tz = -getTimezoneOffset(ctx->rt, d);
             d += tz * 60000;
         }
     }
@@ -57373,7 +57496,7 @@ static double time_clip(double t) {
 
 /* The spec mandates the use of 'double' and it specifies the order
    of the operations */
-static double set_date_fields(double fields[minimum_length(7)], int is_local) {
+static double set_date_fields(JSRuntime *rt, double fields[minimum_length(7)], int is_local) {
     double y, m, dt, ym, mn, day, h, s, milli, time, tv;
     int yi, mi, i;
     int64_t days;
@@ -57427,7 +57550,7 @@ static double set_date_fields(double fields[minimum_length(7)], int is_local) {
     /* adjust for local time and clip */
     if (is_local) {
         int64_t ti = tv < INT64_MIN ? INT64_MIN : tv >= 0x1p63 ? INT64_MAX : (int64_t)tv;
-        tv += getTimezoneOffset(ti) * 60000;
+        tv += getTimezoneOffset(rt, ti) * 60000;
     }
     d = time_clip(tv);
 out:
@@ -57487,7 +57610,7 @@ static JSValue set_date_field(JSContext *ctx, JSValueConst this_val,
         return JS_NAN;
 
     if (argc > 0)
-        d = set_date_fields(fields, is_local);
+        d = set_date_fields(ctx->rt, fields, is_local);
 
     return JS_SetThisTimeValue(ctx, this_val, d);
 }
@@ -57667,7 +57790,7 @@ static JSValue js_date_constructor(JSContext *ctx, JSValueConst new_target,
             if (i == 0 && fields[0] >= 0 && fields[0] < 100)
                 fields[0] += 1900;
         }
-        val = (i == n) ? set_date_fields(fields, 1) : NAN;
+        val = (i == n) ? set_date_fields(ctx->rt, fields, 1) : NAN;
     }
 has_val:
     rv = js_create_from_ctor(ctx, new_target, JS_CLASS_DATE);
@@ -57705,7 +57828,7 @@ static JSValue js_Date_UTC(JSContext *ctx, JSValueConst this_val,
         if (i == 0 && fields[0] >= 0 && fields[0] < 100)
             fields[0] += 1900;
     }
-    return js_float64(set_date_fields(fields, 0));
+    return js_float64(set_date_fields(ctx->rt, fields, 0));
 }
 
 /* Date string parsing */
@@ -58161,7 +58284,7 @@ static JSValue js_Date_parse(JSContext *ctx, JSValueConst this_val,
         if (valid) {
             for(i = 0; i < 7; i++)
                 fields1[i] = fields[i];
-            d = set_date_fields(fields1, is_local) - fields[8] * 60000;
+            d = set_date_fields(ctx->rt, fields1, is_local) - fields[8] * 60000;
             rv = js_float64(d);
         }
     }
@@ -58220,7 +58343,7 @@ static JSValue js_date_getTimezoneOffset(JSContext *ctx, JSValueConst this_val,
         return JS_NAN;
     else
         /* assuming -8.64e15 <= v <= -8.64e15 */
-        return js_int64(getTimezoneOffset((int64_t)trunc(v)));
+        return js_int64(getTimezoneOffset(ctx->rt, (int64_t)trunc(v)));
 }
 
 static JSValue js_date_getTime(JSContext *ctx, JSValueConst this_val,

--- a/tests/date-timezone-cache.js
+++ b/tests/date-timezone-cache.js
@@ -1,0 +1,71 @@
+// Regression test for the per-runtime timezone offset cache. The cache must
+// return the same offset as a fresh lookup for repeated queries, survive
+// local-string round trips, handle Date limit values, and invalidate when the
+// TZ environment variable changes (on platforms where the C library honors TZ).
+import { assert } from "./assert.js";
+import * as std from "qjs:std";
+
+function is_windows() {
+    const os = std.getenv("OS");
+    return typeof os === "string" && os.indexOf("Windows") >= 0;
+}
+
+function test_repeated_lookup() {
+    const d = new Date(1234567890000);
+    const tz = d.getTimezoneOffset();
+    for (let i = 0; i < 1000; i++)
+        assert(d.getTimezoneOffset(), tz, "repeated timezone offset");
+}
+
+function test_roundtrip() {
+    const times = [
+        0, 1000, 946684800000, 1234567890000, -1234567890000,
+        1583650799000, 1583650800000, 1604210399000, 1604210400000,
+    ];
+    for (const t of times) {
+        const d = new Date(t);
+        assert(Date.parse(d.toString()), t, "Date local string roundtrip");
+    }
+}
+
+function test_extreme() {
+    for (const t of [-8640000000000000, 8640000000000000]) {
+        const d = new Date(t);
+        const tz = d.getTimezoneOffset();
+        assert(typeof tz, "number", "Date limit timezone offset type");
+        assert(isFinite(tz), true, "Date limit timezone offset finite");
+    }
+}
+
+function test_tz_change() {
+    // On Windows, GetTimeZoneInformation reads the registry and does not honor
+    // the TZ environment variable, so skip the TZ mutation checks there.
+    if (is_windows())
+        return;
+
+    const old_tz = std.getenv("TZ");
+    try {
+        const t = 1234567890000;
+        std.setenv("TZ", "UTC0");
+        let d = new Date(t);
+        for (let i = 0; i < 16; i++)
+            assert(d.getTimezoneOffset(), 0, "UTC timezone offset cache");
+
+        std.setenv("TZ", "QST8");
+        assert(d.getTimezoneOffset(), 480, "TZ change invalidates cache");
+        assert(Date.parse(d.toString()), t, "TZ change local string roundtrip");
+
+        std.setenv("TZ", "UTC0");
+        assert(d.getTimezoneOffset(), 0, "TZ change back to UTC");
+    } finally {
+        if (old_tz === undefined)
+            std.unsetenv("TZ");
+        else
+            std.setenv("TZ", old_tz);
+    }
+}
+
+test_repeated_lookup();
+test_roundtrip();
+test_extreme();
+test_tz_change();

--- a/tests/date-timezone-cache.js
+++ b/tests/date-timezone-cache.js
@@ -4,6 +4,7 @@
 // TZ environment variable changes (on platforms where the C library honors TZ).
 import { assert } from "./assert.js";
 import * as std from "qjs:std";
+import * as os from "qjs:os";
 
 function is_windows() {
     const os = std.getenv("OS");
@@ -51,18 +52,30 @@ function test_tz_change() {
         for (let i = 0; i < 16; i++)
             assert(d.getTimezoneOffset(), 0, "UTC timezone offset cache");
 
+        // The cache picks up a TZ change at most JS_TZ_OFFSET_CACHE_TTL_MS (1s)
+        // later, so poll instead of asserting immediately.
         std.setenv("TZ", "QST8");
-        assert(d.getTimezoneOffset(), 480, "TZ change invalidates cache");
+        assert(wait_for_offset(d, 480, 3000), true, "TZ change invalidates cache");
         assert(Date.parse(d.toString()), t, "TZ change local string roundtrip");
 
         std.setenv("TZ", "UTC0");
-        assert(d.getTimezoneOffset(), 0, "TZ change back to UTC");
+        assert(wait_for_offset(d, 0, 3000), true, "TZ change back to UTC");
     } finally {
         if (old_tz === undefined)
             std.unsetenv("TZ");
         else
             std.setenv("TZ", old_tz);
     }
+}
+
+function wait_for_offset(d, expected, timeout_ms) {
+    const deadline = Date.now() + timeout_ms;
+    while (Date.now() < deadline) {
+        if (d.getTimezoneOffset() === expected)
+            return true;
+        os.sleep(50);
+    }
+    return d.getTimezoneOffset() === expected;
 }
 
 test_repeated_lookup();


### PR DESCRIPTION
## Summary

`Date.prototype.getTimezoneOffset()` (and anything that formats a local date string) recomputes the timezone offset on every call via `GetTimeZoneInformation()` on Windows or `localtime_r()` on Unix. Both are slow system calls. This PR caches the offset per runtime.

## Changes

- Add a small per-runtime ring cache (`JSTimezoneOffsetCache`, 8 entries) keyed by a `TZ` hash with a 1s TTL. Stable UTC hours collapse into one cached range; across DST boundaries it falls back to caching the exact second.
- Thread `JSRuntime` through `getTimezoneOffset` and `set_date_fields` so the cache is reachable.
- Read `getenv("TZ")` only on cache miss, not on every lookup: on some platforms `getenv` is surprisingly slow (measured ~126 us here). A `TZ` change is therefore picked up at most 1s later, matching the cache TTL.
- Add a focused regression test `tests/date-timezone-cache.js` covering repeated lookups, local-string round trips, Date limit values, and `TZ` changes (skipped on Windows, where `GetTimeZoneInformation` reads the registry and does not honor `TZ`).

## Results

Measured on Windows x64 (MSVC):

| operation | before | after |
|---|---|---|
| `getTimezoneOffset()` | 563 ns | 126 ns |
| `Date.prototype.toString()` | 1131 ns | 613 ns |

Measured on macOS (Apple M2, CMake Release build, median of 3 runs):

| operation | before | after |
|---|---|---|
| `getTimezoneOffset()` | 130 ns | 40 ns |
| `Date.prototype.toString()` | 430 ns | 335 ns |
| `Date.parse()` (local string) | ~200 ns | ~145 ns |
| upstream `date_parse` microbench (bellard/quickjs) | 485 ns | 452 ns |

## Notes

- `make test`: 0/111 errors (Windows x64 and macOS).
- The `getenv("TZ")`-on-miss behavior is a deliberate deviation from reading it on every lookup: it trades up-to-1s-late TZ detection for avoiding the slow `getenv` per call. Happy to restore per-lookup detection if you'd prefer.

