### PR TITLE
Move Map hash seed to runtime

### DIFF
--- a/api-test.c
+++ b/api-test.c
@@ -2058,6 +2058,58 @@ static void get_class_name(void)
     JS_FreeRuntime(rt);
 }
 
+static void map_set_cross_context(void)
+{
+    static const char create_source[] =
+        "({"
+        "  map: new Map(Array.from({length: 1024}, (_, i) => ['key' + i, i])),"
+        "  set: new Set(Array.from({length: 1024}, (_, i) => 'key' + i))"
+        "})";
+    static const char check_source[] =
+        "(() => {"
+        "  for (let i = 0; i < 1024; i++) {"
+        "    const key = 'key' + i;"
+        "    if (Map.prototype.get.call(foreign.map, key) !== i) return false;"
+        "    if (!Set.prototype.has.call(foreign.set, key)) return false;"
+        "  }"
+        "  return true;"
+        "})()";
+    JSRuntime *rt = new_runtime();
+    JSContext *owner_ctx = JS_NewContext(rt);
+    JSValue containers = eval(owner_ctx, create_source);
+    int i;
+
+    assert(!JS_IsException(containers));
+    for (i = 0; i < 4; i++) {
+        uint64_t timestamp = js__gettimeofday_us();
+        JSContext *caller_ctx;
+        JSValue global, result;
+
+        while (js__gettimeofday_us() == timestamp) {
+        }
+        caller_ctx = JS_NewContext(rt);
+        global = JS_GetGlobalObject(caller_ctx);
+        assert(JS_SetPropertyStr(caller_ctx, global, "foreign",
+                                 JS_DupValue(caller_ctx, containers)) >= 0);
+        JS_FreeValue(caller_ctx, global);
+
+        result = eval(caller_ctx, check_source);
+        assert(!JS_IsException(result));
+        assert(JS_IsBool(result));
+        assert(JS_VALUE_GET_BOOL(result));
+        JS_FreeValue(caller_ctx, result);
+
+        result = eval(caller_ctx, "globalThis.foreign = undefined");
+        assert(!JS_IsException(result));
+        JS_FreeValue(caller_ctx, result);
+        JS_FreeContext(caller_ctx);
+    }
+
+    JS_FreeValue(owner_ctx, containers);
+    JS_FreeContext(owner_ctx);
+    JS_FreeRuntime(rt);
+}
+
 void object_from(void)
 {
     JSRuntime *rt = new_runtime();
@@ -2153,6 +2205,7 @@ int main(void)
     resize_external_array_buffer();
     transfer_default_managed_array_buffer();
     get_class_name();
+    map_set_cross_context();
     object_from();
     add_intrinsic_bigint();
     new_typed_array();

--- a/quickjs.c
+++ b/quickjs.c
@@ -339,6 +339,7 @@ struct JSRuntime {
     JSMallocState malloc_state;
     JSArenaState arena_state;
     const char *rt_info;
+    uint32_t hash_seed;
 
     int atom_hash_size; /* power of two */
     int atom_count;
@@ -602,7 +603,6 @@ struct JSContext {
     double time_origin;
 
     uint64_t random_state;
-    uint32_t hash_seed;
 
     /* when the counter reaches zero, JSRutime.interrupt_handler is called */
     int interrupt_counter;
@@ -2315,6 +2315,7 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
 {
     JSRuntime *rt;
     JSMallocState ms;
+    uint64_t random_state;
 
     memset(&ms, 0, sizeof(ms));
     ms.opaque = opaque;
@@ -2334,6 +2335,10 @@ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque)
     rt->malloc_state = ms;
     js_arena_init(rt);
     rt->malloc_gc_threshold = 256 * 1024;
+    random_state = js__gettimeofday_us();
+    if (random_state == 0)
+        random_state = 1;
+    rt->hash_seed = xorshift64star(&random_state);
 
     init_list_head(&rt->context_list);
     init_list_head(&rt->gc_obj_list);
@@ -2885,7 +2890,6 @@ JSContext *JS_NewContextRaw(JSRuntime *rt)
     // the state must be non zero
     if (ctx->random_state == 0)
         ctx->random_state = 1;
-    ctx->hash_seed = xorshift64star(&ctx->random_state);
 
     if (JS_AddIntrinsicBasicObjects(ctx)) {
         JS_FreeContext(ctx);
@@ -53362,7 +53366,7 @@ static uint32_t map_hash_key(JSContext *ctx, JSValueConst key)
         h = 0;
         break;
     }
-    return h ^ ctx->hash_seed ^ hash32(tag);
+    return h ^ ctx->rt->hash_seed ^ hash32(tag);
 }
 
 static JSMapRecord *map_find_record(JSContext *ctx, JSMapState *s,


### PR DESCRIPTION
Map and Set objects can be accessed from a context other than the one that created them. With a per-context hash seed, insertion and lookup may select different buckets.

Store the seed on JSRuntime so every context sharing these objects uses the same hash seed.