### PR TITLE
Preserve old interrupt handler in std.evalScript

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,7 @@ if(NOT EMSCRIPTEN)
     target_link_libraries(run-test262 PRIVATE qjs)
 endif()
 
-# Interrupt test
+# C API tests
 #
 
 add_executable(api-test
@@ -453,6 +453,7 @@ add_executable(api-test
 )
 target_compile_definitions(api-test PRIVATE ${qjs_defines})
 target_link_libraries(api-test PRIVATE qjs)
+add_qjs_libc_if_needed(api-test)
 
 add_executable(lre-test
     lre-test.c

--- a/api-test.c
+++ b/api-test.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "quickjs.h"
+#include "quickjs-libc.h"
 #include "cutils.h"
 
 static JSRuntime *new_runtime(void)
@@ -175,9 +176,7 @@ static void cfunctions(void)
 static int timeout_interrupt_handler(JSRuntime *rt, void *opaque)
 {
     int *time = (int *)opaque;
-    if (*time <= MAX_TIME)
-        *time += 1;
-    return *time > MAX_TIME;
+    return (*time)++ > MAX_TIME;
 }
 
 static void sync_call(void)
@@ -234,6 +233,38 @@ static void async_call(void)
     JSValue e = JS_GetException(ctx);
     assert(JS_IsUncatchableError(e));
     JS_FreeValue(ctx, e);
+    JS_FreeContext(ctx);
+    JS_FreeRuntime(rt);
+}
+
+static void std_eval_interrupt_handler(void)
+{
+    static const char code[] =
+        "import * as std from 'std'; std.evalScript('for(;;){}')";
+    JSRuntime *rt = new_runtime();
+    js_std_init_handlers(rt);
+    JSContext *ctx = JS_NewContext(rt);
+    js_init_module_std(ctx, "std");
+    int time = 0;
+    JS_SetInterruptHandler(rt, timeout_interrupt_handler, &time);
+    JSValue ret =
+        JS_Eval(ctx, code, strlen(code), "<input>", JS_EVAL_TYPE_MODULE);
+    ret = js_std_await(ctx, ret);
+    assert(time > MAX_TIME);
+    assert(JS_IsException(ret));
+    ret = JS_GetException(ctx);
+    assert(JS_IsError(ret));
+    // uncatchable "interrupted" exception is turned into a regular exception
+    assert(!JS_IsUncatchableError(ret));
+    const char *str = JS_ToCString(ctx, ret);
+    assert(str != NULL);
+    assert(strstr(str, "InternalError: interrupted"));
+    JS_FreeCString(ctx, str);
+    JS_FreeValue(ctx, ret);
+    uintptr_t interrupt_handler = js_std_cmd(/*GetInterruptHandler*/5, rt);
+    uintptr_t interrupt_opaque = js_std_cmd(/*GetInterruptOpaque*/6, rt);
+    assert(interrupt_handler == (uintptr_t)timeout_interrupt_handler);
+    assert(interrupt_opaque == (uintptr_t)&time);
     JS_FreeContext(ctx);
     JS_FreeRuntime(rt);
 }
@@ -2112,5 +2143,6 @@ int main(void)
     object_from();
     add_intrinsic_bigint();
     new_typed_array();
+    std_eval_interrupt_handler();
     return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -518,7 +518,7 @@ if tests.allowed()
       'api-test.c',
 
       c_args: qjs_c_args,
-      dependencies: qjs_dep,
+      dependencies: [qjs_dep, qjs_libc_dep],
       build_by_default: false,
     ),
   )

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -197,6 +197,8 @@ typedef struct JSThreadState {
 #endif // USE_WORKER
     JSClassID std_file_class_id;
     JSClassID worker_class_id;
+    JSInterruptHandler *prev_interrupt_handler;
+    void *prev_interrupt_opaque;
 } JSThreadState;
 
 static uint64_t os_pending_signals;
@@ -1085,7 +1087,13 @@ static JSValue js_std_gc(JSContext *ctx, JSValueConst this_val,
 
 static int interrupt_handler(JSRuntime *rt, void *opaque)
 {
-    return (os_pending_signals >> SIGINT) & 1;
+    JSThreadState *ts = opaque;
+
+    if (1 & (os_pending_signals >> SIGINT))
+        return 1;
+    if (ts->prev_interrupt_handler)
+        return ts->prev_interrupt_handler(rt, ts->prev_interrupt_opaque);
+    return 0;
 }
 
 static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val,
@@ -1148,7 +1156,14 @@ static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val,
     }
     if (!ts->recv_pipe && ++ts->eval_script_recurse == 1) {
         /* install the interrupt handler */
-        JS_SetInterruptHandler(JS_GetRuntime(ctx), interrupt_handler, NULL);
+        ts->prev_interrupt_handler =
+            (JSInterruptHandler *)js_std_cmd(/*GetInterruptHandler*/5, rt);
+        ts->prev_interrupt_opaque =
+            (void *)js_std_cmd(/*GetInterruptOpaque*/6, rt);
+        // FIXME(bnoordhuis) Questionable hack to make the REPL interruptible.
+        // Ideally qjs installs a signal handler + interrupt handler but then
+        // scripts can intercept it with os.signal(SIGINT).
+        JS_SetInterruptHandler(JS_GetRuntime(ctx), interrupt_handler, ts);
     }
     flags = compile_module ? JS_EVAL_TYPE_MODULE : JS_EVAL_TYPE_GLOBAL;
     if (backtrace_barrier)
@@ -1166,7 +1181,11 @@ static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val,
     JS_FreeCString(ctx, str);
     if (!ts->recv_pipe && --ts->eval_script_recurse == 0) {
         /* remove the interrupt handler */
-        JS_SetInterruptHandler(JS_GetRuntime(ctx), NULL, NULL);
+        JS_SetInterruptHandler(JS_GetRuntime(ctx),
+                               ts->prev_interrupt_handler,
+                               ts->prev_interrupt_opaque);
+        ts->prev_interrupt_handler = NULL;
+        ts->prev_interrupt_opaque = NULL;
         os_pending_signals &= ~((uint64_t)1 << SIGINT);
         /* convert the uncatchable "interrupted" error into a normal error
            so that it can be caught by the REPL */

--- a/quickjs.c
+++ b/quickjs.c
@@ -64865,6 +64865,14 @@ uintptr_t js_std_cmd(int cmd, ...) {
         rt = va_arg(ap, JSRuntime *);
         rv = rt->shape_hash_count;
         break;
+    case 5: // GetInterruptHandler
+        rt = va_arg(ap, JSRuntime *);
+        rv = (uintptr_t)rt->interrupt_handler;
+        break;
+    case 6: // GetInterruptOpaque
+        rt = va_arg(ap, JSRuntime *);
+        rv = (uintptr_t)rt->interrupt_opaque;
+        break;
     default:
         rv = -1;
     }


### PR DESCRIPTION
std.evalScript installs a handler to make REPL scripts interruptible but did so in a way where it removed and forgot about the old one. Instead chain the handlers and restore the old one when we're done.

Fixes: https://github.com/quickjs-ng/quickjs/issues/1673