### PR TITLE
Throw an error when mixing BigInt and other types in TypedArray.prototype.set

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -59993,6 +59993,13 @@ static JSValue js_typed_array_set_internal(JSContext *ctx,
         goto fail;
     src_p = JS_VALUE_GET_OBJ(src_obj);
     if (is_typed_array(src_p->class_id)) {
+        if (p->class_id != src_p->class_id && ((p->class_id == JS_CLASS_BIG_INT64_ARRAY ||
+            p->class_id == JS_CLASS_BIG_UINT64_ARRAY) ^ (src_p->class_id == JS_CLASS_BIG_INT64_ARRAY
+            || src_p->class_id == JS_CLASS_BIG_UINT64_ARRAY))) {
+            JS_ThrowTypeError(ctx, "Cannot mix BigInt and other types, use explicit conversions");
+            goto fail;
+        }
+
         JSTypedArray *dest_ta = p->u.typed_array;
         JSArrayBuffer *dest_abuf = dest_ta->buffer->u.array_buffer;
         JSTypedArray *src_ta = src_p->u.typed_array;

--- a/tests/typedarray-set-type-mismatch.js
+++ b/tests/typedarray-set-type-mismatch.js
@@ -1,0 +1,13 @@
+import { assertThrows } from "./assert.js";
+
+assertThrows(TypeError, () => new BigInt64Array(0).set(new Int8Array(0)));
+assertThrows(TypeError, () => new Int8Array(0).set(new BigInt64Array(0)));
+
+assertThrows(TypeError, () => new BigUint64Array(0).set(new Int8Array(0)));
+assertThrows(TypeError, () => new Int8Array(0).set(new BigUint64Array(0)));
+
+assertThrows(TypeError, () => new BigInt64Array(0).set(new Uint8Array(0)));
+assertThrows(TypeError, () => new Uint8Array(0).set(new BigInt64Array(0)));
+
+assertThrows(TypeError, () => new BigUint64Array(0).set(new Uint8Array(0)));
+assertThrows(TypeError, () => new Uint8Array(0).set(new BigUint64Array(0)));


### PR DESCRIPTION
When mixing BigInt and other types in the set method of a TypedArray, a TypeError should be thrown, but instead, undefined is returned by the latest build. Minimal reproducer:
```javascript
new BigInt64Array(0).set(new Int8Array(0))
```
QuickJS output:
```
undefined
```
NodeJS output:
```
Uncaught TypeError: Cannot mix BigInt and other types, use explicit conversions
    at BigInt64Array.set (<anonymous>)
```
I patched this issue and added regression tests.