### PR TITLE
Fix String.prototype.normalize() crash from #1683

### DIFF
--- a/libunicode.c
+++ b/libunicode.c
@@ -1053,6 +1053,11 @@ int unicode_normalize(uint32_t **pdst, const uint32_t *src, int src_len,
     int *buf, buf_len, i, p, starter_pos, cc, last_cc, out_len;
     bool is_compat;
     DynBuf dbuf_s, *dbuf = &dbuf_s;
+    
+    if (src_len == 0) {
+        *pdst = NULL;
+        return 0;
+    }
 
     is_compat = n_type >> 1;
 

--- a/tests/bug1683.js
+++ b/tests/bug1683.js
@@ -1,0 +1,3 @@
+import { assert } from "./assert.js";
+
+assert("".normalize(), "");


### PR DESCRIPTION
Return an empty string early in the String.prototype.normalize() method when the string is empty. This prevents an error caused by the first argument of memcpy being a null pointer, as reported in #1683. I added a test to verify that this is fixed. 

When I was testing, I could not reproduce the issue on my Mac. However, I successfully reproduced it on a Docker container running ubuntu:24.04.