### PR TITLE
Move JSClass out of quickjs.h

### DIFF
--- a/docs/docs/developer-guide/intro.md
+++ b/docs/docs/developer-guide/intro.md
@@ -80,11 +80,9 @@ it. A `gc_mark` method can be provided so that the cycle removal
 algorithm can find the other objects referenced by this object. Other
 methods are available to define exotic object behaviors.
 
-The Class ID are allocated per-runtime. The
-`JSClass` are allocated per `JSRuntime`. `JS_SetClassProto()`
-is used to define a prototype for a given class in a given
-`JSContext`. `JS_NewObjectClass()` sets this prototype in the
-created object.
+The class and class ID are allocated per-runtime. `JS_SetClassProto()`
+is used to define a prototype for a given class in a given `JSContext`.
+`JS_NewObjectClass()` sets this prototype in the created object.
 
 Examples are available in `quickjs-libc.c`.
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -324,6 +324,16 @@ typedef struct JSValueLink {
     JSValueConst value;
 } JSValueLink;
 
+typedef struct JSClass {
+    uint32_t class_id; /* 0 means free entry */
+    JSAtom class_name;
+    JSClassFinalizer *finalizer;
+    JSClassGCMark *gc_mark;
+    JSClassCall *call;
+    /* pointers for exotic behavior, can be NULL if none are present */
+    const JSClassExoticMethods *exotic;
+} JSClass;
+
 struct JSRuntime {
     JSMallocFunctions mf;
     JSMallocState malloc_state;
@@ -412,16 +422,6 @@ struct JSRuntime {
     void *user_opaque;
     void *libc_opaque;
     JSRuntimeFinalizerState *finalizers;
-};
-
-struct JSClass {
-    uint32_t class_id; /* 0 means free entry */
-    JSAtom class_name;
-    JSClassFinalizer *finalizer;
-    JSClassGCMark *gc_mark;
-    JSClassCall *call;
-    /* pointers for exotic behavior, can be NULL if none are present */
-    const JSClassExoticMethods *exotic;
 };
 
 typedef struct JSStackFrame {

--- a/quickjs.h
+++ b/quickjs.h
@@ -160,7 +160,6 @@ extern "C" {
 typedef struct JSRuntime JSRuntime;
 typedef struct JSContext JSContext;
 typedef struct JSObject JSObject;
-typedef struct JSClass JSClass;
 typedef uint32_t JSClassID;
 typedef uint32_t JSAtom;
 


### PR DESCRIPTION
No public APIs use JSClass. Move it to quickjs.c.