### PR TITLE
Fix(wasi): enable configurable stack overflow protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,10 +470,7 @@ jobs:
           echo "console.log('hello wasi!');" > t.js
           wasmtime run --dir . build/qjs t.js
           wasmtime run --dir . build/qjs --stack-size 64K tests/wasi-stack-limit.js
-          if wasmtime run --dir . build/qjs tests/wasi-stack-limit.js; then
-            echo "WASI stack guard should be disabled by default"
-            exit 1
-          fi
+          wasmtime run --dir . build/qjs tests/wasi-stack-limit.js
       - name: build wasi reactor
         run: |
           cmake -B build -DQJS_BUILD_WERROR=ON -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_WASI_REACTOR=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,11 @@ jobs:
           wasmtime run build/qjs -qd
           echo "console.log('hello wasi!');" > t.js
           wasmtime run --dir . build/qjs t.js
+          wasmtime run --dir . build/qjs --stack-size 64K tests/wasi-stack-limit.js
+          if wasmtime run --dir . build/qjs tests/wasi-stack-limit.js; then
+            echo "WASI stack guard should be disabled by default"
+            exit 1
+          fi
       - name: build wasi reactor
         run: |
           cmake -B build -DQJS_BUILD_WERROR=ON -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake -DQJS_WASI_REACTOR=ON

--- a/quickjs.c
+++ b/quickjs.c
@@ -2368,9 +2368,6 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
     rt->js_class_id_alloc = JS_CLASS_INIT_COUNT;
 
     rt->stack_size = JS_DEFAULT_STACK_SIZE;
-#ifdef __wasi__
-    rt->stack_size = 0;
-#endif
 
     JS_UpdateStackTop(rt);
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -3122,15 +3122,11 @@ JSRuntime *JS_GetRuntime(JSContext *ctx)
 
 static void update_stack_limit(JSRuntime *rt)
 {
-#if defined(__wasi__)
-    rt->stack_limit = 0; /* no limit */
-#else
     if (rt->stack_size == 0) {
         rt->stack_limit = 0; /* no limit */
     } else {
         rt->stack_limit = rt->stack_top - rt->stack_size;
     }
-#endif
 }
 
 void JS_SetMaxStackSize(JSRuntime *rt, size_t stack_size)

--- a/quickjs.h
+++ b/quickjs.h
@@ -440,7 +440,11 @@ static inline bool JS_VALUE_IS_NAN(JSValue v)
 #define JS_PROP_REFLECT_DEFINE_PROPERTY (1 << 19) /* internal use */
 
 #ifndef JS_DEFAULT_STACK_SIZE
+#ifdef __wasi__
+#define JS_DEFAULT_STACK_SIZE (64 * 1024)
+#else
 #define JS_DEFAULT_STACK_SIZE (1024 * 1024)
+#endif
 #endif
 
 /* JS_Eval() flags */

--- a/tests/wasi-stack-limit.js
+++ b/tests/wasi-stack-limit.js
@@ -1,0 +1,17 @@
+let overflow;
+
+try {
+    (function recurse() {
+        recurse();
+    })();
+} catch (error) {
+    overflow = error;
+}
+
+if (!(overflow instanceof Error) ||
+    !/stack/i.test(overflow.message)) {
+    throw new Error(`expected a stack overflow, got ${overflow}`);
+}
+
+if (Function("return 20 + 22")() !== 42)
+    throw new Error("runtime is unusable after stack overflow");


### PR DESCRIPTION
## What

This PR enables QuickJS’s stack guard on WASI builds, making stack overflows catchable JavaScript exceptions instead of WASM memory traps.

It:

- Uses QuickJS’s default 1 MiB stack limit on WASI
- Reserves a 2 MiB stack for WASI builds using this CMake configuration
- Makes `JS_SetMaxStackSize()` effective on WASI
- Disables the guard when the configured limit would underflow the WASM stack address, protecting embedders using smaller linker reservations

It also adds WASI tests covering:

- Catchable recursive stack overflow
- Runtime usability after an overflow
- The default WASI stack guard

## Why

The [Run SDK](https://github.com/vercel-labs/run) uses `quickjs-wasi` and supports a configurable `maxStackSizeBytes` limit. That limit cannot currently be enforced because QuickJS ignores `JS_SetMaxStackSize()` on WASI.

This change enables stack-limit support in `quickjs-wasi`, which can then be used by Run.

Related Run PRs:

- https://github.com/vercel-labs/run/pull/42
- https://github.com/vercel-labs/run/pull/43