### PR TITLE
Throw error when converting BigIntArray to Int8Array (#1690)

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -61722,6 +61722,14 @@ static JSValue js_typed_array_constructor_ta(JSContext *ctx,
         JS_ThrowTypeErrorArrayBufferOOB(ctx);
         goto fail;
     }
+    bool src_is_bigint = p->class_id == JS_CLASS_BIG_INT64_ARRAY ||
+                         p->class_id == JS_CLASS_BIG_UINT64_ARRAY;
+    bool dst_is_bigint = classid == JS_CLASS_BIG_INT64_ARRAY ||
+                         classid == JS_CLASS_BIG_UINT64_ARRAY;
+    if (src_is_bigint != dst_is_bigint) {
+        JS_ThrowTypeError(ctx, "Cannot mix BigInt and other types, use explicit conversions");
+        goto fail;
+    }
     if (len > p->u.array.count) {
         JS_ThrowRangeError(ctx, "length out of bounds");
         goto fail;

--- a/tests/bug1690.js
+++ b/tests/bug1690.js
@@ -1,0 +1,6 @@
+import { assertThrows } from "./assert.js";
+
+assertThrows(TypeError, function () {new Int8Array(new BigInt64Array());});
+assertThrows(TypeError, function () {new Int8Array(new BigUint64Array());});
+assertThrows(TypeError, function () {new BigInt64Array(new Int8Array());});
+assertThrows(TypeError, function () {new BigUint64Array(new Int8Array());});


### PR DESCRIPTION
Fixes #1690 by checking that types are compatible in the typed array constructor. Added a regression test.