### PR TITLE
docs: add Vayu to projects

### DIFF
--- a/docs/docs/projects.md
+++ b/docs/docs/projects.md
@@ -102,3 +102,7 @@ TypeScript-to-Native Compiler
 ## [Qbs](https://github.com/qbs/qbs)
 
 Cross-platform build system. Uses QuickJS-NG as its JavaScript backend for evaluating project files.
+
+## [Vayu](https://github.com/athrvk/vayu)
+
+Open-source API client with a native C++ load-testing engine. Embeds QuickJS-NG to enable in-app scripting: pre-request and test scripts with a Postman-compatible `pm.*` API.


### PR DESCRIPTION
Adds [Vayu](https://github.com/athrvk/vayu) to the projects page — an open-source API client that embeds QuickJS-NG for Postman-compatible request/test scripting.