### PR TITLE
Fix out-of-bound read in JS_NewTypedArray

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -2052,6 +2052,28 @@ void add_intrinsic_bigint(void)
     JS_FreeRuntime(rt);
 }
 
+void new_typed_array(void)
+{
+    JSValueConst argv[4];
+    JSRuntime *rt = new_runtime();
+    JSContext *ctx = JS_NewContext(rt);
+    uint8_t *buf = js_malloc(ctx, 8);
+    JSValue ab = JS_NewArrayBuffer(ctx, buf, 8, /*max_len*/0, NULL, NULL, false);
+    assert(JS_IsArrayBuffer(ab));
+    for (int argc = 0; argc < (int)countof(argv); argc++) {
+        JSValue ret = JS_NewTypedArray(ctx, argc, argv, JS_TYPED_ARRAY_UINT8);
+        assert(!JS_IsException(ret));
+        assert(JS_IsObject(ret));
+        JS_FreeValue(ctx, ret);
+        argv[argc] = JS_UNDEFINED;
+        argv[0] = ab;
+    }
+    JS_FreeValue(ctx, ab);
+    js_free(ctx, buf);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
 int main(void)
 {
     cfunctions();
@@ -2089,5 +2111,6 @@ int main(void)
     get_class_name();
     object_from();
     add_intrinsic_bigint();
+    new_typed_array();
     return 0;
 }

--- a/quickjs.c
+++ b/quickjs.c
@@ -59883,9 +59883,21 @@ static JSValue js_typed_array_get_byteOffset(JSContext *ctx, JSValueConst this_v
 JSValue JS_NewTypedArray(JSContext *ctx, int argc, JSValueConst *argv,
                          JSTypedArrayEnum type)
 {
+    JSValueConst temp[3];
+
     if (type < JS_TYPED_ARRAY_UINT8C || type > JS_TYPED_ARRAY_FLOAT64)
         return JS_ThrowRangeError(ctx, "invalid typed array type");
-
+    // js_typed_array_constructor makes assumptions about the length
+    // of the argv vector without checking argc, so let's ensure our
+    // side upholds said assumptions
+    if (argc < countof(temp)) {
+        temp[0] = temp[1] = temp[2] = JS_UNDEFINED;
+        switch (argc) {
+        case 2: temp[1] = argv[1]; // fallthru
+        case 1: temp[0] = argv[0]; // fallthru
+        }
+        argv = temp;
+    }
     return js_typed_array_constructor(ctx, JS_UNDEFINED, argc, argv,
                                       JS_CLASS_UINT8C_ARRAY + type);
 }
@@ -60236,6 +60248,7 @@ static JSValue js_typed_array_create(JSContext *ctx, JSValueConst ctor,
     return ret;
 }
 
+// expects typed array object in argv[0] so argc *must* be > 0
 static JSValue js_typed_array___speciesCreate(JSContext *ctx,
                                               JSValueConst this_val,
                                               int argc, JSValueConst *argv,
@@ -60244,8 +60257,8 @@ static JSValue js_typed_array___speciesCreate(JSContext *ctx,
     JSValueConst obj;
     JSObject *p;
     JSValue ctor, ret;
-    int argc1;
 
+    assert(argc > 0);
     obj = argv[0];
     p = get_typed_array(ctx, obj);
     if (!p)
@@ -60253,12 +60266,13 @@ static JSValue js_typed_array___speciesCreate(JSContext *ctx,
     ctor = JS_SpeciesConstructor(ctx, obj, JS_UNDEFINED);
     if (JS_IsException(ctor))
         return ctor;
-    argc1 = max_int(argc - 1, 0);
+    argc--;
+    argv++;
     if (JS_IsUndefined(ctor)) {
-        ret = js_typed_array_constructor(ctx, JS_UNDEFINED, argc1, argv + 1,
+        ret = js_typed_array_constructor(ctx, JS_UNDEFINED, argc, argv,
                                          p->class_id);
     } else {
-        ret = js_typed_array_create(ctx, ctor, argc1, argv + 1, require_mutable);
+        ret = js_typed_array_create(ctx, ctor, argc, argv, require_mutable);
         JS_FreeValue(ctx, ctor);
     }
     return ret;


### PR DESCRIPTION
JS_NewTypedArray calls js_typed_array_constructor. The latter function makes assumptions about the length of the argv vector so uphold those assumptions.

Only an issue when the embedder calls JS_NewTypedArray with fewer arguments than expected. The minimum argument count isn't documented so we can't hold embedders responsible for that.

Make a semi-related change in js_typed_array___speciesCreate where we simplify the kludgy argument forwarding. We know it's always called with enough arguments (all the callers are internal) so just enforce that through an assert.