### PR TITLE
Fix TypedArray.prototype.at() to handle resized ArrayBuffer correctly

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -60070,7 +60070,7 @@ static JSValue js_typed_array_at(JSContext *ctx, JSValueConst this_val,
     if (idx < 0)
         idx = len + idx;
 
-    if (idx < 0 || idx >= p->u.array.count)
+    if (idx < 0 || idx >= len || idx >= p->u.array.count)
         return JS_UNDEFINED;
 
     switch (p->class_id) {

--- a/tests/resize_array_buffer_index_valueOf.js
+++ b/tests/resize_array_buffer_index_valueOf.js
@@ -1,0 +1,10 @@
+import { assert } from "./assert.js";
+const buffer = new ArrayBuffer(4 * Int8Array.BYTES_PER_ELEMENT, {maxByteLength: 8 * Int8Array.BYTES_PER_ELEMENT,});
+const array = new Int8Array(buffer);
+const index = {
+    valueOf() {
+        buffer.resize(6 * Int8Array.BYTES_PER_ELEMENT);
+        return 4;
+    },
+};
+assert(array.at(index), undefined);


### PR DESCRIPTION
There is a bug where, when you expand a resizable array buffer backing a typed array, the at method reads from the newly allocated data rather than returning undefined. Below is a minimal reproducer I made:
```javascript
const buffer = new ArrayBuffer(4 * Int8Array.BYTES_PER_ELEMENT, {maxByteLength: 8 * Int8Array.BYTES_PER_ELEMENT,});
const array = new Int8Array(buffer);
const index = {
    valueOf() {
        buffer.resize(6 * Int8Array.BYTES_PER_ELEMENT);
        return 4;
    },
};
array.at(index); // Node.JS gives undefined, but 0 is returned by QuickJS at master
```
I checked past PRs/issues, but all I could find was one about shrinking TypedArrays, while this one is about expanding them. I also added a test based on the minimal reproducer above.