### PR TITLE
Prevent Object.preventExtensions when a TypedArray has a resizable ArrayBuffer

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -9858,6 +9858,15 @@ int JS_PreventExtensions(JSContext *ctx, JSValueConst obj)
     p = JS_VALUE_GET_OBJ(obj);
     if (unlikely(p->class_id == JS_CLASS_PROXY))
         return js_proxy_preventExtensions(ctx, obj);
+    if (is_typed_array(p->class_id)) {
+        JSTypedArray *ta = p->u.typed_array;
+        JSArrayBuffer *abuf = ta->buffer->u.array_buffer;
+        if (ta->track_rab ||
+            (array_buffer_is_resizable(abuf) && !abuf->shared))
+        {
+            return false;
+        }
+    }
     p->extensible = false;
     return true;
 }
@@ -41752,7 +41761,7 @@ static JSValue js_object_preventExtensions(JSContext *ctx, JSValueConst this_val
         return js_bool(ret);
     } else {
         if (!ret)
-            return JS_ThrowTypeError(ctx, "proxy preventExtensions handler returned false");
+            return JS_ThrowTypeError(ctx, "Cannot prevent extensions");
         return js_dup(obj);
     }
 }

--- a/tests/bug1691.js
+++ b/tests/bug1691.js
@@ -1,0 +1,3 @@
+import { assertThrows } from "./assert.js";
+
+assertThrows(TypeError, function () {Object.preventExtensions(new Int8Array(new ArrayBuffer(16, { maxByteLength: 16 })));});


### PR DESCRIPTION
Fixes #1691 by checking if the TypedArray's underlying ArrayBuffer is resizable, and throws an error if so. I also edited the error message when JS_PreventExtensions is false to be "Cannot prevent extensions", as this is more applicable to the widened set of reasons why the function might return false. Finally, I added a regression test.