### PR TITLE
Link against libm unconditionally on Unices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,9 @@ list(APPEND qjs_defines _GNU_SOURCE)
 if(WIN32)
     # NB: Windows 7 is EOL and we are only supporting in so far as it doesn't interfere with progress.
     list(APPEND qjs_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0601)
+else()
+    # UNIX-y platforms.
+    list(APPEND qjs_libs m)
 endif()
 if(TVOS)
     list(APPEND qjs_defines _TVOS)
@@ -296,12 +299,6 @@ list(APPEND qjs_libs ${CMAKE_DL_LIBS})
 find_package(Threads)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
     list(APPEND qjs_libs ${CMAKE_THREAD_LIBS_INIT})
-endif()
-
-# try to find libm
-find_library(M_LIBRARIES m)
-if(M_LIBRARIES OR CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
-    list(APPEND qjs_libs m)
 endif()
 
 add_library(qjs ${qjs_sources})


### PR DESCRIPTION
The find_library call breaks cross-compilation on my system.

N.B. This commit does not update the meson.build. I don't use it and don't know how it works.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1697
Refs: https://github.com/quickjs-ng/quickjs/issues/728